### PR TITLE
Fix #33: JDK 9 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+		<maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+		<maven-javadoc-plugin.version>3.0.0</maven-javadoc-plugin.version>
+        <maven-war-plugin.version>3.1.0</maven-war-plugin.version>
 	</properties>
 
 	<build>
@@ -101,7 +105,18 @@
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>${maven-jar-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-war-plugin</artifactId>
+			    <version>${maven-war-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin.version}</version>
 				<configuration>
 					<failOnError>false</failOnError>
 				</configuration>
@@ -111,13 +126,18 @@
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+							<additionalOptions>
+								<additionalOption>-Xdoclint:none</additionalOption>
+							</additionalOptions>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>${maven-deploy-plugin.version}</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -150,15 +170,6 @@
                 </plugins>
             </build>
         </profile>
-		<profile>
-			<id>disable-java8-doclint</id>
-			<activation>
-				<jdk>[1.8,)</jdk>
-			</activation>
-			<properties>
-				<additionalparam>-Xdoclint:none</additionalparam>
-			</properties>
-		</profile>
 	</profiles>
 
 	<distributionManagement>

--- a/powerauth-java-client-spring/pom.xml
+++ b/powerauth-java-client-spring/pom.xml
@@ -60,8 +60,9 @@
 
 	<build>
 		<plugins>
+			<!-- JAXB Maven plug-in does not work on JDK 9 yet. See: https://github.com/highsource/maven-jaxb2-plugin/issues/120 -->
 			<!-- tag::wsdl[] -->
-			<plugin>
+			<!--plugin>
 				<groupId>org.jvnet.jaxb2.maven2</groupId>
 				<artifactId>maven-jaxb2-plugin</artifactId>
 				<version>0.13.3</version>
@@ -84,8 +85,74 @@
 						</schema>
 					</schemas>
 				</configuration>
-			</plugin>
+			</plugin-->
 			<!-- end::wsdl[] -->
+
+			<!-- Workaround for generating sources from JAXB classes on JDK9 -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<configuration>
+							<target>
+								<echo message="Classes will be generated in ${project.build.directory}/generated-sources/jaxb"/>
+								<mkdir dir="${project.build.directory}/generated-sources/jaxb"/>
+							</target>
+						</configuration>
+						<goals>
+							<goal>run</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>generate-schema-types</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>exec</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<executable>xjc</executable>
+					<arguments>
+						<argument>-wsdl</argument>
+						<argument>-extension</argument>
+						<argument>-d</argument>
+						<argument>${project.build.directory}/generated-sources/jaxb</argument>
+						<argument>-p</argument>
+						<argument>io.getlime.powerauth.soap</argument>
+						<argument>${project.basedir}/src/main/resources/soap/wsdl/service.wsdl</argument>
+					</arguments>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>include-generated-sources</id>
+						<goals>
+							<goal>add-source</goal>
+						</goals>
+						<configuration>
+							<sources>
+								<source>${project.basedir}/target/generated-sources/jaxb</source>
+							</sources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- End of JDK 9 JAXB class generation workaround -->
+
 		</plugins>
 	</build>
 

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -139,10 +139,19 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
+
+            <!-- JAXB Maven plug-in does not work on JDK 9 yet. See: https://github.com/highsource/maven-jaxb2-plugin/issues/120 -->
+            <!--plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>2.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.activation</groupId>
+                        <artifactId>javax.activation-api</artifactId>
+                        <version>1.2.0</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>xjc</id>
@@ -152,9 +161,74 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <schemaDirectory>${project.basedir}/src/main/resources/xsd/</schemaDirectory>
+                    <sources>
+                        <source>${project.basedir}/src/main/resources/xsd/</source>
+                    </sources>
+                </configuration>
+            </plugin-->
+
+            <!-- Workaround for generating sources from JAXB classes on JDK9 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <echo message="Classes will be generated in ${project.build.directory}/generated-sources/jaxb"/>
+                                <mkdir dir="${project.build.directory}/generated-sources/jaxb"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-schema-types</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>xjc</executable>
+                    <arguments>
+                        <argument>-extension</argument>
+                        <argument>-d</argument>
+                        <argument>${project.build.directory}/generated-sources/jaxb</argument>
+                        <argument>${project.basedir}/src/main/resources/xsd/PowerAuth-2.0.xsd</argument>
+                    </arguments>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>include-generated-sources</id>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/target/generated-sources/jaxb</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- End of JDK 9 JAXB class generation workaround -->
+
         </plugins>
     </build>
 

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/WebServiceConfig.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/configuration/WebServiceConfig.java
@@ -113,11 +113,11 @@ public class WebServiceConfig extends WsConfigurerAdapter {
      * @return New servlet registration with correct context.
      */
     @Bean
-    public ServletRegistrationBean messageDispatcherServlet(ApplicationContext applicationContext) {
+    public ServletRegistrationBean<MessageDispatcherServlet> messageDispatcherServlet(ApplicationContext applicationContext) {
         MessageDispatcherServlet servlet = new MessageDispatcherServlet();
         servlet.setApplicationContext(applicationContext);
         servlet.setTransformWsdlLocations(true);
-        return new ServletRegistrationBean(servlet, "/soap/*");
+        return new ServletRegistrationBean<>(servlet, "/soap/*");
     }
 
     /**

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/ActivationStatusConverter.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/ActivationStatusConverter.java
@@ -33,7 +33,18 @@ public class ActivationStatusConverter implements AttributeConverter<ActivationS
 
     @Override
     public Integer convertToDatabaseColumn(ActivationStatus status) {
-        return new Integer(status.getByte());
+        switch (status) {
+            case CREATED:
+                return 1;
+            case OTP_USED:
+                return 2;
+            case ACTIVE:
+                return 3;
+            case BLOCKED:
+                return 4;
+            default:
+                return 5;
+        }
     }
 
     @Override


### PR DESCRIPTION
Additional changes:

* Disabled JavaDoc warnings globally because of generated classes which contain hundrends of warnings.
* JAXB classes are generated directly by XJC because of missing support for JDK 9 in JAXB2 Maven plugin.
* Fixed compilation warnings.