### PR TITLE
Fix #32: Database deadlock when multiple PA signatures are validated at the same time

### DIFF
--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -97,6 +97,21 @@
             <artifactId>bcprov-jdk15on</artifactId>
             <version>1.58</version>
         </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.41</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
@@ -19,9 +19,11 @@ package io.getlime.security.powerauth.app.server.database.repository;
 
 import io.getlime.security.powerauth.app.server.database.model.ActivationStatus;
 import io.getlime.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Component;
 
+import javax.persistence.LockModeType;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
@@ -35,11 +37,14 @@ import java.util.List;
 public interface ActivationRepository extends CrudRepository<ActivationRecordEntity, String> {
 
     /**
-     * Find a first activation with given activation ID
+     * Find a first activation with given activation ID.
+     * The activation record is locked in DB in PESSIMISTIC_WRITE mode to avoid concurrency issues
+     * (DB deadlock, invalid counter value in second transaction, etc.).
      *
      * @param activationId Activation ID
      * @return Activation with given ID or null if not found
      */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     ActivationRecordEntity findFirstByActivationId(String activationId);
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/ActivationRepository.java
@@ -67,6 +67,8 @@ public interface ActivationRepository extends CrudRepository<ActivationRecordEnt
     /**
      * Find the first activation associated with given application by the activation ID short.
      * Filter the results by activation state and make sure to apply activation time window.
+     * The activation record is locked in DB in PESSIMISTIC_WRITE mode to avoid concurrency issues
+     * (DB deadlock, invalid counter value in second transaction, etc.).
      *
      * @param applicationId     Application ID
      * @param activationIdShort Short activation ID
@@ -74,6 +76,7 @@ public interface ActivationRepository extends CrudRepository<ActivationRecordEnt
      * @param currentTimestamp  Current timestamp
      * @return Activation matching the search criteria or null if not found
      */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     ActivationRecordEntity findFirstByApplicationIdAndActivationIdShortAndActivationStatusInAndTimestampActivationExpireAfter(Long applicationId, String activationIdShort, Collection<ActivationStatus> states, Date currentTimestamp);
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/SignatureAuditRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/SignatureAuditRepository.java
@@ -38,7 +38,7 @@ public interface SignatureAuditRepository extends CrudRepository<SignatureEntity
      * @param endingDate   Ending date (date "to").
      * @return List of {@link SignatureEntity} instances.
      */
-    List<SignatureEntity> findByActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDesc(String userId, Date startingDate, Date endingDate);
+    List<SignatureEntity> findByActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(String userId, Date startingDate, Date endingDate);
 
     /**
      * Return signature audit records for given user, application and date range.
@@ -49,6 +49,6 @@ public interface SignatureAuditRepository extends CrudRepository<SignatureEntity
      * @param endingDate    Ending date (date "to").
      * @return List of {@link SignatureEntity} instances.
      */
-    List<SignatureEntity> findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDesc(Long applicationId, String userId, Date startingDate, Date endingDate);
+    List<SignatureEntity> findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(Long applicationId, String userId, Date startingDate, Date endingDate);
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/SignatureAuditRepository.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/repository/SignatureAuditRepository.java
@@ -38,7 +38,7 @@ public interface SignatureAuditRepository extends CrudRepository<SignatureEntity
      * @param endingDate   Ending date (date "to").
      * @return List of {@link SignatureEntity} instances.
      */
-    List<SignatureEntity> findByActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(String userId, Date startingDate, Date endingDate);
+    List<SignatureEntity> findByActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDescIdDesc(String userId, Date startingDate, Date endingDate);
 
     /**
      * Return signature audit records for given user, application and date range.
@@ -49,6 +49,6 @@ public interface SignatureAuditRepository extends CrudRepository<SignatureEntity
      * @param endingDate    Ending date (date "to").
      * @return List of {@link SignatureEntity} instances.
      */
-    List<SignatureEntity> findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(Long applicationId, String userId, Date startingDate, Date endingDate);
+    List<SignatureEntity> findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDescIdDesc(Long applicationId, String userId, Date startingDate, Date endingDate);
 
 }

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/AuditingServiceBehavior.java
@@ -68,9 +68,9 @@ public class AuditingServiceBehavior {
 
         List<SignatureEntity> signatureAuditEntityList;
         if (applicationId == null) {
-            signatureAuditEntityList = signatureAuditRepository.findByActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(userId, startingDate, endingDate);
+            signatureAuditEntityList = signatureAuditRepository.findByActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDescIdDesc(userId, startingDate, endingDate);
         } else {
-            signatureAuditEntityList = signatureAuditRepository.findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(applicationId, userId, startingDate, endingDate);
+            signatureAuditEntityList = signatureAuditRepository.findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDescIdDesc(applicationId, userId, startingDate, endingDate);
         }
 
         SignatureAuditResponse response = new SignatureAuditResponse();

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/AuditingServiceBehavior.java
@@ -21,12 +21,12 @@ package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 import com.google.common.io.BaseEncoding;
 import io.getlime.security.powerauth.SignatureAuditResponse;
 import io.getlime.security.powerauth.SignatureType;
+import io.getlime.security.powerauth.app.server.converter.ActivationStatusConverter;
 import io.getlime.security.powerauth.app.server.converter.SignatureTypeConverter;
-import io.getlime.security.powerauth.app.server.database.repository.SignatureAuditRepository;
+import io.getlime.security.powerauth.app.server.converter.XMLGregorianCalendarConverter;
 import io.getlime.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import io.getlime.security.powerauth.app.server.database.model.entity.SignatureEntity;
-import io.getlime.security.powerauth.app.server.converter.ActivationStatusConverter;
-import io.getlime.security.powerauth.app.server.converter.XMLGregorianCalendarConverter;
+import io.getlime.security.powerauth.app.server.database.repository.SignatureAuditRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -68,9 +68,9 @@ public class AuditingServiceBehavior {
 
         List<SignatureEntity> signatureAuditEntityList;
         if (applicationId == null) {
-            signatureAuditEntityList = signatureAuditRepository.findByActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDesc(userId, startingDate, endingDate);
+            signatureAuditEntityList = signatureAuditRepository.findByActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(userId, startingDate, endingDate);
         } else {
-            signatureAuditEntityList = signatureAuditRepository.findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByTimestampCreatedDesc(applicationId, userId, startingDate, endingDate);
+            signatureAuditEntityList = signatureAuditRepository.findByActivation_ApplicationIdAndActivation_UserIdAndTimestampCreatedBetweenOrderByIdDesc(applicationId, userId, startingDate, endingDate);
         }
 
         SignatureAuditResponse response = new SignatureAuditResponse();

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -50,3 +50,6 @@ powerauth.service.crypto.generateActivationShortIdIterations=10
 powerauth.service.crypto.activationValidityInMilliseconds=120000
 powerauth.service.crypto.signatureMaxFailedAttempts=5
 powerauth.service.crypto.signatureValidationLookahead=20
+
+# Database Lock Timeout Configuration
+javax.persistence.lock.timeout=10000

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -9,6 +9,7 @@ import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
 import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
 import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
 import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-
 @SpringBootTest
 @RunWith(SpringJUnit4ClassRunner.class)
 public class VerifySignatureConcurrencyTest {
@@ -35,12 +34,7 @@ public class VerifySignatureConcurrencyTest {
         this.powerAuthService = powerAuthService;
     }
 
-    @Test
-    public void testPowerAuthSystemStatus() throws Exception {
-        GetSystemStatusRequest request = new GetSystemStatusRequest();
-        assertEquals("OK", powerAuthService.getSystemStatus(request).getStatus());
-    }
-
+    @Ignore("The test requires running MySQL database.")
     @Test
     public void testVerifySignatureConcurrent() throws Exception {
 

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -1,0 +1,142 @@
+package io.getlime.security.powerauth.app.server;
+
+import com.google.common.io.BaseEncoding;
+import io.getlime.security.powerauth.*;
+import io.getlime.security.powerauth.app.server.converter.XMLGregorianCalendarConverter;
+import io.getlime.security.powerauth.app.server.service.PowerAuthService;
+import io.getlime.security.powerauth.crypto.client.activation.PowerAuthClientActivation;
+import io.getlime.security.powerauth.crypto.lib.config.PowerAuthConfiguration;
+import io.getlime.security.powerauth.crypto.lib.generator.KeyGenerator;
+import io.getlime.security.powerauth.crypto.lib.util.AESEncryptionUtils;
+import io.getlime.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class VerifySignatureConcurrencyTest {
+
+    private PowerAuthService powerAuthService;
+
+    @Autowired
+    public void setPowerAuthService(PowerAuthService powerAuthService) {
+        this.powerAuthService = powerAuthService;
+    }
+
+    @Test
+    public void testPowerAuthSystemStatus() throws Exception {
+        GetSystemStatusRequest request = new GetSystemStatusRequest();
+        assertEquals("OK", powerAuthService.getSystemStatus(request).getStatus());
+    }
+
+    @Test
+    public void testVerifySignatureConcurrent() throws Exception {
+
+        // Generate test application
+        String testId = "Test_"+System.currentTimeMillis();
+        CreateApplicationRequest createApplicationRequest = new CreateApplicationRequest();
+        createApplicationRequest.setApplicationName(testId);
+        CreateApplicationResponse createApplicationResponse = powerAuthService.createApplication(createApplicationRequest);
+
+        // Generate test application version
+        CreateApplicationVersionRequest createApplicationVersionRequest = new CreateApplicationVersionRequest();
+        createApplicationVersionRequest.setApplicationId(createApplicationResponse.getApplicationId());
+        createApplicationVersionRequest.setApplicationVersionName("test");
+        CreateApplicationVersionResponse createApplicationVersionResponse = powerAuthService.createApplicationVersion(createApplicationVersionRequest);
+
+        // Generate public key for non-existent client device
+        KeyGenerator keyGenerator = new KeyGenerator();
+        KeyPair keyPair = keyGenerator.generateKeyPair();
+        PublicKey publicKey = keyPair.getPublic();
+        byte[] publicKeyBytes = PowerAuthConfiguration.INSTANCE.getKeyConvertor().convertPublicKeyToBytes(publicKey);
+
+        // Generate random activation request values
+        PowerAuthServerActivation serverActivation = new PowerAuthServerActivation();
+        byte[] activationNonce = serverActivation.generateActivationNonce();
+        String activationNonceBase64 = BaseEncoding.base64().encode(activationNonce);
+        String activationOtp = serverActivation.generateActivationOTP();
+        String activationIdShort = serverActivation.generateActivationIdShort();
+
+        // Derive and encrypt non-existent device public key
+        SecretKey otpBasedSymmetricKey = new KeyGenerator().deriveSecretKeyFromPassword(activationOtp, activationIdShort.getBytes());
+        byte[] encryptedDevicePublicKey = new AESEncryptionUtils().encrypt(publicKeyBytes, activationNonce, otpBasedSymmetricKey);
+        String encryptedDevicePublicKeyBase64 = BaseEncoding.base64().encode(encryptedDevicePublicKey);
+
+        // Compute application signature
+        PowerAuthClientActivation clientActivation = new PowerAuthClientActivation();
+        byte[] signature = clientActivation.computeApplicationSignature(
+                activationIdShort,
+                activationNonce,
+                encryptedDevicePublicKey,
+                BaseEncoding.base64().decode(createApplicationVersionResponse.getApplicationKey()),
+                BaseEncoding.base64().decode(createApplicationVersionResponse.getApplicationSecret()));
+
+        // Generate expiration time
+        Calendar expiration = Calendar.getInstance();
+        expiration.add(Calendar.MINUTE, 5);
+
+        // Create activation
+        CreateActivationRequest createActivationRequest = new CreateActivationRequest();
+        createActivationRequest.setApplicationId(createApplicationResponse.getApplicationId());
+        createActivationRequest.setUserId("test");
+        createActivationRequest.setActivationName(testId);
+        createActivationRequest.setTimestampActivationExpire(XMLGregorianCalendarConverter.convertFrom(expiration.getTime()));
+        createActivationRequest.setEncryptedDevicePublicKey(encryptedDevicePublicKeyBase64);
+        createActivationRequest.setActivationNonce(activationNonceBase64);
+        createActivationRequest.setActivationOtp(activationOtp);
+        createActivationRequest.setIdentity(activationIdShort);
+        createActivationRequest.setApplicationKey(createApplicationVersionResponse.getApplicationKey());
+        createActivationRequest.setApplicationSignature(BaseEncoding.base64().encode(signature));
+        CreateActivationResponse createActivationResponse = powerAuthService.createActivation(createActivationRequest);
+
+        // Commit activation
+        CommitActivationRequest commitActivationRequest = new CommitActivationRequest();
+        commitActivationRequest.setActivationId(createActivationResponse.getActivationId());
+        CommitActivationResponse commitActivationResponse = powerAuthService.commitActivation(commitActivationRequest);
+
+        // Finally here comes the test - create two threads and verify signatures in parallel
+        Runnable verifySignatureRunnable = () -> {
+            try {
+                VerifySignatureRequest verifySignatureRequest = new VerifySignatureRequest();
+                verifySignatureRequest.setActivationId(createActivationResponse.getActivationId());
+                verifySignatureRequest.setApplicationKey(createApplicationVersionResponse.getApplicationKey());
+                verifySignatureRequest.setSignatureType(SignatureType.KNOWLEDGE);
+                verifySignatureRequest.setData("data");
+                verifySignatureRequest.setSignature("bad signature");
+                VerifySignatureResponse response = powerAuthService.verifySignature(verifySignatureRequest);
+                System.out.println("Signature verification response: "+response.isSignatureValid());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        };
+
+        // In case two threads are not enough, increase the THREAD_COUNT constant
+        final int THREAD_COUNT = 2;
+
+        List<Thread> threads = new ArrayList<>();
+        for (int i=0; i<THREAD_COUNT; i++) {
+            threads.add(new Thread(verifySignatureRunnable));
+        }
+
+        for (Thread t: threads) {
+            t.start();
+        }
+
+        for (Thread t: threads) {
+            t.join();
+        }
+
+    }
+}


### PR DESCRIPTION
* Fix #32: Database deadlock when multiple PA signatures are validated at the same time - the problem was fixed by introducing a row level PESSIMISTIC_WRITE DB lock and increasing lock timeout  
* Fix ordering of signature audit records - concurrent requests occurring within same second were ordered incorrectly in MySQL database, ordering is now done by record ID which has no such problems
* Added test for MySQL deadlock. The test is disabled to avoid failing Travis builds due to missing MySQL database.