### PR TITLE
Fix #1764: Set release version to 1.6.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>io.getlime.security</groupId>
     <artifactId>powerauth-server-parent</artifactId>
-    <version>1.6.6</version>
+    <version>1.6.5</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/powerauth-admin/pom.xml
+++ b/powerauth-admin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.5</version>
     </parent>
 
     <dependencies>

--- a/powerauth-client-model/pom.xml
+++ b/powerauth-client-model/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.5</version>
     </parent>
 
     <dependencies>

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.5</version>
     </parent>
 
     <dependencies>

--- a/powerauth-rest-client-spring/pom.xml
+++ b/powerauth-rest-client-spring/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>io.getlime.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>1.6.6</version>
+        <version>1.6.5</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
We skipped version 1.6.5 in #1761 by accident.