### PR TITLE
Fix #45: Update library dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.9.RELEASE</version>
+		<version>1.5.10.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/powerauth-java-client-axis/pom.xml
+++ b/powerauth-java-client-axis/pom.xml
@@ -36,23 +36,23 @@
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.7</version>
 			<type>pom</type>
         </dependency>
 		<dependency>
 		    <groupId>org.apache.axis2</groupId>
 		    <artifactId>axis2-adb</artifactId>
-		    <version>1.7.6</version>
+		    <version>1.7.7</version>
 		</dependency>
         <dependency>
             <groupId>org.apache.axis2</groupId>
             <artifactId>axis2-transport-http</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.7</version>
         </dependency>
 		<dependency>
 			<groupId>org.apache.axis2</groupId>
 			<artifactId>axis2-transport-local</artifactId>
-			<version>1.7.6</version>
+			<version>1.7.7</version>
 		</dependency>
 	</dependencies>
 
@@ -62,7 +62,7 @@
 			<plugin>
 				<groupId>org.apache.axis2</groupId>
 				<artifactId>axis2-wsdl2code-maven-plugin</artifactId>
-				<version>1.7.6</version>
+				<version>1.7.7</version>
 				<executions>
 					<execution>
 						<goals>

--- a/powerauth-java-client-spring/pom.xml
+++ b/powerauth-java-client-spring/pom.xml
@@ -64,7 +64,7 @@
 			<plugin>
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
 				<artifactId>maven-jaxb2-plugin</artifactId>
-				<version>0.12.3</version>
+				<version>0.13.3</version>
 				<executions>
 					<execution>
 						<goals>

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>io.getlime.security</groupId>
             <artifactId>powerauth-java-crypto</artifactId>
-            <version>0.17.0</version>
+            <version>0.18.0</version>
         </dependency>
 
         <!-- Other Dependencies -->
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.58</version>
+            <version>1.59</version>
         </dependency>
 
         <!-- Test Dependencies -->


### PR DESCRIPTION
In order to prepare for the release, we should update library dependencies.