### PR TITLE
Fix #1844: Migrate encryptors to generified interfaces for crypto4

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -44,11 +44,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
@@ -942,7 +942,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1005,10 +1005,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(protocolVersion, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -1117,7 +1117,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             // Persist activation report and notify listeners
             activationHistoryServiceBehavior.saveActivationAndLogChange(activation);
@@ -1188,7 +1188,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1278,10 +1278,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(protocolVersion, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -1354,7 +1354,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             // Generate encrypted response
             final CreateActivationResponse response = new CreateActivationResponse();
@@ -1873,7 +1873,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Prepare and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1940,10 +1940,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(version, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -2142,7 +2142,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             final RecoveryCodeActivationResponse response = new RecoveryCodeActivationResponse();
             response.setActivationId(activation.getActivationId());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
@@ -37,11 +37,12 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -169,14 +170,14 @@ public class EciesEncryptionBehavior {
             }
 
             // Build encryptor to derive shared info
-            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> encryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.APPLICATION_SCOPE_GENERIC,
                     new EncryptorParameters(request.getProtocolVersion(), applicationVersion.getApplicationKey(), null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
             // Calculate secrets for the external encryptor
-            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
-                    new EncryptedRequest(
+            final EncryptorSecrets encryptorSecrets = encryptor.deriveSecretsForExternalEncryptor(
+                    new EciesEncryptedRequest(
                             request.getTemporaryKeyId(),
                             request.getEphemeralPublicKey(),
                             null,
@@ -185,7 +186,7 @@ public class EciesEncryptionBehavior {
                             request.getTimestamp()
                     )
             );
-            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+            if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
                 // ECIES V3.0, V3.1, V3.2
                 final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
                 response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
@@ -284,14 +285,14 @@ public class EciesEncryptionBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Build encryptor to derive shared info
-            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> encryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_SCOPE_GENERIC,
                     new EncryptorParameters(protocolVersion, applicationVersion.getApplicationKey(), activation.getActivationId(), temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Calculate secrets for the external encryptor. The request object may not contain encrypted data and mac.
-            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
-                    new EncryptedRequest(
+            final EncryptorSecrets encryptorSecrets = encryptor.deriveSecretsForExternalEncryptor(
+                    new EciesEncryptedRequest(
                             temporaryKeyId,
                             ephemeralPublicKey,
                             null,
@@ -300,7 +301,7 @@ public class EciesEncryptionBehavior {
                             timestamp
                     )
             );
-            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+            if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
                 // ECIES V3.0, V3.1, V3.2
                 final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
                 response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -46,11 +46,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.RecoveryInfo;
@@ -291,7 +291,7 @@ public class RecoveryServiceBehavior {
             });
 
             // Build and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -347,10 +347,10 @@ public class RecoveryServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server decryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.CONFIRM_RECOVERY_CODE,
                     new EncryptorParameters(request.getProtocolVersion(), applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Decrypt request data
             final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
@@ -403,7 +403,7 @@ public class RecoveryServiceBehavior {
             final byte[] responseBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response using server encryptor
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseBytes);
 
             // Return response
             final ConfirmRecoveryCodeResponse response = new ConfirmRecoveryCodeResponse();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -48,11 +48,12 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -128,7 +129,7 @@ public class TokenBehavior {
             final SignatureType signatureType = request.getSignatureType();
             final String temporaryKeyId = request.getTemporaryKeyId();
 
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -136,7 +137,7 @@ public class TokenBehavior {
                     request.getNonce(),
                     request.getTimestamp()
             );
-            final EncryptedResponse encryptedResponse = createToken(activationId, applicationKey, encryptedRequest, signatureType.name(), version, temporaryKeyId, keyConvertor);
+            final EciesEncryptedResponse encryptedResponse = (EciesEncryptedResponse) createToken(activationId, applicationKey, encryptedRequest, signatureType.name(), version, temporaryKeyId, keyConvertor);
             final CreateTokenResponse response = new CreateTokenResponse();
             response.setEncryptedData(encryptedResponse.getEncryptedData());
             response.setMac(encryptedResponse.getMac());
@@ -293,7 +294,7 @@ public class TokenBehavior {
      * @return Encrypted Response with a newly created token information.
      * @throws GenericServiceException In case a business error occurs.
      */
-    private EncryptedResponse createToken(String activationId, String applicationKey, EncryptedRequest encryptedRequest,
+    private EncryptedResponse createToken(String activationId, String applicationKey, EciesEncryptedRequest encryptedRequest,
                                           String signatureType, String version, String temporaryKeyId, KeyConvertor keyConversion) throws GenericServiceException {
         try {
             // Lookup the activation
@@ -339,10 +340,10 @@ public class TokenBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.CREATE_TOKEN,
                     new EncryptorParameters(version, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data. Ignore result of decryption.
             serverEncryptor.decryptRequest(encryptedRequest);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -41,11 +41,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -105,7 +105,7 @@ public class UpgradeServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -173,10 +173,10 @@ public class UpgradeServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.UPGRADE,
                     new EncryptorParameters(protocolVersion, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
 
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data. Ignore result of decryption.
@@ -206,7 +206,7 @@ public class UpgradeServiceBehavior {
             // Encrypt response payload and return it
             final byte[] payloadBytes = objectMapper.writeValueAsBytes(payload);
 
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(payloadBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(payloadBytes);
 
             final StartUpgradeResponse response = new StartUpgradeResponse();
             response.setEncryptedData(encryptedResponse.getEncryptedData());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -45,11 +45,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -124,7 +124,7 @@ public class VaultUnlockServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -204,10 +204,10 @@ public class VaultUnlockServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.VAULT_UNLOCK,
                     new EncryptorParameters(signatureVersion, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Decrypt request to obtain vault unlock reason
             final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
@@ -263,7 +263,7 @@ public class VaultUnlockServiceBehavior {
             final byte[] reponsePayloadBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response payload
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(reponsePayloadBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(reponsePayloadBytes);
 
             // Return vault unlock response, set signature validity
             final VaultUnlockResponse response = new VaultUnlockResponse();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -13,10 +13,11 @@ import com.wultra.security.powerauth.app.server.service.behavior.tasks.OnlineSig
 import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Disabled;
@@ -87,15 +88,15 @@ public class VerifySignatureConcurrencyTest {
 
         final String version = "3.2";
         final String applicationKey = createApplicationVersionResponse.getApplicationKey();
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, createApplicationVersionResponse.getApplicationSecret())
+                new ClientEciesSecrets(masterPublicKey, createApplicationVersionResponse.getApplicationSecret())
         );
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new ObjectMapper().writeValue(baos, requestL2);
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(baos.toByteArray());
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(baos.toByteArray());
 
         // Create activation
         CreateActivationRequest createActivationRequest = new CreateActivationRequest();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
@@ -24,6 +24,8 @@ import com.wultra.security.powerauth.client.model.enumeration.*;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClient;
 import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
@@ -32,8 +34,8 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.BeforeAll;
@@ -842,7 +844,7 @@ class PowerAuthControllerTest {
     void testVerifyOfflineSignature() throws Exception {
         initActivation();
 
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
 
         final PrepareActivationRequest prepareActivationRequest = new PrepareActivationRequest();
         prepareActivationRequest.setActivationCode(config.getActivationCode());
@@ -897,7 +899,7 @@ class PowerAuthControllerTest {
     void testCreateActivation() throws Exception {
         final Date expireDate = Date.from(LocalDateTime.now().plusMinutes(5).atZone(ZoneId.systemDefault()).toInstant());
         final String activationName = "TEST_ACTIVATION";
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(activationName);
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(activationName);
 
         final CreateActivationRequest createActivationRequest = new CreateActivationRequest();
         createActivationRequest.setUserId(PowerAuthControllerTestConfig.USER_ID);
@@ -947,7 +949,7 @@ class PowerAuthControllerTest {
     void testUpdateActivationOtpAndCommit() throws Exception {
         initActivation();
         final String activationOtp = "12345678";
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
 
         final PrepareActivationRequest prepareActivationRequest = new PrepareActivationRequest();
         prepareActivationRequest.setActivationCode(config.getActivationCode());
@@ -1000,12 +1002,12 @@ class PowerAuthControllerTest {
     void testGetEciesDecryptor() throws Exception {
         final String requestData = "test_data";
 
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.APPLICATION_SCOPE_GENERIC,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ClientEncryptorSecrets(wrapPublicKeyString(), config.getApplicationSecret())
+                new ClientEciesSecrets(wrapPublicKeyString(), config.getApplicationSecret())
         );
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
         final GetEciesDecryptorRequest eciesDecryptorRequest = new GetEciesDecryptorRequest();
         eciesDecryptorRequest.setProtocolVersion(PowerAuthControllerTestConfig.PROTOCOL_VERSION);
         eciesDecryptorRequest.setActivationId(null);
@@ -1017,10 +1019,10 @@ class PowerAuthControllerTest {
 
         final byte[] secretKey = Base64.getDecoder().decode(decryptorResponse.getSecretKey());
         final byte[] sharedInfo2Base = Base64.getDecoder().decode(decryptorResponse.getSharedInfo2());
-        final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+        final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                 EncryptorId.APPLICATION_SCOPE_GENERIC,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ServerEncryptorSecrets(secretKey, sharedInfo2Base)
+                new ServerEciesSecrets(secretKey, sharedInfo2Base)
         );
         final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
         assertArrayEquals(requestData.getBytes(StandardCharsets.UTF_8), decryptedData);
@@ -1328,7 +1330,7 @@ class PowerAuthControllerTest {
      * @return The {@link EncryptedRequest} containing the encrypted request data.
      * @throws Exception if there is an error during the encryption or serialization process.
      */
-    private EncryptedRequest generateEncryptedRequestActivationLayer(final String activationName) throws Exception {
+    private EciesEncryptedRequest generateEncryptedRequestActivationLayer(final String activationName) throws Exception {
         final KeyPair keyPair = keyGenerator.generateKeyPair();
         final PublicKey publicKey = keyPair.getPublic();
         final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
@@ -1336,10 +1338,10 @@ class PowerAuthControllerTest {
         requestL2.setActivationName(activationName);
         requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
 
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ClientEncryptorSecrets(wrapPublicKeyString(), config.getApplicationSecret())
+                new ClientEciesSecrets(wrapPublicKeyString(), config.getApplicationSecret())
         );
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -27,11 +27,11 @@ import com.wultra.security.powerauth.app.server.service.model.request.Activation
 import com.wultra.security.powerauth.app.server.service.model.response.ActivationLayer2Response;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Test;
@@ -95,7 +95,7 @@ class ActivationServiceBehaviorTest {
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation
         final String activationCode = initActivationResponse.getActivationCode();
@@ -128,7 +128,7 @@ class ActivationServiceBehaviorTest {
 
         // Create request payload, omit device public key
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation with missing devicePublicKey
         final String activationCode = initActivationResponse.getActivationCode();
@@ -164,7 +164,7 @@ class ActivationServiceBehaviorTest {
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Create activation
         final String applicationKey = detailResponse.getVersions().get(0).getApplicationKey();
@@ -190,7 +190,7 @@ class ActivationServiceBehaviorTest {
 
         // Create request payload, omit device public key
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Create activation with missing devicePublicKey
         final String applicationKey = detailResponse.getVersions().get(0).getApplicationKey();
@@ -409,11 +409,11 @@ class ActivationServiceBehaviorTest {
         final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, applicationSecret));
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(activationLayer2Request));
+                new ClientEciesSecrets(masterPublicKey, applicationSecret));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(activationLayer2Request));
 
         // Create activation
         final CreateActivationRequest request = new CreateActivationRequest();
@@ -475,8 +475,8 @@ class ActivationServiceBehaviorTest {
         activationServiceBehavior.commitActivation(commitActivationRequest);
     }
 
-    private ActivationLayer2Response decryptPayload(CreateActivationResponse response, ClientEncryptor clientEncryptor) throws Exception {
-        final EncryptedResponse encryptedResponse = new EncryptedResponse(response.getEncryptedData(), response.getMac(), response.getNonce(), response.getTimestamp());
+    private ActivationLayer2Response decryptPayload(CreateActivationResponse response, ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor) throws Exception {
+        final EciesEncryptedResponse encryptedResponse = new EciesEncryptedResponse(response.getEncryptedData(), response.getMac(), response.getNonce(), response.getTimestamp());
         final byte[] decryptedActivationResponsePayload = clientEncryptor.decryptResponse(encryptedResponse);
         return objectMapper.readValue(decryptedActivationResponsePayload, ActivationLayer2Response.class);
     }
@@ -490,7 +490,7 @@ class ActivationServiceBehaviorTest {
         return lookupRecoveryCodesResponse.getRecoveryCodes().get(0).getStatus();
     }
 
-    private EncryptedRequest buildPrepareActivationPayload(
+    private EciesEncryptedRequest buildPrepareActivationPayload(
             final ActivationLayer2Request requestL2,
             final GetApplicationDetailResponse applicationDetail) throws Exception {
 
@@ -500,15 +500,15 @@ class ActivationServiceBehaviorTest {
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
         // Encrypt payload
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, applicationSecret));
+                new ClientEciesSecrets(masterPublicKey, applicationSecret));
         return clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(requestL2));
     }
 
     private RecoveryCodeActivationRequest buildRecoveryCodeActivationRequest(String recoveryCode, String puk, ActivationLayer2Request payload, GetApplicationDetailResponse detailResponse) throws Exception {
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(payload, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(payload, detailResponse);
 
         final RecoveryCodeActivationRequest recoveryCodeActivationRequest = new RecoveryCodeActivationRequest();
         recoveryCodeActivationRequest.setRecoveryCode(recoveryCode);
@@ -554,7 +554,7 @@ class ActivationServiceBehaviorTest {
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
         requestL2.setActivationOtp(otpToUse);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, applicationDetail);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, applicationDetail);
 
         // Prepare activation
         final String activationCode = initActivationResponse.getActivationCode();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
@@ -36,11 +36,12 @@ import com.wultra.security.powerauth.app.server.service.model.request.Activation
 import com.wultra.security.powerauth.app.server.service.util.SdkConfigurationSerializer;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -219,11 +220,11 @@ class TemporaryKeyBehaviourTest {
         final String applicationKey = applicationVersion.getApplicationKey();
         final String applicationSecret = applicationVersion.getApplicationSecret();
 
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters("3.3", applicationKey, null, temporaryKeyId),
-                new ClientEncryptorSecrets(temporaryPublicKey, applicationSecret));
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(OBJECT_MAPPER.writeValueAsBytes(activationLayer2Request));
+                new ClientEciesSecrets(temporaryPublicKey, applicationSecret));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(OBJECT_MAPPER.writeValueAsBytes(activationLayer2Request));
 
         final CreateActivationRequest activationRequest = new CreateActivationRequest();
         activationRequest.setUserId(UUID.randomUUID().toString());


### PR DESCRIPTION
Migration to generified interfaces and classes introduced in crypto4 for existing end-to-end encryption.