### PR TITLE
Fix #1766: JavaDoc warning when referencing Lombok generated methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,11 +227,39 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok-maven-plugin</artifactId>
+                <version>1.18.20.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.projectlombok</groupId>
+                        <artifactId>lombok</artifactId>
+                        <version>${lombok.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <outputDirectory>${project.build.directory}/delombok</outputDirectory>
+                    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
+                    <addOutputDirectory>false</addOutputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>delombok</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
+                    <sourcepath>${project.build.directory}/delombok</sourcepath>
                     <failOnError>false</failOnError>
                 </configuration>
                 <executions>


### PR DESCRIPTION
The solution used in https://github.com/wultra/powerauth-push-server/pull/867 was applied. An alternative is to avoid using references to Lombok generated methods. Currently, the only problem seem so be `{@link CallbackUrlEntity#getId()}` in `CacheConfiguration` class.