### PR TITLE
Fix #1853: Document ActivationHistoryEntity.activationName

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -222,6 +222,7 @@ Stores a log of activation changes.
 | external_user_id   | VARCHAR(255) | -                                         | External user ID of user who caused change of the activation (e.g. banker user ID). In case the value is null the change was caused by the user associated with the activation. |
 | timestamp_created  | DATETIME     | -                                         | Timestamp of the record creation.                                                                                                                                               |
 | activation_version | INT(2)       | -                                         | Activation version                                                                                                                                                              |
+| activation_name    | VARCHAR(255  | -                                         | Activation name.                                                                                                                                                                |
 <!-- end -->
 
 <!-- begin database table pa_recovery_code -->

--- a/docs/PowerAuth-Server-1.5.0.md
+++ b/docs/PowerAuth-Server-1.5.0.md
@@ -115,6 +115,27 @@ CREATE TABLE PA_UNIQUE_VALUE (
 CREATE INDEX pa_unique_value_expiration ON pa_unique_value(timestamp_expires);
 ```
 
+
+### Add activation_name Column to pa_activation_history
+
+Add a new column `activation_name` to the `pa_activation_history` table.
+Since it is possible to change the activation name, it is recorded in the history.
+
+
+#### PostgreSQL
+
+```sql
+ALTER TABLE pa_activation_history ADD activation_name VARCHAR(255);
+```
+
+
+#### Oracle
+
+```sql
+ALTER TABLE pa_activation_history ADD activation_name VARCHAR2(255);
+```
+
+
 ### Drop MySQL Support
 
 Since version `1.5.0`, MySQL database is not supported anymore.

--- a/docs/PowerAuth-Server-1.6.0.md
+++ b/docs/PowerAuth-Server-1.6.0.md
@@ -44,8 +44,3 @@ provides several enhancements:
 
 * It allows the creation of a new operation tied to a specific mobile device, identified by its activation ID.
 * It ensures that the operation can only be approved on that specific mobile device, again identified by its activation ID.
-
-### Add activation_name Column to pa_activation_history
-
-Add a new column `activation_name` to the `pa_activation_history` table.
-Since it is possible to change the activation name, it is recorded in the history.

--- a/docs/sql/mssql/migration_1.5.3_1.6.0.sql
+++ b/docs/sql/mssql/migration_1.5.3_1.6.0.sql
@@ -3,11 +3,6 @@
 ALTER TABLE pa_operation_template ADD CONSTRAINT pa_operation_template_template_name_uk UNIQUE (template_name);
 GO
 
--- Changeset powerauth-java-server/1.6.x/20231103-add-activation-name-history.xml::1::Lubos Racansky
--- Add activation_name column to pa_activation_history
-ALTER TABLE pa_activation_history ADD activation_name varchar(255);
-GO
-
 -- Changeset powerauth-java-server/1.6.x/20231106-add-foreign-keys.xml::1::Jan Pesek
 ALTER TABLE pa_operation_application ADD CONSTRAINT pa_operation_application_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application (id);
 GO

--- a/docs/sql/oracle/migration_1.5.3_1.6.0.sql
+++ b/docs/sql/oracle/migration_1.5.3_1.6.0.sql
@@ -2,10 +2,6 @@
 -- Add unique constraint to pa_operation_template.template_name
 ALTER TABLE pa_operation_template ADD CONSTRAINT pa_operation_template_template_name_uk UNIQUE (template_name);
 
--- Changeset powerauth-java-server/1.6.x/20231103-add-activation-name-history.xml::1::Lubos Racansky
--- Add activation_name column to pa_activation_history
-ALTER TABLE pa_activation_history ADD activation_name VARCHAR2(255);
-
 -- Changeset powerauth-java-server/1.6.x/20231106-add-foreign-keys.xml::1::Jan Pesek
 ALTER TABLE pa_operation_application ADD CONSTRAINT pa_operation_application_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application (id);
 

--- a/docs/sql/postgresql/migration_1.5.3_1.6.0.sql
+++ b/docs/sql/postgresql/migration_1.5.3_1.6.0.sql
@@ -2,10 +2,6 @@
 -- Add unique constraint to pa_operation_template.template_name
 ALTER TABLE pa_operation_template ADD CONSTRAINT pa_operation_template_template_name_uk UNIQUE (template_name);
 
--- Changeset powerauth-java-server/1.6.x/20231103-add-activation-name-history.xml::1::Lubos Racansky
--- Add activation_name column to pa_activation_history
-ALTER TABLE pa_activation_history ADD activation_name VARCHAR(255);
-
 -- Changeset powerauth-java-server/1.6.x/20231106-add-foreign-keys.xml::1::Jan Pesek
 ALTER TABLE pa_operation_application ADD CONSTRAINT pa_operation_application_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application (id);
 


### PR DESCRIPTION
When approved, should be backported up to 1.5.x