### PR TITLE
Fix #1846: Migrate from deprecated methods for crypto4

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -49,6 +49,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
@@ -498,7 +499,7 @@ public class ActivationServiceBehavior {
                     final byte[] masterPrivateKeyBytes = Base64.getDecoder().decode(masterPrivateKeyBase64);
                     final byte[] activationSignature = powerAuthServerActivation.generateActivationSignature(
                             activation.getActivationCode(),
-                            keyConvertor.convertBytesToPrivateKey(masterPrivateKeyBytes)
+                            keyConvertor.convertBytesToPrivateKey(EcCurve.P256, masterPrivateKeyBytes)
                     );
 
                     // return the data
@@ -558,9 +559,9 @@ public class ActivationServiceBehavior {
                     // the real encryptedStatusBlob value.
                     if (devicePublicKeyBase64 != null) {
 
-                        final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(serverPrivateKeyBase64));
-                        final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(devicePublicKeyBase64));
-                        final PublicKey serverPublicKey = keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(serverPublicKeyBase64));
+                        final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(serverPrivateKeyBase64));
+                        final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(devicePublicKeyBase64));
+                        final PublicKey serverPublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(serverPublicKeyBase64));
 
                         final SecretKey masterSecretKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(serverPrivateKey, devicePublicKey);
                         final SecretKey transportKey = powerAuthServerKeyFactory.generateServerTransportKey(masterSecretKey);
@@ -778,7 +779,7 @@ public class ActivationServiceBehavior {
                 throw ex;
             }
             final byte[] masterPrivateKeyBytes = Base64.getDecoder().decode(masterKeyPair.getMasterKeyPrivateBase64());
-            final PrivateKey masterPrivateKey = keyConvertor.convertBytesToPrivateKey(masterPrivateKeyBytes);
+            final PrivateKey masterPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, masterPrivateKeyBytes);
 
             // Generate new activation data, generate a unique activation ID
             String activationId = null;
@@ -823,7 +824,7 @@ public class ActivationServiceBehavior {
             // Generate server key pair
             final KeyPair serverKeyPair = powerAuthServerActivation.generateServerKeyPair();
             final byte[] serverKeyPrivateBytes = keyConvertor.convertPrivateKeyToBytes(serverKeyPair.getPrivate());
-            final byte[] serverKeyPublicBytes = keyConvertor.convertPublicKeyToBytes(serverKeyPair.getPublic());
+            final byte[] serverKeyPublicBytes = keyConvertor.convertPublicKeyToBytes(EcCurve.P256, serverKeyPair.getPublic());
 
             // Store the new activation
             final ActivationRecordEntity activation = new ActivationRecordEntity();
@@ -1001,7 +1002,7 @@ public class ActivationServiceBehavior {
                 }
 
                 final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
-                privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
+                privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterPrivateKeyBase64));
             }
 
             // Get server encryptor
@@ -1066,7 +1067,7 @@ public class ActivationServiceBehavior {
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(retrievedDevicePublicKey);
             PublicKey devicePublicKey = null;
             try {
-                devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+                devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             } catch (InvalidKeySpecException ex) {
                 logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
                 logger.debug("Invalid public key, activation ID: {}", activation.getActivationId(), ex);
@@ -1081,7 +1082,7 @@ public class ActivationServiceBehavior {
             // Update the activation record
             activation.setActivationStatus(activationStatus);
             // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
-            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, devicePublicKey)));
             activation.setActivationName(layer2Request.getActivationName());
             activation.setExternalId(layer2Request.getExternalId());
             activation.setExtras(layer2Request.getExtras());
@@ -1274,7 +1275,7 @@ public class ActivationServiceBehavior {
                     throw localizationProvider.buildRollbackingExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
                 }
                 final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
-                privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
+                privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterPrivateKeyBase64));
             }
 
             // Get server encryptor
@@ -1309,7 +1310,7 @@ public class ActivationServiceBehavior {
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(retrievedDevicePublicKey);
             PublicKey devicePublicKey;
             try {
-                devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+                devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             } catch (InvalidKeySpecException ex) {
                 logger.warn("Device public key is invalid, activation ID: {}", activationId);
                 // Device public key is invalid, rollback this transaction
@@ -1324,7 +1325,7 @@ public class ActivationServiceBehavior {
             // Update and persist the activation record
             activation.setActivationStatus(ActivationStatus.PENDING_COMMIT);
             // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
-            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, devicePublicKey)));
             activation.setActivationName(layer2Request.getActivationName());
             activation.setExternalId(layer2Request.getExternalId());
             activation.setExtras(layer2Request.getExtras());
@@ -1936,7 +1937,7 @@ public class ActivationServiceBehavior {
                     throw localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR);
                 }
                 final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
-                privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
+                privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterPrivateKeyBase64));
             }
 
             // Get server encryptor
@@ -2090,7 +2091,7 @@ public class ActivationServiceBehavior {
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(retrievedDevicePublicKey);
             PublicKey devicePublicKey;
             try {
-                devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+                devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             } catch (InvalidKeySpecException ex) {
                 logger.warn("Device public key is invalid, activation ID: {}", activationId);
                 // Device public key is invalid, rollback this transaction
@@ -2105,7 +2106,7 @@ public class ActivationServiceBehavior {
             // Update and persist the activation record, activation is automatically committed in the next step in RESTful integration.
             activation.setActivationStatus(ActivationStatus.PENDING_COMMIT);
             // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
-            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, devicePublicKey)));
             activation.setActivationName(layer2Request.getActivationName());
             activation.setExternalId(layer2Request.getExternalId());
             activation.setExtras(layer2Request.getExtras());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -44,11 +44,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
