### PR TITLE
Application level record encryption - performance optimization

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/KeyEncryptionMode.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/KeyEncryptionMode.java
@@ -22,7 +22,7 @@ package io.getlime.security.powerauth.app.server.database.model;
  * Enum representing server private key encryption modes. Following values are supported:
  * <p>
  * - NO_ENCRYPTION = 0
- * - AES_PBKDF2_500000 = 1
+ * - AES_HMAC = 1
  * </p>
  *
  * @author Roman Strobl, roman.strobl@lime-company.eu
@@ -35,9 +35,9 @@ public enum KeyEncryptionMode {
     NO_ENCRYPTION((byte) 0),
 
     /**
-     * AES encryption with PBKDF2 using 500000 iterations.
+     * AES encryption with HMAC-based index.
      */
-    AES_PBKDF2_500000((byte) 1);
+    AES_HMAC((byte) 1);
 
     /**
      * Byte value of key encryption mode.

--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/entity/ActivationRecordEntity.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/database/model/entity/ActivationRecordEntity.java
@@ -128,7 +128,7 @@ public class ActivationRecordEntity implements Serializable {
      * @param timestampLastUsed          Last signature timestamp.
      * @param activationStatus           Activation status.
      * @param blockedReason              Reason why activation is blocked.
-     * @param serverPrivateKeyEncryption Mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_PBKDF2_500000).
+     * @param serverPrivateKeyEncryption Mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_HMAC).
      * @param masterKeyPair              Associated master keypair.
      * @param application                Associated application.
      */
@@ -484,7 +484,7 @@ public class ActivationRecordEntity implements Serializable {
     }
 
     /**
-     * Get mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_PBKDF2_500000).
+     * Get mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_HMAC).
      * @return Mode of server private key encryption.
      */
     public KeyEncryptionMode getServerPrivateKeyEncryption() {
@@ -492,7 +492,7 @@ public class ActivationRecordEntity implements Serializable {
     }
 
     /**
-     * Set mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_PBKDF2_500000).
+     * Set mode of server private key encryption (0 = NO_ENCRYPTION, 1 = AES_HMAC).
      * @param serverPrivateKeyEncryption Mode of server private key encryption.
      */
     public void setServerPrivateKeyEncryption(KeyEncryptionMode serverPrivateKeyEncryption) {

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
@@ -42,7 +42,7 @@ public class ServerPrivateKeyConverterTest {
     public void testEncryptionAndDecryptionSuccess() throws Exception {
         byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
         ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes,"test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-        String serverPrivateKeyActual = serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_PBKDF2_500000, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+        String serverPrivateKeyActual = serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         assertEquals(SERVER_PRIVATE_KEY_PLAIN, serverPrivateKeyActual);
     }
 
@@ -51,7 +51,7 @@ public class ServerPrivateKeyConverterTest {
         assertThrows(GenericServiceException.class, ()-> {
             byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
             ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-            serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_PBKDF2_500000, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test2", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+            serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test2", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         });
     }
 
@@ -60,7 +60,7 @@ public class ServerPrivateKeyConverterTest {
         assertThrows(GenericServiceException.class, ()-> {
             byte[] serverPrivateKeyBytes = BaseEncoding.base64().decode(SERVER_PRIVATE_KEY_PLAIN);
             ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, "test", "015286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-            serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_PBKDF2_500000, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test", "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+            serverPrivateKeyConverter.fromDBValue(KeyEncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.getServerPrivateKeyBase64(), "test", "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
         });
     }
 


### PR DESCRIPTION
Avoid using PBKF2 function when deriving secret key to improve performance, renamed related encryption mode