### PR TITLE
Fix #71: Implement personalized and non-personalized variants of createOfflineSignaturePayload

### DIFF
--- a/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-axis/src/main/java/io/getlime/security/powerauth/soap/axis/client/PowerAuthServiceClient.java
@@ -486,29 +486,51 @@ public class PowerAuthServiceClient {
     }
 
     /**
-     * Call the createOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * Call the createPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
      * @param activationId Activation ID.
      * @param data Data for offline signature.
-     * @param message Message displayed to the user during offline signature authentication.
-     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateOfflineSignaturePayloadResponse}
+     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadResponse}
      * @throws RemoteException In case of a business logic error.
      */
-    public PowerAuthPortServiceStub.CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(String activationId, String data, String message) throws RemoteException {
-        PowerAuthPortServiceStub.CreateOfflineSignaturePayloadRequest request = new PowerAuthPortServiceStub.CreateOfflineSignaturePayloadRequest();
+    public PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(String activationId, String data) throws RemoteException {
+        PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadRequest request = new PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadRequest();
         request.setActivationId(activationId);
         request.setData(data);
-        request.setMessage(message);
-        return createOfflineSignaturePayload(request);
+        return createPersonalizedOfflineSignaturePayload(request);
     }
 
     /**
-     * Call the createOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
-     * @param request {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateOfflineSignaturePayloadRequest} instance.
-     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateOfflineSignaturePayloadResponse}
+     * Call the createPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param request {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadRequest} instance.
+     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadResponse}
      * @throws RemoteException In case of a business logic error.
      */
-    public PowerAuthPortServiceStub.CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(PowerAuthPortServiceStub.CreateOfflineSignaturePayloadRequest request) throws RemoteException {
-        return clientStub.createOfflineSignaturePayload(request);
+    public PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(PowerAuthPortServiceStub.CreatePersonalizedOfflineSignaturePayloadRequest request) throws RemoteException {
+        return clientStub.createPersonalizedOfflineSignaturePayload(request);
+    }
+
+    /**
+     * Call the createNonPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param applicationId Application ID.
+     * @param data Data for offline signature.
+     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadResponse}
+     * @throws RemoteException In case of a business logic error.
+     */
+    public PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(long applicationId, String data) throws RemoteException {
+        PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadRequest request = new PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadRequest();
+        request.setApplicationId(applicationId);
+        request.setData(data);
+        return createNonPersonalizedOfflineSignaturePayload(request);
+    }
+
+    /**
+     * Call the createNonPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param request {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadRequest} instance.
+     * @return {@link io.getlime.powerauth.soap.PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadResponse}
+     * @throws RemoteException In case of a business logic error.
+     */
+    public PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(PowerAuthPortServiceStub.CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws RemoteException {
+        return clientStub.createNonPersonalizedOfflineSignaturePayload(request);
     }
 
     /**

--- a/powerauth-java-client-axis/src/main/resources/soap/wsdl/service.wsdl
+++ b/powerauth-java-client-axis/src/main/resources/soap/wsdl/service.wsdl
@@ -545,32 +545,54 @@
                 </xs:complexType>
             </xs:element>
 
-            <!-- Create offline signature payload //-->
+            <!-- Create personalized offline signature payload //-->
 
-            <xs:element name="CreateOfflineSignaturePayloadRequest">
+            <xs:element name="CreatePersonalizedOfflineSignaturePayloadRequest">
                 <xs:annotation>
-                    <xs:documentation>Request for generating signature payload for the offline signature.</xs:documentation>
+                    <xs:documentation>Request for generating personalized signature payload for the offline signature.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="message" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
 
-            <xs:element name="CreateOfflineSignaturePayloadResponse">
+            <xs:element name="CreatePersonalizedOfflineSignaturePayloadResponse">
                 <xs:annotation>
-                    <xs:documentation>Response for generating signature payload for the offline signature.</xs:documentation>
+                    <xs:documentation>Response for generating personalized signature payload for the offline signature.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="message" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="dataHash" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="offlineData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="nonce" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="signature" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <!-- Create non-personalized offline signature payload //-->
+
+            <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+                <xs:annotation>
+                    <xs:documentation>Request for generating non-personalized signature payload for the offline signature.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+                <xs:annotation>
+                    <xs:documentation>Response for generating non-personalized signature payload for the offline signature.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="1" minOccurs="1" name="offlineData" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="nonce" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1249,8 +1271,12 @@
         <wsdl:part element="tns:GetErrorCodeListResponse" name="GetErrorCodeListResponse">
         </wsdl:part>
     </wsdl:message>
-    <wsdl:message name="CreateOfflineSignaturePayloadRequest">
-        <wsdl:part element="tns:CreateOfflineSignaturePayloadRequest" name="CreateOfflineSignaturePayloadRequest">
+    <wsdl:message name="CreatePersonalizedOfflineSignaturePayloadRequest">
+        <wsdl:part element="tns:CreatePersonalizedOfflineSignaturePayloadRequest" name="CreatePersonalizedOfflineSignaturePayloadRequest">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+        <wsdl:part element="tns:CreateNonPersonalizedOfflineSignaturePayloadRequest" name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
         </wsdl:part>
     </wsdl:message>
     <wsdl:message name="VerifyOfflineSignatureRequest">
@@ -1293,8 +1319,12 @@
         <wsdl:part element="tns:BlockActivationResponse" name="BlockActivationResponse">
         </wsdl:part>
     </wsdl:message>
-    <wsdl:message name="CreateOfflineSignaturePayloadResponse">
-        <wsdl:part element="tns:CreateOfflineSignaturePayloadResponse" name="CreateOfflineSignaturePayloadResponse">
+    <wsdl:message name="CreatePersonalizedOfflineSignaturePayloadResponse">
+        <wsdl:part element="tns:CreatePersonalizedOfflineSignaturePayloadResponse" name="CreatePersonalizedOfflineSignaturePayloadResponse">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+        <wsdl:part element="tns:CreateNonPersonalizedOfflineSignaturePayloadResponse" name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
         </wsdl:part>
     </wsdl:message>
     <wsdl:message name="VerifyECDSASignatureRequest">
@@ -1562,10 +1592,16 @@
             <wsdl:output message="tns:GetErrorCodeListResponse" name="GetErrorCodeListResponse">
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="CreateOfflineSignaturePayload">
-            <wsdl:input message="tns:CreateOfflineSignaturePayloadRequest" name="CreateOfflineSignaturePayloadRequest">
+        <wsdl:operation name="CreatePersonalizedOfflineSignaturePayload">
+            <wsdl:input message="tns:CreatePersonalizedOfflineSignaturePayloadRequest" name="CreatePersonalizedOfflineSignaturePayloadRequest">
             </wsdl:input>
-            <wsdl:output message="tns:CreateOfflineSignaturePayloadResponse" name="CreateOfflineSignaturePayloadResponse">
+            <wsdl:output message="tns:CreatePersonalizedOfflineSignaturePayloadResponse" name="CreatePersonalizedOfflineSignaturePayloadResponse">
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CreateNonPersonalizedOfflineSignaturePayload">
+            <wsdl:input message="tns:CreateNonPersonalizedOfflineSignaturePayloadRequest" name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+            </wsdl:input>
+            <wsdl:output message="tns:CreateNonPersonalizedOfflineSignaturePayloadResponse" name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="GetApplicationDetail">
@@ -1841,15 +1877,24 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="CreateOfflineSignaturePayload">
+        <wsdl:operation name="CreatePersonalizedOfflineSignaturePayload">
             <soap:operation soapAction=""/>
-            <wsdl:input name="CreateOfflineSignaturePayloadRequest">
+            <wsdl:input name="CreatePersonalizedOfflineSignaturePayloadRequest">
                 <soap:body use="literal"/>
             </wsdl:input>
-            <wsdl:output name="CreateOfflineSignaturePayloadResponse">
+            <wsdl:output name="CreatePersonalizedOfflineSignaturePayloadResponse">
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
+        <wsdl:operation name="CreateNonPersonalizedOfflineSignaturePayload">
+            <soap:operation soapAction=""/>
+            <wsdl:input name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>\
         <wsdl:operation name="GetApplicationDetail">
             <soap:operation soapAction=""/>
             <wsdl:input name="GetApplicationDetailRequest">

--- a/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
+++ b/powerauth-java-client-spring/src/main/java/io/getlime/security/powerauth/soap/spring/client/PowerAuthServiceClient.java
@@ -376,27 +376,47 @@ public class PowerAuthServiceClient extends WebServiceGatewaySupport {
     }
 
     /**
-     * Call the createOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * Call the createPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
      * @param activationId Activation ID.
      * @param data Data for offline signature.
-     * @param message Message displayed to the user during offline signature authentication.
-     * @return {@link io.getlime.powerauth.soap.CreateOfflineSignaturePayloadResponse}
+     * @return {@link io.getlime.powerauth.soap.CreatePersonalizedOfflineSignaturePayloadResponse}
      */
-    public CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(String activationId, String data, String message) {
-        CreateOfflineSignaturePayloadRequest request = new CreateOfflineSignaturePayloadRequest();
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(String activationId, String data) {
+        CreatePersonalizedOfflineSignaturePayloadRequest request = new CreatePersonalizedOfflineSignaturePayloadRequest();
         request.setActivationId(activationId);
         request.setData(data);
-        request.setMessage(message);
-        return createOfflineSignaturePayload(request);
+        return createPersonalizedOfflineSignaturePayload(request);
     }
 
     /**
-     * Call the createOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
-     * @param request {@link io.getlime.powerauth.soap.CreateOfflineSignaturePayloadRequest} instance.
-     * @return {@link io.getlime.powerauth.soap.CreateOfflineSignaturePayloadResponse}
+     * Call the createPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param request {@link io.getlime.powerauth.soap.CreatePersonalizedOfflineSignaturePayloadRequest} instance.
+     * @return {@link io.getlime.powerauth.soap.CreatePersonalizedOfflineSignaturePayloadResponse}
      */
-    public CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(CreateOfflineSignaturePayloadRequest request) {
-        return (CreateOfflineSignaturePayloadResponse) getWebServiceTemplate().marshalSendAndReceive(request);
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) {
+        return (CreatePersonalizedOfflineSignaturePayloadResponse) getWebServiceTemplate().marshalSendAndReceive(request);
+    }
+
+    /**
+     * Call the createNonPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param applicationId Application ID.
+     * @param data Data for offline signature.
+     * @return {@link io.getlime.powerauth.soap.CreateNonPersonalizedOfflineSignaturePayloadResponse}
+     */
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(long applicationId, String data) {
+        CreateNonPersonalizedOfflineSignaturePayloadRequest request = new CreateNonPersonalizedOfflineSignaturePayloadRequest();
+        request.setApplicationId(applicationId);
+        request.setData(data);
+        return createNonPersonalizedOfflineSignaturePayload(request);
+    }
+
+    /**
+     * Call the createNonPersonalizedOfflineSignaturePayload method of the PowerAuth 2.0 Server SOAP interface.
+     * @param request {@link io.getlime.powerauth.soap.CreateNonPersonalizedOfflineSignaturePayloadRequest} instance.
+     * @return {@link io.getlime.powerauth.soap.CreateNonPersonalizedOfflineSignaturePayloadResponse}
+     */
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) {
+        return (CreateNonPersonalizedOfflineSignaturePayloadResponse) getWebServiceTemplate().marshalSendAndReceive(request);
     }
 
     /**

--- a/powerauth-java-client-spring/src/main/resources/soap/wsdl/service.wsdl
+++ b/powerauth-java-client-spring/src/main/resources/soap/wsdl/service.wsdl
@@ -545,32 +545,54 @@
                 </xs:complexType>
             </xs:element>
 
-            <!-- Create offline signature payload //-->
+            <!-- Create personalized offline signature payload //-->
 
-            <xs:element name="CreateOfflineSignaturePayloadRequest">
+            <xs:element name="CreatePersonalizedOfflineSignaturePayloadRequest">
                 <xs:annotation>
-                    <xs:documentation>Request for generating signature payload for the offline signature.</xs:documentation>
+                    <xs:documentation>Request for generating personalized signature payload for the offline signature.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element maxOccurs="1" minOccurs="1" name="activationId" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="message" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
 
-            <xs:element name="CreateOfflineSignaturePayloadResponse">
+            <xs:element name="CreatePersonalizedOfflineSignaturePayloadResponse">
                 <xs:annotation>
-                    <xs:documentation>Response for generating signature payload for the offline signature.</xs:documentation>
+                    <xs:documentation>Response for generating personalized signature payload for the offline signature.</xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
                     <xs:sequence>
-                        <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="message" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="dataHash" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="offlineData" type="xs:string"/>
                         <xs:element maxOccurs="1" minOccurs="1" name="nonce" type="xs:string"/>
-                        <xs:element maxOccurs="1" minOccurs="1" name="signature" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <!-- Create non-personalized offline signature payload //-->
+
+            <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+                <xs:annotation>
+                    <xs:documentation>Request for generating non-personalized signature payload for the offline signature.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="1" minOccurs="1" name="applicationId" type="xs:long"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="data" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+
+            <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+                <xs:annotation>
+                    <xs:documentation>Response for generating non-personalized signature payload for the offline signature.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element maxOccurs="1" minOccurs="1" name="offlineData" type="xs:string"/>
+                        <xs:element maxOccurs="1" minOccurs="1" name="nonce" type="xs:string"/>
                     </xs:sequence>
                 </xs:complexType>
             </xs:element>
@@ -1249,8 +1271,12 @@
         <wsdl:part element="tns:GetErrorCodeListResponse" name="GetErrorCodeListResponse">
         </wsdl:part>
     </wsdl:message>
-    <wsdl:message name="CreateOfflineSignaturePayloadRequest">
-        <wsdl:part element="tns:CreateOfflineSignaturePayloadRequest" name="CreateOfflineSignaturePayloadRequest">
+    <wsdl:message name="CreatePersonalizedOfflineSignaturePayloadRequest">
+        <wsdl:part element="tns:CreatePersonalizedOfflineSignaturePayloadRequest" name="CreatePersonalizedOfflineSignaturePayloadRequest">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+        <wsdl:part element="tns:CreateNonPersonalizedOfflineSignaturePayloadRequest" name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
         </wsdl:part>
     </wsdl:message>
     <wsdl:message name="VerifyOfflineSignatureRequest">
@@ -1293,8 +1319,12 @@
         <wsdl:part element="tns:BlockActivationResponse" name="BlockActivationResponse">
         </wsdl:part>
     </wsdl:message>
-    <wsdl:message name="CreateOfflineSignaturePayloadResponse">
-        <wsdl:part element="tns:CreateOfflineSignaturePayloadResponse" name="CreateOfflineSignaturePayloadResponse">
+    <wsdl:message name="CreatePersonalizedOfflineSignaturePayloadResponse">
+        <wsdl:part element="tns:CreatePersonalizedOfflineSignaturePayloadResponse" name="CreatePersonalizedOfflineSignaturePayloadResponse">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+        <wsdl:part element="tns:CreateNonPersonalizedOfflineSignaturePayloadResponse" name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
         </wsdl:part>
     </wsdl:message>
     <wsdl:message name="VerifyECDSASignatureRequest">
@@ -1562,10 +1592,16 @@
             <wsdl:output message="tns:GetErrorCodeListResponse" name="GetErrorCodeListResponse">
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="CreateOfflineSignaturePayload">
-            <wsdl:input message="tns:CreateOfflineSignaturePayloadRequest" name="CreateOfflineSignaturePayloadRequest">
+        <wsdl:operation name="CreatePersonalizedOfflineSignaturePayload">
+            <wsdl:input message="tns:CreatePersonalizedOfflineSignaturePayloadRequest" name="CreatePersonalizedOfflineSignaturePayloadRequest">
             </wsdl:input>
-            <wsdl:output message="tns:CreateOfflineSignaturePayloadResponse" name="CreateOfflineSignaturePayloadResponse">
+            <wsdl:output message="tns:CreatePersonalizedOfflineSignaturePayloadResponse" name="CreatePersonalizedOfflineSignaturePayloadResponse">
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CreateNonPersonalizedOfflineSignaturePayload">
+            <wsdl:input message="tns:CreateNonPersonalizedOfflineSignaturePayloadRequest" name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+            </wsdl:input>
+            <wsdl:output message="tns:CreateNonPersonalizedOfflineSignaturePayloadResponse" name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
             </wsdl:output>
         </wsdl:operation>
         <wsdl:operation name="GetApplicationDetail">
@@ -1841,12 +1877,21 @@
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>
-        <wsdl:operation name="CreateOfflineSignaturePayload">
+        <wsdl:operation name="CreatePersonalizedOfflineSignaturePayload">
             <soap:operation soapAction=""/>
-            <wsdl:input name="CreateOfflineSignaturePayloadRequest">
+            <wsdl:input name="CreatePersonalizedOfflineSignaturePayloadRequest">
                 <soap:body use="literal"/>
             </wsdl:input>
-            <wsdl:output name="CreateOfflineSignaturePayloadResponse">
+            <wsdl:output name="CreatePersonalizedOfflineSignaturePayloadResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="CreateNonPersonalizedOfflineSignaturePayload">
+            <soap:operation soapAction=""/>
+            <wsdl:input name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
                 <soap:body use="literal"/>
             </wsdl:output>
         </wsdl:operation>

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/controller/PowerAuthController.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/controller/PowerAuthController.java
@@ -173,16 +173,29 @@ public class PowerAuthController {
     }
 
     /**
-     * Call {@link PowerAuthService#createOfflineSignaturePayload(CreateOfflineSignaturePayloadRequest)} method and
+     * Call {@link PowerAuthService#createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest)} method and
      * return the response.
      *
-     * @param request Create offline signature data request.
-     * @return Create offline signature data response.
+     * @param request Create personalized offline signature data request.
+     * @return Create personalized offline signature data response.
      * @throws Exception In case the service throws exception.
      */
-    @RequestMapping(value = "/signature/offline/create", method = RequestMethod.POST)
-    public @ResponseBody RESTResponseWrapper<CreateOfflineSignaturePayloadResponse> createOfflineSignaturePayload(@RequestBody RESTRequestWrapper<CreateOfflineSignaturePayloadRequest> request) throws Exception {
-        return new RESTResponseWrapper<>("OK", powerAuthService.createOfflineSignaturePayload(request.getRequestObject()));
+    @RequestMapping(value = "/signature/offline/personalized/create", method = RequestMethod.POST)
+    public @ResponseBody RESTResponseWrapper<CreatePersonalizedOfflineSignaturePayloadResponse> createPersonalizedOfflineSignaturePayload(@RequestBody RESTRequestWrapper<CreatePersonalizedOfflineSignaturePayloadRequest> request) throws Exception {
+        return new RESTResponseWrapper<>("OK", powerAuthService.createPersonalizedOfflineSignaturePayload(request.getRequestObject()));
+    }
+
+    /**
+     * Call {@link PowerAuthService#createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest)} method and
+     * return the response.
+     *
+     * @param request Create non-personalized offline signature data request.
+     * @return Create non-personalized offline signature data response.
+     * @throws Exception In case the service throws exception.
+     */
+    @RequestMapping(value = "/signature/offline/non-personalized/create", method = RequestMethod.POST)
+    public @ResponseBody RESTResponseWrapper<CreateNonPersonalizedOfflineSignaturePayloadResponse> createNonPersonalizedOfflineSignaturePayload(@RequestBody RESTRequestWrapper<CreateNonPersonalizedOfflineSignaturePayloadRequest> request) throws Exception {
+        return new RESTResponseWrapper<>("OK", powerAuthService.createNonPersonalizedOfflineSignaturePayload(request.getRequestObject()));
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/endpoint/PowerAuthEndpoint.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/endpoint/PowerAuthEndpoint.java
@@ -183,17 +183,31 @@ public class PowerAuthEndpoint {
     }
 
     /**
-     * Call {@link PowerAuthService#createOfflineSignaturePayload(CreateOfflineSignaturePayloadRequest)} method and
+     * Call {@link PowerAuthService#createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest)} method and
      * return the response.
      *
-     * @param request Create offline signature data request.
-     * @return Create offline signature response.
+     * @param request Create personalized offline signature data request.
+     * @return Create personalized offline signature response.
      * @throws Exception In case the service throws exception.
      */
-    @PayloadRoot(namespace = NAMESPACE_URI, localPart = "CreateOfflineSignaturePayloadRequest")
+    @PayloadRoot(namespace = NAMESPACE_URI, localPart = "CreatePersonalizedOfflineSignaturePayloadRequest")
     @ResponsePayload
-    public CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(@RequestPayload CreateOfflineSignaturePayloadRequest request) throws Exception {
-        return powerAuthService.createOfflineSignaturePayload(request);
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(@RequestPayload CreatePersonalizedOfflineSignaturePayloadRequest request) throws Exception {
+        return powerAuthService.createPersonalizedOfflineSignaturePayload(request);
+    }
+
+    /**
+     * Call {@link PowerAuthService#createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest)} method and
+     * return the response.
+     *
+     * @param request Create non-personalized offline signature data request.
+     * @return Create non-personalized offline signature response.
+     * @throws Exception In case the service throws exception.
+     */
+    @PayloadRoot(namespace = NAMESPACE_URI, localPart = "CreateNonPersonalizedOfflineSignaturePayloadRequest")
+    @ResponsePayload
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(@RequestPayload CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws Exception {
+        return powerAuthService.createNonPersonalizedOfflineSignaturePayload(request);
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthService.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthService.java
@@ -111,14 +111,24 @@ public interface PowerAuthService {
     VerifySignatureResponse verifySignature(VerifySignatureRequest request) throws Exception;
 
     /**
-     * Generate data that is used as a challenge when computing offline signatures. It takes "data" and
-     * displayable message and computes data hash, nonce and ECDSA signature of the data.
+     * Generate data that is used as a challenge when computing personalized offline signatures. It takes "data" and
+     * generates nonce and ECDSA signature of the data.
      *
      * @param request Request with data and message to generate signature from.
-     * @return Resposne with offline signature data.
+     * @return Response with offline signature data.
      * @throws Exception In case of a business logic error.
      */
-    CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(CreateOfflineSignaturePayloadRequest request) throws Exception;
+    CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws Exception;
+
+    /*
+     * Generate data that is used as a challenge when computing non-personalized offline signatures. It takes "data" and
+     * generates nonce and ECDSA signature of the data.
+     *
+     * @param request Request with data and message to generate signature from.
+     * @return Response with offline signature data.
+     * @throws Exception In case of a business logic error.
+     */
+    CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws Exception;
 
     /**
      * Verify offline signature. Each call to this method

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthServiceImpl.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/PowerAuthServiceImpl.java
@@ -263,12 +263,27 @@ public class PowerAuthServiceImpl implements PowerAuthService {
 
     @Override
     @Transactional
-    public CreateOfflineSignaturePayloadResponse createOfflineSignaturePayload(CreateOfflineSignaturePayloadRequest request) throws Exception {
+    public CreatePersonalizedOfflineSignaturePayloadResponse createPersonalizedOfflineSignaturePayload(CreatePersonalizedOfflineSignaturePayloadRequest request) throws Exception {
         try {
             String activationId = request.getActivationId();
             String data = request.getData();
-            String message = request.getMessage();
-            return behavior.getSignatureServiceBehavior().createOfflineSignaturePayload(activationId, data, message, keyConversionUtilities);
+            return behavior.getSignatureServiceBehavior().createPersonalizedOfflineSignaturePayload(activationId, data, keyConversionUtilities);
+        } catch (GenericServiceException ex) {
+            Logger.getLogger(PowerAuthServiceImpl.class.getName()).log(Level.SEVERE, null, ex);
+            throw ex;
+        } catch (Exception ex) {
+            Logger.getLogger(PowerAuthServiceImpl.class.getName()).log(Level.SEVERE, ex.getMessage(), ex);
+            throw new GenericServiceException(ServiceError.UNABLE_TO_COMPUTE_SIGNATURE, ex.getMessage(), ex.getLocalizedMessage());
+        }
+    }
+
+    @Override
+    @Transactional
+    public CreateNonPersonalizedOfflineSignaturePayloadResponse createNonPersonalizedOfflineSignaturePayload(CreateNonPersonalizedOfflineSignaturePayloadRequest request) throws Exception {
+        try {
+            long applicationId = request.getApplicationId();
+            String data = request.getData();
+            return behavior.getSignatureServiceBehavior().createNonPersonalizedOfflineSignaturePayload(applicationId, data, keyConversionUtilities);
         } catch (GenericServiceException ex) {
             Logger.getLogger(PowerAuthServiceImpl.class.getName()).log(Level.SEVERE, null, ex);
             throw ex;

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/SignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/SignatureServiceBehavior.java
@@ -448,7 +448,7 @@ public class SignatureServiceBehavior {
             final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
             String nonce = BaseEncoding.base64().encode(nonceBytes);
 
-            // Prepare the private key
+            // Prepare the private key - KEY_SERVER_PRIVATE is used for personalized offline signatures
             final String keyPrivateBase64 = activation.getServerPrivateKeyBase64();
             final PrivateKey privateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(keyPrivateBase64));
 
@@ -491,7 +491,7 @@ public class SignatureServiceBehavior {
             final byte[] nonceBytes = new KeyGenerator().generateRandomBytes(16);
             String nonce = BaseEncoding.base64().encode(nonceBytes);
 
-            // Prepare the private key
+            // Prepare the private key - KEY_MASTER_SERVER_PRIVATE is used for non-personalized offline signatures
             final String keyPrivateBase64 = masterKeyPair.getMasterKeyPrivateBase64();
             final PrivateKey privateKey = keyConversionUtilities.convertBytesToPrivateKey(BaseEncoding.base64().decode(keyPrivateBase64));
 

--- a/powerauth-java-server/src/main/resources/xsd/PowerAuth-2.0.xsd
+++ b/powerauth-java-server/src/main/resources/xsd/PowerAuth-2.0.xsd
@@ -547,32 +547,54 @@
     </xs:element>
 
 
-    <!-- Create offline signature payload //-->
+    <!-- Create personalized offline signature payload //-->
 
-    <xs:element name="CreateOfflineSignaturePayloadRequest">
+    <xs:element name="CreatePersonalizedOfflineSignaturePayloadRequest">
         <xs:annotation>
-            <xs:documentation>Request for generating signature payload for the offline signature.</xs:documentation>
+            <xs:documentation>Request for generating personalized signature payload for the offline signature.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="activationId" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="data" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="CreateOfflineSignaturePayloadResponse">
+    <xs:element name="CreatePersonalizedOfflineSignaturePayloadResponse">
         <xs:annotation>
-            <xs:documentation>Response for generating signature payload for the offline signature.</xs:documentation>
+            <xs:documentation>Response for generating personalized signature payload for the offline signature.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="data" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="message" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="dataHash" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="offlineData" type="xs:string" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="nonce" type="xs:string" minOccurs="1" maxOccurs="1"/>
-                <xs:element name="signature" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <!-- Create offline signature payload //-->
+
+    <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadRequest">
+        <xs:annotation>
+            <xs:documentation>Request for generating non-personalized signature payload for the offline signature.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="applicationId" type="xs:long" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="data" type="xs:string" minOccurs="1" maxOccurs="1"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="CreateNonPersonalizedOfflineSignaturePayloadResponse">
+        <xs:annotation>
+            <xs:documentation>Response for generating non-personalized signature payload for the offline signature.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="offlineData" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                <xs:element name="nonce" type="xs:string" minOccurs="1" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>


### PR DESCRIPTION
Note that I use "data" in requests  and "offlineData" in responses to differentiate incoming and outgoing data during signature payload construction. The "offlineData" now contains all data that is required to construct the QR code. If you have a better idea how to name this input/output data, let me know.