@@ -942,7 +942,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1005,10 +1005,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(protocolVersion, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -1117,7 +1117,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             // Persist activation report and notify listeners
             activationHistoryServiceBehavior.saveActivationAndLogChange(activation);
@@ -1188,7 +1188,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1278,10 +1278,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(protocolVersion, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -1354,7 +1354,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             // Generate encrypted response
             final CreateActivationResponse response = new CreateActivationResponse();
@@ -1873,7 +1873,7 @@ public class ActivationServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Prepare and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -1940,10 +1940,10 @@ public class ActivationServiceBehavior {
             }
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_LAYER_2,
                     new EncryptorParameters(version, applicationKey, null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
 
             // Decrypt activation data
@@ -2142,7 +2142,7 @@ public class ActivationServiceBehavior {
             final byte[] responseData = objectMapper.writeValueAsBytes(layer2Response);
 
             // Encrypt response data
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseData);
 
             final RecoveryCodeActivationResponse response = new RecoveryCodeActivationResponse();
             response.setActivationId(activation.getActivationId());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ApplicationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ApplicationServiceBehavior.java
@@ -32,6 +32,7 @@ import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvide
 import com.wultra.security.powerauth.app.server.service.model.SdkConfiguration;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.util.SdkConfigurationSerializer;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -207,7 +208,7 @@ public class ApplicationServiceBehavior {
             application = applicationRepository.save(application);
 
             final KeyGenerator keyGen = new KeyGenerator();
-            final KeyPair kp = keyGen.generateKeyPair();
+            final KeyPair kp = keyGen.generateKeyPair(EcCurve.P256);
             final PrivateKey privateKey = kp.getPrivate();
             final PublicKey publicKey = kp.getPublic();
 
@@ -219,7 +220,7 @@ public class ApplicationServiceBehavior {
             final MasterKeyPairEntity keyPair = new MasterKeyPairEntity();
             keyPair.setApplication(application);
             keyPair.setMasterKeyPrivateBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPrivateKeyToBytes(privateKey)));
-            keyPair.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(publicKey)));
+            keyPair.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, publicKey)));
             keyPair.setTimestampCreated(new Date());
             keyPair.setName(applicationId + " Default Keypair");
             masterKeyPairRepository.save(keyPair);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/AsymmetricSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/AsymmetricSignatureServiceBehavior.java
@@ -33,6 +33,7 @@ import com.wultra.security.powerauth.app.server.service.exceptions.GenericServic
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -106,10 +107,10 @@ public class AsymmetricSignatureServiceBehavior {
             final EncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();
             final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
-            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(serverPrivateKeyBase64));
+            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(serverPrivateKeyBase64));
 
             // Sign data with the private key
-            final byte[] signature = signatureUtils.computeECDSASignature(Base64.getDecoder().decode(data), serverPrivateKey);
+            final byte[] signature = signatureUtils.computeECDSASignature(EcCurve.P256, Base64.getDecoder().decode(data), serverPrivateKey);
             final String signatureBase64 = Base64.getEncoder().encodeToString(signature);
 
             final SignECDSAResponse response = new SignECDSAResponse();
@@ -166,13 +167,13 @@ public class AsymmetricSignatureServiceBehavior {
             activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
 
             final byte[] devicePublicKeyData = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyData);
+            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyData);
 
             final byte[] dataBytes = Base64.getDecoder().decode(data);
             final byte[] signatureBytes = Base64.getDecoder().decode(signature);
             final byte[] signatureBytesDER = signatureDER(signatureFormat, signatureBytes);
 
-            final boolean matches = signatureUtils.validateECDSASignature(dataBytes, signatureBytesDER, devicePublicKey);
+            final boolean matches = signatureUtils.validateECDSASignature(EcCurve.P256, dataBytes, signatureBytesDER, devicePublicKey);
 
             return VerifyECDSASignatureResponse.builder()
                     .signatureValid(matches)
@@ -209,7 +210,7 @@ public class AsymmetricSignatureServiceBehavior {
      * @return Signature value in DER format.
      * @throws JOSEException In case JOSE conversion fails.
      */
-    private byte[] signatureDER(ECDSASignatureFormat signatureFormat, byte[] signature) throws JOSEException {;
+    private byte[] signatureDER(ECDSASignatureFormat signatureFormat, byte[] signature) throws JOSEException {
         return (signatureFormat == ECDSASignatureFormat.JOSE) ? ECDSA.transcodeSignatureToDER(signature) : signature;
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
@@ -43,6 +43,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -166,7 +167,7 @@ public class EciesEncryptionBehavior {
                 }
 
                 final String masterPrivateKeyBase64 = masterKeyPairEntity.getMasterKeyPrivateBase64();
-                privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterPrivateKeyBase64));
+                privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterPrivateKeyBase64));
             }
 
             // Build encryptor to derive shared info
@@ -273,11 +274,11 @@ public class EciesEncryptionBehavior {
             final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
+            final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConversion.convertSharedSecretKeyToBytes(transportKey);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/EciesEncryptionBehavior.java
@@ -37,11 +37,12 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -169,14 +170,14 @@ public class EciesEncryptionBehavior {
             }
 
             // Build encryptor to derive shared info
-            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> encryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.APPLICATION_SCOPE_GENERIC,
                     new EncryptorParameters(request.getProtocolVersion(), applicationVersion.getApplicationKey(), null, temporaryKeyId),
-                    new ServerEncryptorSecrets(privateKey, applicationVersion.getApplicationSecret())
+                    new ServerEciesSecrets(privateKey, applicationVersion.getApplicationSecret())
             );
             // Calculate secrets for the external encryptor
