### PR TITLE
Fix #64: Suppress Hibernate warnings

### DIFF
--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -53,3 +53,7 @@ powerauth.service.crypto.signatureValidationLookahead=20
 
 # Database Lock Timeout Configuration
 javax.persistence.lock.timeout=10000
+
+# TODO: Workaround for Hibernate <5.2 and Oracle harmless warnings
+# Disabled follow-on-locking warnings
+logging.level.org.hibernate.loader.Loader=ERROR


### PR DESCRIPTION
I think we should add this line in deployment. I cannot imagine a customer who would like to leave it without the flag.