### PR TITLE
fix #1776: Assertion of allowed credentials ID is always false (backport)

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
@@ -277,7 +277,7 @@ public class PowerAuthAssertionProvider implements AssertionProvider {
         final Map<String, Object> additionalData = new LinkedHashMap<>();
         additionalData.put(ATTR_ACTIVATION_ID, authenticatorDetail.getActivationId());
         additionalData.put(ATTR_APPLICATION_ID, authenticatorDetail.getApplicationId());
-        additionalData.put(ATTR_CREDENTIAL_ID, authenticatorData.getAttestedCredentialData().getCredentialId());
+        additionalData.put(ATTR_CREDENTIAL_ID, authenticatorDetail.getCredentialId());
         additionalData.put(ATTR_AUTH_FACTOR, supportedSignatureType(authenticatorDetail, authenticatorData.getFlags().isUserVerified()));
         additionalData.put(ATTR_ORIGIN, clientDataJSON.getOrigin());
         additionalData.put(ATTR_TOP_ORIGIN, clientDataJSON.getTopOrigin());


### PR DESCRIPTION
(cherry picked from commit 12e24eab174ecab2050248962582908e31f15cd5)