-            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
-                    new EncryptedRequest(
+            final EncryptorSecrets encryptorSecrets = encryptor.deriveSecretsForExternalEncryptor(
+                    new EciesEncryptedRequest(
                             request.getTemporaryKeyId(),
                             request.getEphemeralPublicKey(),
                             null,
@@ -185,7 +186,7 @@ public class EciesEncryptionBehavior {
                             request.getTimestamp()
                     )
             );
-            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+            if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
                 // ECIES V3.0, V3.1, V3.2
                 final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
                 response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
@@ -284,14 +285,14 @@ public class EciesEncryptionBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Build encryptor to derive shared info
-            final ServerEncryptor encryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> encryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.ACTIVATION_SCOPE_GENERIC,
                     new EncryptorParameters(protocolVersion, applicationVersion.getApplicationKey(), activation.getActivationId(), temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Calculate secrets for the external encryptor. The request object may not contain encrypted data and mac.
-            final EncryptorSecrets encryptorSecrets = encryptor.calculateSecretsForExternalEncryptor(
-                    new EncryptedRequest(
+            final EncryptorSecrets encryptorSecrets = encryptor.deriveSecretsForExternalEncryptor(
+                    new EciesEncryptedRequest(
                             temporaryKeyId,
                             ephemeralPublicKey,
                             null,
@@ -300,7 +301,7 @@ public class EciesEncryptionBehavior {
                             timestamp
                     )
             );
-            if (encryptorSecrets instanceof ServerEncryptorSecrets encryptorSecretsV3) {
+            if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
                 // ECIES V3.0, V3.1, V3.2
                 final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
                 response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/OfflineSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/OfflineSignatureServiceBehavior.java
@@ -44,6 +44,7 @@ import com.wultra.security.powerauth.app.server.service.model.signature.Signatur
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.crypto.lib.config.DecimalSignatureConfiguration;
 import com.wultra.security.powerauth.crypto.lib.config.SignatureConfiguration;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -172,14 +173,14 @@ public class OfflineSignatureServiceBehavior {
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
 
             // Decode the private key - KEY_SERVER_PRIVATE is used for personalized offline signatures
-            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(serverPrivateKeyBase64));
+            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(serverPrivateKeyBase64));
 
             // Compute ECDSA signature of '{DATA}\n{NONCE}\n{KEY_SERVER_PRIVATE_INDICATOR}'
             // {DATA} consist of data from request plus optional generated proximity TOTP value
             final SignatureUtils signatureUtils = new SignatureUtils();
             final String dataPlusNonce = fetchDataAndTotp(offlineSignatureParameter, powerAuthServiceConfiguration.getProximityCheckOtpLength()) + "\n" + nonce;
             final byte[] signatureBase = (dataPlusNonce + "\n" + KEY_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            final byte[] ecdsaSignatureBytes = signatureUtils.computeECDSASignature(signatureBase, privateKey);
+            final byte[] ecdsaSignatureBytes = signatureUtils.computeECDSASignature(EcCurve.P256, signatureBase, privateKey);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 
             // Construct complete offline data as '{DATA}\n{NONCE}\n{KEY_SERVER_PRIVATE_INDICATOR}{ECDSA_SIGNATURE}'
@@ -265,12 +266,12 @@ public class OfflineSignatureServiceBehavior {
 
             // Prepare the private key - KEY_MASTER_SERVER_PRIVATE is used for non-personalized offline signatures
             final String keyPrivateBase64 = masterKeyPair.getMasterKeyPrivateBase64();
-            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(keyPrivateBase64));
+            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(keyPrivateBase64));
 
             // Compute ECDSA signature of '{DATA}\n{NONCE}\n{KEY_MASTER_SERVER_PRIVATE_INDICATOR}'
             final SignatureUtils signatureUtils = new SignatureUtils();
             final byte[] signatureBase = (data + "\n" + nonce + "\n" + KEY_MASTER_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            final byte[] ecdsaSignatureBytes = signatureUtils.computeECDSASignature(signatureBase, privateKey);
+            final byte[] ecdsaSignatureBytes = signatureUtils.computeECDSASignature(EcCurve.P256, signatureBase, privateKey);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 
             // Construct complete offline data as '{DATA}\n{NONCE}\n{KEY_MASTER_SERVER_PRIVATE_INDICATOR}{ECDSA_SIGNATURE}'

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -51,6 +51,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.RecoveryInfo;
@@ -171,9 +172,9 @@ public class RecoveryServiceBehavior {
             final RecoveryPrivateKey recoveryPrivateKeyEncrypted = new RecoveryPrivateKey(encryptionMode, recoveryPrivateKeyBase64);
             String decryptedPrivateKey = recoveryPrivateKeyConverter.fromDBValue(recoveryPrivateKeyEncrypted, applicationEntity.getRid());
             final byte[] privateKeyBytes = Base64.getDecoder().decode(decryptedPrivateKey);
-            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(privateKeyBytes);
+            final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, privateKeyBytes);
             final byte[] publicKeyBytes = Base64.getDecoder().decode(recoveryConfigEntity.getRemotePostcardPublicKeyBase64());
-            final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(publicKeyBytes);
+            final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, publicKeyBytes);
 
             final SecretKey secretKey = keyGenerator.computeSharedKey(privateKey, publicKey, true);
             String recoveryCode = null;
@@ -323,13 +324,13 @@ public class RecoveryServiceBehavior {
             final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
 
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConvertor.convertSharedSecretKeyToBytes(transportKey);
 
@@ -703,11 +704,11 @@ public class RecoveryServiceBehavior {
             if (request.isRecoveryPostcardEnabled() && recoveryConfigEntity.getRecoveryPostcardPrivateKeyBase64() == null) {
                 // Private key does not exist, generate key pair and persist it
                 KeyGenerator keyGen = new KeyGenerator();
-                KeyPair kp = keyGen.generateKeyPair();
+                KeyPair kp = keyGen.generateKeyPair(EcCurve.P256);
                 PrivateKey privateKey = kp.getPrivate();
                 PublicKey publicKey = kp.getPublic();
                 byte[] privateKeyBytes = keyConvertor.convertPrivateKeyToBytes(privateKey);
-                byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
+                byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(EcCurve.P256, publicKey);
                 String publicKeyBase64 = Base64.getEncoder().encodeToString(publicKeyBytes);
 
                 RecoveryPrivateKey recoveryPrivateKey = recoveryPrivateKeyConverter.toDBValue(privateKeyBytes, applicationEntity.getRid());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/RecoveryServiceBehavior.java
@@ -46,11 +46,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.IdentifierGenerator;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.RecoveryInfo;
@@ -291,7 +291,7 @@ public class RecoveryServiceBehavior {
             });
 
             // Build and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -347,10 +347,10 @@ public class RecoveryServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server decryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.CONFIRM_RECOVERY_CODE,
                     new EncryptorParameters(request.getProtocolVersion(), applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Decrypt request data
             final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
@@ -403,7 +403,7 @@ public class RecoveryServiceBehavior {
             final byte[] responseBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response using server encryptor
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(responseBytes);
 
             // Return response
             final ConfirmRecoveryCodeResponse response = new ConfirmRecoveryCodeResponse();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/SignatureSharedServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/SignatureSharedServiceBehavior.java
@@ -35,6 +35,7 @@ import com.wultra.security.powerauth.app.server.service.model.signature.OfflineS
 import com.wultra.security.powerauth.app.server.service.model.signature.OnlineSignatureRequest;
 import com.wultra.security.powerauth.app.server.service.model.signature.SignatureData;
 import com.wultra.security.powerauth.app.server.service.model.signature.SignatureResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.enums.PowerAuthSignatureTypes;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
@@ -250,8 +251,8 @@ public class SignatureSharedServiceBehavior {
         // Decode the keys to byte[]
         final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
         final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-        final PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(serverPrivateKeyBytes);
-        final PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(devicePublicKeyBytes);
+        final PrivateKey serverPrivateKey = keyConversionUtilities.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
+        final PublicKey devicePublicKey = keyConversionUtilities.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
 
         // Compute the master secret key
         final SecretKey masterSecretKey = powerAuthServerKeyFactory.generateServerMasterSecretKey(serverPrivateKey, devicePublicKey);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehavior.java
@@ -48,6 +48,7 @@ import com.wultra.security.powerauth.app.server.service.exceptions.GenericServic
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.util.jwt.MACVerifier16B;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -207,7 +208,7 @@ public class TemporaryKeyBehavior {
         final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
         final String serverPrivateKeyBase64 = temporaryPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, temporaryKey.getId(), temporaryKey.getAppKey(), temporaryKey.getActivationId());
         final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-        return keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+        return keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
     }
 
     /**
@@ -263,8 +264,8 @@ public class TemporaryKeyBehavior {
 
                 final MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersionEntity.getApplication().getId());
 
-                final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPrivateBase64()));
-                final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPublicBase64()));
+                final PrivateKey privateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPrivateBase64()));
+                final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPublicBase64()));
 
                 final byte[] secretKeyBytes = Base64.getDecoder().decode(applicationSecret);
 
@@ -293,13 +294,13 @@ public class TemporaryKeyBehavior {
                 final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(encryptionMode, serverPrivateKeyBase64);
                 final String decryptedServerPrivateKey = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
                 final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(decryptedServerPrivateKey);
-                final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+                final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
                 final byte[] serverPublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-                final PublicKey serverPublicKey = keyConvertor.convertBytesToPublicKey(serverPublicKeyBytes);
+                final PublicKey serverPublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, serverPublicKeyBytes);
 
                 final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-                final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+                final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
                 final SecretKey transportKey = keyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
 
                 final byte[] applicationSecretKeyBytes = Base64.getDecoder().decode(applicationSecret);
@@ -320,7 +321,7 @@ public class TemporaryKeyBehavior {
     private TemporaryPublicKeyResponseClaims generateAndStoreNewKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp) throws CryptoProviderException, GenericServiceException {
 
         // Generate a temporary key pair
-        final KeyPair temporaryKeyPair = keyGenerator.generateKeyPair();
+        final KeyPair temporaryKeyPair = keyGenerator.generateKeyPair(EcCurve.P256);
 
         // Prepare the parameters key pair
         final String keyId = UUID.randomUUID().toString();
@@ -328,7 +329,7 @@ public class TemporaryKeyBehavior {
         final String activationId = requestClaims.getActivationId();
         final String challenge = requestClaims.getChallenge();
         final byte[] privateKeyBytes = keyConvertor.convertPrivateKeyToBytes(temporaryKeyPair.getPrivate());
-        final String temporaryPublicKeyBase64 = Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(temporaryKeyPair.getPublic()));
+        final String temporaryPublicKeyBase64 = Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, temporaryKeyPair.getPublic()));
         final Date expirationDate = Date.from(currentTimestamp.toInstant().plusMillis(powerAuthServiceConfiguration.getTemporaryKeyValidity().toMillis()));
 
         // Prepare encrypted temporary private key, if encryption is enabled

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -54,6 +54,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -327,12 +328,12 @@ public class TokenBehavior {
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
 
             // KEY_SERVER_PRIVATE is used in Crypto version 3.0 for ECIES, note that in version 2.0 KEY_SERVER_MASTER_PRIVATE is used
-            final PrivateKey serverPrivateKey = keyConversion.convertBytesToPrivateKey(serverPrivateKeyBytes);
+            final PrivateKey serverPrivateKey = keyConversion.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(devicePublicKeyBytes);
+            final PublicKey devicePublicKey = keyConversion.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConversion.convertSharedSecretKeyToBytes(transportKey);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -48,11 +48,12 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -128,7 +129,7 @@ public class TokenBehavior {
             final SignatureType signatureType = request.getSignatureType();
             final String temporaryKeyId = request.getTemporaryKeyId();
 
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -136,7 +137,7 @@ public class TokenBehavior {
                     request.getNonce(),
                     request.getTimestamp()
             );
-            final EncryptedResponse encryptedResponse = createToken(activationId, applicationKey, encryptedRequest, signatureType.name(), version, temporaryKeyId, keyConvertor);
+            final EciesEncryptedResponse encryptedResponse = (EciesEncryptedResponse) createToken(activationId, applicationKey, encryptedRequest, signatureType.name(), version, temporaryKeyId, keyConvertor);
             final CreateTokenResponse response = new CreateTokenResponse();
             response.setEncryptedData(encryptedResponse.getEncryptedData());
             response.setMac(encryptedResponse.getMac());
@@ -293,7 +294,7 @@ public class TokenBehavior {
      * @return Encrypted Response with a newly created token information.
      * @throws GenericServiceException In case a business error occurs.
      */
-    private EncryptedResponse createToken(String activationId, String applicationKey, EncryptedRequest encryptedRequest,
+    private EncryptedResponse createToken(String activationId, String applicationKey, EciesEncryptedRequest encryptedRequest,
                                           String signatureType, String version, String temporaryKeyId, KeyConvertor keyConversion) throws GenericServiceException {
         try {
             // Lookup the activation
@@ -339,10 +340,10 @@ public class TokenBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.CREATE_TOKEN,
                     new EncryptorParameters(version, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data. Ignore result of decryption.
             serverEncryptor.decryptRequest(encryptedRequest);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -46,6 +46,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -161,11 +162,11 @@ public class UpgradeServiceBehavior {
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
 
             // KEY_SERVER_PRIVATE is used in Crypto version 3.0 for ECIES, note that in version 2.0 KEY_SERVER_MASTER_PRIVATE is used
-            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
             // Get ECIES parameters
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConvertor.convertSharedSecretKeyToBytes(transportKey);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -41,11 +41,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
@@ -105,7 +105,7 @@ public class UpgradeServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build and validate encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -173,10 +173,10 @@ public class UpgradeServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.UPGRADE,
                     new EncryptorParameters(protocolVersion, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
 
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data. Ignore result of decryption.
@@ -206,7 +206,7 @@ public class UpgradeServiceBehavior {
             // Encrypt response payload and return it
             final byte[] payloadBytes = objectMapper.writeValueAsBytes(payload);
 
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(payloadBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(payloadBytes);
 
             final StartUpgradeResponse response = new StartUpgradeResponse();
             response.setEncryptedData(encryptedResponse.getEncryptedData());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -45,11 +45,11 @@ import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificatio
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -124,7 +124,7 @@ public class VaultUnlockServiceBehavior {
             final String temporaryKeyId = request.getTemporaryKeyId();
 
             // Build encrypted request
-            final EncryptedRequest encryptedRequest = new EncryptedRequest(
+            final EciesEncryptedRequest encryptedRequest = new EciesEncryptedRequest(
                     request.getTemporaryKeyId(),
                     request.getEphemeralPublicKey(),
                     request.getEncryptedData(),
@@ -204,10 +204,10 @@ public class VaultUnlockServiceBehavior {
             final PrivateKey encryptorPrivateKey = (temporaryKeyId != null) ? temporaryKeyBehavior.temporaryPrivateKey(temporaryKeyId, applicationKey, activationId) : serverPrivateKey;
 
             // Get server encryptor
-            final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+            final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                     EncryptorId.VAULT_UNLOCK,
                     new EncryptorParameters(signatureVersion, applicationKey, activationId, temporaryKeyId),
-                    new ServerEncryptorSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
+                    new ServerEciesSecrets(encryptorPrivateKey, applicationVersion.getApplicationSecret(), transportKeyBytes)
             );
             // Decrypt request to obtain vault unlock reason
             final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
@@ -263,7 +263,7 @@ public class VaultUnlockServiceBehavior {
             final byte[] reponsePayloadBytes = objectMapper.writeValueAsBytes(responsePayload);
 
             // Encrypt response payload
-            final EncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(reponsePayloadBytes);
+            final EciesEncryptedResponse encryptedResponse = serverEncryptor.encryptResponse(reponsePayloadBytes);
 
             // Return vault unlock response, set signature validity
             final VaultUnlockResponse response = new VaultUnlockResponse();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -50,6 +50,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -192,11 +193,11 @@ public class VaultUnlockServiceBehavior {
             final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
             final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activationId);
             final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(serverPrivateKeyBytes);
+            final PrivateKey serverPrivateKey = keyConvertor.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
             // Get application secret and transport key used in sharedInfo2 parameter of ECIES
             final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+            final PublicKey devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             final SecretKey transportKey = powerAuthServerKeyFactory.deriveTransportKey(serverPrivateKey, devicePublicKey);
             final byte[] transportKeyBytes = keyConvertor.convertSharedSecretKeyToBytes(transportKey);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
@@ -29,6 +29,7 @@ import com.wultra.security.powerauth.client.model.entity.Activation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationProtocol;
 import com.wultra.security.powerauth.client.model.request.GetActivationListForUserRequest;
 import com.wultra.security.powerauth.client.model.response.GetActivationListForUserResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
 import com.wultra.security.powerauth.app.server.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
@@ -192,7 +193,7 @@ public class PowerAuthAuthenticatorProvider implements AuthenticatorProvider {
             final byte[] devicePublicKeyBytes = authenticatorDetail.getPublicKeyBytes();
             PublicKey devicePublicKey = null;
             try {
-                devicePublicKey = keyConvertor.convertBytesToPublicKey(devicePublicKeyBytes);
+                devicePublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
             } catch (InvalidKeySpecException ex) {
                 logger.warn("Invalid public key, activation ID: {}, {}", activation.getActivationId(), ex.getMessage());
                 logger.debug("Invalid public key, activation ID: {}", activation.getActivationId(), ex);
@@ -207,7 +208,7 @@ public class PowerAuthAuthenticatorProvider implements AuthenticatorProvider {
             // Update the activation record
             activation.setActivationStatus(com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus.ACTIVE);
             // The device public key is converted back to bytes and base64 encoded so that the key is saved in normalized form
-            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(devicePublicKey)));
+            activation.setDevicePublicKeyBase64(Base64.getEncoder().encodeToString(keyConvertor.convertPublicKeyToBytes(EcCurve.P256, devicePublicKey)));
             activation.setActivationName(authenticatorDetail.getActivationName());
             activation.setExternalId(authenticatorDetail.getCredentialId());
             activation.setExtras(objectMapper.writeValueAsString(authenticatorDetail.getExtras()));

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthCryptographyService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthCryptographyService.java
@@ -21,6 +21,7 @@ package com.wultra.security.powerauth.app.server.service.fido2;
 import com.wultra.powerauth.fido2.rest.model.entity.*;
 import com.wultra.powerauth.fido2.service.model.Fido2DefaultAuthenticators;
 import com.wultra.powerauth.fido2.service.provider.CryptographyService;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorDetail;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.repository.ActivationRepository;
@@ -82,7 +83,7 @@ public class PowerAuthCryptographyService implements CryptographyService {
             }
         }
         final byte[] publicKeyBytes = authenticatorDetail.getPublicKeyBytes();
-        final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(publicKeyBytes);
+        final PublicKey publicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, publicKeyBytes);
         return verifySignature(clientDataJSON, authData, dataSuffix, signature, publicKey);
     }
 
@@ -93,14 +94,14 @@ public class PowerAuthCryptographyService implements CryptographyService {
             return false;
         }
         final ECPoint point = pointOptional.get();
-        final PublicKey publicKey = keyConvertor.convertPointBytesToPublicKey(point.getX(), point.getY());
+        final PublicKey publicKey = keyConvertor.convertPointBytesToPublicKey(EcCurve.P256, point.getX(), point.getY());
         return verifySignature(clientDataJSON, attestationObject.getAuthData(), null, signature, publicKey);
     }
 
     public byte[] publicKeyToBytes(PublicKeyObject publicKey) throws GenericCryptoException, InvalidKeySpecException, CryptoProviderException {
         final ECPoint point = publicKey.getPoint();
-        final PublicKey publicKeyConverted = keyConvertor.convertPointBytesToPublicKey(point.getX(), point.getY());
-        return keyConvertor.convertPublicKeyToBytes(publicKeyConverted);
+        final PublicKey publicKeyConverted = keyConvertor.convertPointBytesToPublicKey(EcCurve.P256, point.getX(), point.getY());
+        return keyConvertor.convertPublicKeyToBytes(EcCurve.P256, publicKeyConverted);
     }
 
     // private methods
@@ -114,7 +115,7 @@ public class PowerAuthCryptographyService implements CryptographyService {
             signableData = ByteUtils.concat(authData.getEncoded(), Hash.sha256(clientDataJSON.getEncoded()));
         }
         final SignatureUtils signatureUtils = new SignatureUtils();
-        return signatureUtils.validateECDSASignature(signableData, signature, publicKey);
+        return signatureUtils.validateECDSASignature(EcCurve.P256, signableData, signature, publicKey);
     }
 
     private boolean checkAndPersistCounter(String applicationId, String credentialId, int signCount) {

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -18,6 +18,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Disabled;
@@ -68,9 +69,9 @@ public class VerifySignatureConcurrencyTest {
 
         // Generate public key for non-existent client device
         KeyGenerator keyGenerator = new KeyGenerator();
-        KeyPair keyPair = keyGenerator.generateKeyPair();
+        KeyPair keyPair = keyGenerator.generateKeyPair(EcCurve.P256);
         PublicKey publicKey = keyPair.getPublic();
-        byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
+        byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(EcCurve.P256, publicKey);
 
         // Generate expiration time
         Calendar expiration = Calendar.getInstance();
@@ -84,7 +85,7 @@ public class VerifySignatureConcurrencyTest {
         detailRequest.setApplicationId(createApplicationResponse.getApplicationId());
         GetApplicationDetailResponse detailResponse = applicationServiceBehavior.getApplicationDetail(detailRequest);
 
-        PublicKey masterPublicKey = keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
+        PublicKey masterPublicKey = keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(detailResponse.getMasterPublicKey()));
 
         final String version = "3.2";
         final String applicationKey = createApplicationVersionResponse.getApplicationKey();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/VerifySignatureConcurrencyTest.java
@@ -13,10 +13,11 @@ import com.wultra.security.powerauth.app.server.service.behavior.tasks.OnlineSig
 import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Disabled;
@@ -87,15 +88,15 @@ public class VerifySignatureConcurrencyTest {
 
         final String version = "3.2";
         final String applicationKey = createApplicationVersionResponse.getApplicationKey();
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, createApplicationVersionResponse.getApplicationSecret())
+                new ClientEciesSecrets(masterPublicKey, createApplicationVersionResponse.getApplicationSecret())
         );
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         new ObjectMapper().writeValue(baos, requestL2);
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(baos.toByteArray());
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(baos.toByteArray());
 
         // Create activation
         CreateActivationRequest createActivationRequest = new CreateActivationRequest();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
@@ -24,6 +24,8 @@ import com.wultra.security.powerauth.client.model.enumeration.*;
 import com.wultra.security.powerauth.client.model.error.PowerAuthClientException;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClient;
 import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
@@ -32,8 +34,8 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.ServerEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.BeforeAll;
@@ -842,7 +844,7 @@ class PowerAuthControllerTest {
     void testVerifyOfflineSignature() throws Exception {
         initActivation();
 
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
 
         final PrepareActivationRequest prepareActivationRequest = new PrepareActivationRequest();
         prepareActivationRequest.setActivationCode(config.getActivationCode());
@@ -897,7 +899,7 @@ class PowerAuthControllerTest {
     void testCreateActivation() throws Exception {
         final Date expireDate = Date.from(LocalDateTime.now().plusMinutes(5).atZone(ZoneId.systemDefault()).toInstant());
         final String activationName = "TEST_ACTIVATION";
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(activationName);
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(activationName);
 
         final CreateActivationRequest createActivationRequest = new CreateActivationRequest();
         createActivationRequest.setUserId(PowerAuthControllerTestConfig.USER_ID);
@@ -947,7 +949,7 @@ class PowerAuthControllerTest {
     void testUpdateActivationOtpAndCommit() throws Exception {
         initActivation();
         final String activationOtp = "12345678";
-        final EncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
+        final EciesEncryptedRequest encryptedRequest = generateEncryptedRequestActivationLayer(config.getActivationName());
 
         final PrepareActivationRequest prepareActivationRequest = new PrepareActivationRequest();
         prepareActivationRequest.setActivationCode(config.getActivationCode());
@@ -1000,12 +1002,12 @@ class PowerAuthControllerTest {
     void testGetEciesDecryptor() throws Exception {
         final String requestData = "test_data";
 
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.APPLICATION_SCOPE_GENERIC,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ClientEncryptorSecrets(wrapPublicKeyString(), config.getApplicationSecret())
+                new ClientEciesSecrets(wrapPublicKeyString(), config.getApplicationSecret())
         );
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(requestData.getBytes(StandardCharsets.UTF_8));
         final GetEciesDecryptorRequest eciesDecryptorRequest = new GetEciesDecryptorRequest();
         eciesDecryptorRequest.setProtocolVersion(PowerAuthControllerTestConfig.PROTOCOL_VERSION);
         eciesDecryptorRequest.setActivationId(null);
@@ -1017,10 +1019,10 @@ class PowerAuthControllerTest {
 
         final byte[] secretKey = Base64.getDecoder().decode(decryptorResponse.getSecretKey());
         final byte[] sharedInfo2Base = Base64.getDecoder().decode(decryptorResponse.getSharedInfo2());
-        final ServerEncryptor serverEncryptor = encryptorFactory.getServerEncryptor(
+        final ServerEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> serverEncryptor = encryptorFactory.getServerEncryptor(
                 EncryptorId.APPLICATION_SCOPE_GENERIC,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ServerEncryptorSecrets(secretKey, sharedInfo2Base)
+                new ServerEciesSecrets(secretKey, sharedInfo2Base)
         );
         final byte[] decryptedData = serverEncryptor.decryptRequest(encryptedRequest);
         assertArrayEquals(requestData.getBytes(StandardCharsets.UTF_8), decryptedData);
@@ -1328,7 +1330,7 @@ class PowerAuthControllerTest {
      * @return The {@link EncryptedRequest} containing the encrypted request data.
      * @throws Exception if there is an error during the encryption or serialization process.
      */
-    private EncryptedRequest generateEncryptedRequestActivationLayer(final String activationName) throws Exception {
+    private EciesEncryptedRequest generateEncryptedRequestActivationLayer(final String activationName) throws Exception {
         final KeyPair keyPair = keyGenerator.generateKeyPair();
         final PublicKey publicKey = keyPair.getPublic();
         final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
@@ -1336,10 +1338,10 @@ class PowerAuthControllerTest {
         requestL2.setActivationName(activationName);
         requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));
 
-        final ClientEncryptor clientEncryptor = encryptorFactory.getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = encryptorFactory.getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(PowerAuthControllerTestConfig.PROTOCOL_VERSION, config.getApplicationKey(), null, null),
-                new ClientEncryptorSecrets(wrapPublicKeyString(), config.getApplicationSecret())
+                new ClientEciesSecrets(wrapPublicKeyString(), config.getApplicationSecret())
         );
 
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/controller/api/PowerAuthControllerTest.java
@@ -26,6 +26,7 @@ import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.rest.client.PowerAuthRestClient;
 import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
@@ -1309,7 +1310,7 @@ class PowerAuthControllerTest {
      * @throws Exception if there is an error during the conversion process.
      */
     private PublicKey wrapPublicKeyString() throws Exception {
-        return keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(config.getMasterPublicKey()));
+        return keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(config.getMasterPublicKey()));
     }
 
     /**
@@ -1331,9 +1332,9 @@ class PowerAuthControllerTest {
      * @throws Exception if there is an error during the encryption or serialization process.
      */
     private EciesEncryptedRequest generateEncryptedRequestActivationLayer(final String activationName) throws Exception {
-        final KeyPair keyPair = keyGenerator.generateKeyPair();
+        final KeyPair keyPair = keyGenerator.generateKeyPair(EcCurve.P256);
         final PublicKey publicKey = keyPair.getPublic();
-        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(publicKey);
+        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(EcCurve.P256, publicKey);
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setActivationName(activationName);
         requestL2.setDevicePublicKey(Base64.getEncoder().encodeToString(publicKeyBytes));

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -27,11 +27,11 @@ import com.wultra.security.powerauth.app.server.service.model.request.Activation
 import com.wultra.security.powerauth.app.server.service.model.response.ActivationLayer2Response;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Test;
@@ -95,7 +95,7 @@ class ActivationServiceBehaviorTest {
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation
         final String activationCode = initActivationResponse.getActivationCode();
@@ -128,7 +128,7 @@ class ActivationServiceBehaviorTest {
 
         // Create request payload, omit device public key
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Prepare activation with missing devicePublicKey
         final String activationCode = initActivationResponse.getActivationCode();
@@ -164,7 +164,7 @@ class ActivationServiceBehaviorTest {
         // Create request payload
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Create activation
         final String applicationKey = detailResponse.getVersions().get(0).getApplicationKey();
@@ -190,7 +190,7 @@ class ActivationServiceBehaviorTest {
 
         // Create request payload, omit device public key
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, detailResponse);
 
         // Create activation with missing devicePublicKey
         final String applicationKey = detailResponse.getVersions().get(0).getApplicationKey();
@@ -409,11 +409,11 @@ class ActivationServiceBehaviorTest {
         final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, applicationSecret));
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(activationLayer2Request));
+                new ClientEciesSecrets(masterPublicKey, applicationSecret));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(activationLayer2Request));
 
         // Create activation
         final CreateActivationRequest request = new CreateActivationRequest();
@@ -475,8 +475,8 @@ class ActivationServiceBehaviorTest {
         activationServiceBehavior.commitActivation(commitActivationRequest);
     }
 
-    private ActivationLayer2Response decryptPayload(CreateActivationResponse response, ClientEncryptor clientEncryptor) throws Exception {
-        final EncryptedResponse encryptedResponse = new EncryptedResponse(response.getEncryptedData(), response.getMac(), response.getNonce(), response.getTimestamp());
+    private ActivationLayer2Response decryptPayload(CreateActivationResponse response, ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor) throws Exception {
+        final EciesEncryptedResponse encryptedResponse = new EciesEncryptedResponse(response.getEncryptedData(), response.getMac(), response.getNonce(), response.getTimestamp());
         final byte[] decryptedActivationResponsePayload = clientEncryptor.decryptResponse(encryptedResponse);
         return objectMapper.readValue(decryptedActivationResponsePayload, ActivationLayer2Response.class);
     }
@@ -490,7 +490,7 @@ class ActivationServiceBehaviorTest {
         return lookupRecoveryCodesResponse.getRecoveryCodes().get(0).getStatus();
     }
 
-    private EncryptedRequest buildPrepareActivationPayload(
+    private EciesEncryptedRequest buildPrepareActivationPayload(
             final ActivationLayer2Request requestL2,
             final GetApplicationDetailResponse applicationDetail) throws Exception {
 
@@ -500,15 +500,15 @@ class ActivationServiceBehaviorTest {
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
         // Encrypt payload
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters(version, applicationKey, null, null),
-                new ClientEncryptorSecrets(masterPublicKey, applicationSecret));
+                new ClientEciesSecrets(masterPublicKey, applicationSecret));
         return clientEncryptor.encryptRequest(objectMapper.writeValueAsBytes(requestL2));
     }
 
     private RecoveryCodeActivationRequest buildRecoveryCodeActivationRequest(String recoveryCode, String puk, ActivationLayer2Request payload, GetApplicationDetailResponse detailResponse) throws Exception {
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(payload, detailResponse);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(payload, detailResponse);
 
         final RecoveryCodeActivationRequest recoveryCodeActivationRequest = new RecoveryCodeActivationRequest();
         recoveryCodeActivationRequest.setRecoveryCode(recoveryCode);
@@ -554,7 +554,7 @@ class ActivationServiceBehaviorTest {
         final ActivationLayer2Request requestL2 = new ActivationLayer2Request();
         requestL2.setDevicePublicKey(publicKey);
         requestL2.setActivationOtp(otpToUse);
-        final EncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, applicationDetail);
+        final EciesEncryptedRequest encryptedRequest = buildPrepareActivationPayload(requestL2, applicationDetail);
 
         // Prepare activation
         final String activationCode = initActivationResponse.getActivationCode();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehaviorTest.java
@@ -32,6 +32,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParamet
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import org.junit.jupiter.api.Test;
@@ -406,7 +407,7 @@ class ActivationServiceBehaviorTest {
 
         // Encrypt createActivation request payload
         final String applicationKey = applicationDetail.getVersions().get(0).getApplicationKey();
-        final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
+        final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
         final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
@@ -463,8 +464,8 @@ class ActivationServiceBehaviorTest {
 
     private String generatePublicKey() throws Exception {
         final KeyGenerator keyGenerator = new KeyGenerator();
-        final KeyPair keyPair = keyGenerator.generateKeyPair();
-        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(keyPair.getPublic());
+        final KeyPair keyPair = keyGenerator.generateKeyPair(EcCurve.P256);
+        final byte[] publicKeyBytes = keyConvertor.convertPublicKeyToBytes(EcCurve.P256, keyPair.getPublic());
         return Base64.getEncoder().encodeToString(publicKeyBytes);
     }
 
@@ -496,7 +497,7 @@ class ActivationServiceBehaviorTest {
 
         // Set parameters
         final String applicationKey = applicationDetail.getVersions().get(0).getApplicationKey();
-        final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
+        final ECPublicKey masterPublicKey = (ECPublicKey) keyConvertor.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(applicationDetail.getMasterPublicKey()));
         final String applicationSecret = applicationDetail.getVersions().get(0).getApplicationSecret();
 
         // Encrypt payload

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
@@ -42,6 +42,7 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -131,7 +132,7 @@ class TemporaryKeyBehaviourTest {
         assertNotNull(response.getJwt());
         final SignedJWT decodedJWT = SignedJWT.parse(request.getJwt());
         final String masterPublicKeyBase64 = SdkConfigurationSerializer.deserialize(defaultVersion.getMobileSdkConfig()).masterPublicKeyBase64();
-        final PublicKey masterPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(Base64.getDecoder().decode(masterPublicKeyBase64));
+        final PublicKey masterPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(masterPublicKeyBase64));
         validateJwtSignature(decodedJWT, masterPublicKey);
         assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
         assertEquals(challenge, decodedJWT.getJWTClaimsSet().getClaim("challenge"));
@@ -172,7 +173,7 @@ class TemporaryKeyBehaviourTest {
         final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
         final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
         final String temporaryPublicKeyRaw = (String) decodedJWT.getJWTClaimsSet().getClaim("publicKey");
-        final PublicKey temporaryPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(Base64.getDecoder().decode(temporaryPublicKeyRaw));
+        final PublicKey temporaryPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(temporaryPublicKeyRaw));
         // extract temporary key and use it during an activation
         final String activationId = createActivation(defaultVersion, temporaryKeyId, temporaryPublicKey);
         final byte[] challengeBytesActivation = KEY_GENERATOR.generateRandomBytes(18);
@@ -245,15 +246,15 @@ class TemporaryKeyBehaviourTest {
 
     private String generatePublicKey() throws Exception {
         final KeyGenerator keyGenerator = new KeyGenerator();
-        final KeyPair keyPair = keyGenerator.generateKeyPair();
-        final byte[] publicKeyBytes = KEY_CONVERTOR.convertPublicKeyToBytes(keyPair.getPublic());
+        final KeyPair keyPair = keyGenerator.generateKeyPair(EcCurve.P256);
+        final byte[] publicKeyBytes = KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P256, keyPair.getPublic());
         return Base64.getEncoder().encodeToString(publicKeyBytes);
     }
 
     private PublicKey getServerPublicKey(String activationId) throws Exception {
         final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).get();
         final String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
-        return KEY_CONVERTOR.convertBytesToPublicKey(Base64.getDecoder().decode(serverPublicKeyBase64));
+        return KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(serverPublicKeyBase64));
     }
 
     private SecretKey getMasterTransportKey(String activationId) throws Exception {
@@ -264,11 +265,11 @@ class TemporaryKeyBehaviourTest {
         final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
         final String serverPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
         final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-        final PrivateKey serverPrivateKey = KEY_CONVERTOR.convertBytesToPrivateKey(serverPrivateKeyBytes);
+        final PrivateKey serverPrivateKey = KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
 
         // Get application secret and transport key used in sharedInfo2 parameter of ECIES
         final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-        final PublicKey devicePublicKey = KEY_CONVERTOR.convertBytesToPublicKey(devicePublicKeyBytes);
+        final PublicKey devicePublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
         final SecretKey transportKey = PA_SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
         final byte[] transportKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportKey);
         return KEY_CONVERTOR.convertBytesToSharedSecretKey(transportKeyBytes);
@@ -316,7 +317,7 @@ class TemporaryKeyBehaviourTest {
         final Base64URL encodedSignature = jwtParts[2];
         final String signingInput = encodedHeader + "." + encodedPayload;
         final byte[] signatureBytes = convertRawSignatureToDER(encodedSignature.decode());
-        return SIGNATURE_UTILS.validateECDSASignature(signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
+        return SIGNATURE_UTILS.validateECDSASignature(EcCurve.P256, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
     }
 
     private static byte[] convertRawSignatureToDER(byte[] rawSignature) throws Exception {

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TemporaryKeyBehaviourTest.java
@@ -36,11 +36,12 @@ import com.wultra.security.powerauth.app.server.service.model.request.Activation
 import com.wultra.security.powerauth.app.server.service.util.SdkConfigurationSerializer;
 import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ClientEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
@@ -219,11 +220,11 @@ class TemporaryKeyBehaviourTest {
         final String applicationKey = applicationVersion.getApplicationKey();
         final String applicationSecret = applicationVersion.getApplicationSecret();
 
-        final ClientEncryptor clientEncryptor = new EncryptorFactory().getClientEncryptor(
+        final ClientEncryptor<EciesEncryptedRequest, EciesEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
                 EncryptorId.ACTIVATION_LAYER_2,
                 new EncryptorParameters("3.3", applicationKey, null, temporaryKeyId),
-                new ClientEncryptorSecrets(temporaryPublicKey, applicationSecret));
-        final EncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(OBJECT_MAPPER.writeValueAsBytes(activationLayer2Request));
+                new ClientEciesSecrets(temporaryPublicKey, applicationSecret));
+        final EciesEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(OBJECT_MAPPER.writeValueAsBytes(activationLayer2Request));
 
         final CreateActivationRequest activationRequest = new CreateActivationRequest();
         activationRequest.setUserId(UUID.randomUUID().toString());


### PR DESCRIPTION
Migration from deprecated methods to parameterized variants for crypto4.