### PR TITLE
Fix #1853: Document ActivationHistoryEntity.activationName (backport to 1.5)

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -363,6 +363,7 @@ CREATE TABLE pa_activation_history
 | external_user_id | VARCHAR(255) | - | External user ID of user who caused change of the activation (e.g. banker user ID). In case the value is null the change was caused by the user associated with the activation. |
 | timestamp_created | DATETIME | - | Timestamp of the record creation. |
 | activation_version | INT(2) | - | Activation version |
+| activation_name    | VARCHAR(255  | -                                         | Activation name.                                                                                                                                                                |
 <!-- end -->
 
 <!-- begin database table pa_recovery_code -->

--- a/docs/PowerAuth-Server-1.5.0.md
+++ b/docs/PowerAuth-Server-1.5.0.md
@@ -115,6 +115,27 @@ CREATE TABLE PA_UNIQUE_VALUE (
 CREATE INDEX pa_unique_value_expiration ON pa_unique_value(timestamp_expires);
 ```
 
+
+### Add activation_name Column to pa_activation_history
+
+Add a new column `activation_name` to the `pa_activation_history` table.
+Since it is possible to change the activation name, it is recorded in the history.
+
+
+#### PostgreSQL
+
+```sql
+ALTER TABLE pa_activation_history ADD activation_name VARCHAR(255);
+```
+
+
+#### Oracle
+
+```sql
+ALTER TABLE pa_activation_history ADD activation_name VARCHAR2(255);
+```
+
+
 ### Drop MySQL Support
 
 Since version `1.5.0`, MySQL database is not supported anymore.


### PR DESCRIPTION
(cherry picked from commit ca017b6ba81c962d18b1380863ebb861f3b4a16b)