### PR TITLE
Fix #766: Failing test testEncryptionAndDecryptionDifferentActivationFailServerPrivateKeyConverter

### DIFF
--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/ServerPrivateKeyConverterTest.java
@@ -95,8 +95,13 @@ class ServerPrivateKeyConverterTest {
         final ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, USER_ID, ACTIVATION_ID);
 
         assertEquals(EncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.encryptionMode());
-        assertThrows(GenericServiceException.class, () ->
-            serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
+
+        try {
+            String decryptedPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+            assertNotEquals(decryptedPrivateKeyBase64, SERVER_PRIVATE_KEY_PLAIN);
+        } catch (GenericServiceException ex) {
+            assertEquals("Generic cryptography error occurred.", ex.getMessage());
+        }
     }
 
 }


### PR DESCRIPTION
The test was failing randomly because sometimes the decryption worked, depending on generated IV value. I fixed the test so it handles the state when decryption succeeds, however the decrypted private key is different.