### PR TITLE
Fix #1885: Update JPA entities, serialization and encryption for crypto4

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -127,16 +127,17 @@ Stores master key pairs associated with applications and used during the activat
 
 #### Columns
 
-| Name                      | Type         | Info                            | Note                                                                   |
-|---------------------------|--------------|---------------------------------|------------------------------------------------------------------------|
-| id                        | BIGINT(20)   | primary key, autoincrement      | Unique master key pair ID.                                             |
-| application_id            | BIGINT(20)   | foreign key: pa\_application.id | Associated application ID.                                             |
-| name                      | VARCHAR(255) | -                               | Name of the key pair.                                                  |
-| master_key_private_base64 | VARCHAR(255) | -                               | Private key encoded as Base64                                          |
-| master_key_public_base64  | VARCHAR(255) | -                               | Public key encoded as Base64                                           |
-| master_private_keys       | TEXT         | -                               | Private keys used for newer cryptography algorithms serialized as JSON |
-| master_public_keys        | TEXT         | -                               | Public keys used for newer cryptography algorithms serialized as JSON  |
-| timestamp_created         | DATETIME     | -                               | Timestamp of creation.                                                 |
+| Name                           | Type         | Info                            | Note                                                                   |
+|--------------------------------|--------------|---------------------------------|------------------------------------------------------------------------|
+| id                             | BIGINT(20)   | primary key, autoincrement      | Unique master key pair ID.                                             |
+| application_id                 | BIGINT(20)   | foreign key: pa\_application.id | Associated application ID.                                             |
+| name                           | VARCHAR(255) | -                               | Name of the key pair.                                                  |
+| master_key_private_base64      | VARCHAR(255) | -                               | Private key encoded as Base64                                          |
+| master_key_public_base64       | VARCHAR(255) | -                               | Public key encoded as Base64                                           |
+| master_private_keys            | TEXT         | -                               | Private keys used for newer cryptography algorithms serialized as JSON |
+| master_private_keys_encryption | INT(11)      | -                               | Encryption indicator (0 = no encryption, 1 = AES_HMAC).                |
+| master_public_keys             | TEXT         | -                               | Public keys used for newer cryptography algorithms serialized as JSON  |
+| timestamp_created              | DATETIME     | -                               | Timestamp of creation.                                                 |
 <!-- end -->
 
 <!-- begin database table pa_signature_audit -->
@@ -395,6 +396,8 @@ Table stores details about temporary key pairs used for data encryption.
 | private_key_encryption | integer      | -                                                      | Indication whether server private key is encrypted (0 = no encryption, 1 = AES_HMAC). |
 | private_key_base64     | varchar(255) | -                                                      | Temporary private key encoded as Base64.                                              |
 | public_key_base64      | varchar(255) | -                                                      | Temporary public key encoded as Base64.                                               |
+| secret_key_base64      | VARCHAR(255) | -                                                      | Base64-encoded secret key.                                                            |
+| secret_key_encryption  | INT(11)      | -                                                      | Encryption indicator (0 = no encryption, 1 = AES_HMAC).                               |
 | timestamp_expires      | timestamp    | index                                                  | Timestamp of when the temporary key pair expires.                                     |
 
 <!-- begin database table pa_application_callback_event -->

--- a/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250317-crypto4-master-keys.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250317-crypto4-master-keys.xml
@@ -7,12 +7,14 @@
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="pa_master_keypair" columnName="master_private_keys" />
+                <columnExists tableName="pa_master_keypair" columnName="master_private_keys_encryption" />
                 <columnExists tableName="pa_master_keypair" columnName="master_public_keys" />
             </not>
         </preConditions>
         <comment>Add columns for crypto4 keys to pa_master_keypair table</comment>
         <addColumn tableName="pa_master_keypair">
             <column name="master_private_keys" type="clob"/>
+            <column name="master_private_keys_encryption" type="integer" defaultValue="0"/>
             <column name="master_public_keys" type="clob"/>
         </addColumn>
     </changeSet>

--- a/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="1" logicalFilePath="powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="pa_temporary_key" columnName="secret_key_base64" />
+                <columnExists tableName="pa_temporary_key" columnName="secret_key_encryption" />
+            </not>
+        </preConditions>
+        <comment>Add columns for crypto4 shared secret storage to pa_temporary_key table</comment>
+        <addColumn tableName="pa_activation">
+            <column name="secret_key_base64" type="varchar(255)"/>
+            <column name="secret_key_encryption" type="integer" defaultValue="0"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/2.0.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.0.x/db.changelog-version.xml
@@ -6,5 +6,6 @@
     <include file="20250314-crypto4-pqc.xml" relativeToChangelogFile="true" />
     <include file="20250317-crypto4-master-keys.xml" relativeToChangelogFile="true" />
     <include file="20250318-crypto4-dynamic-keys.xml" relativeToChangelogFile="true" />
+    <include file="20250320-crypto4-temporary-keys.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/sql/mssql/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/mssql/migration_1.9.0_2.0.0.sql
@@ -28,6 +28,9 @@ GO
 ALTER TABLE pa_master_keypair ADD master_private_keys varchar(MAX);
 GO
 
+ALTER TABLE pa_master_keypair ADD master_private_keys_encryption int CONSTRAINT DF_pa_master_keypair_master_private_keys_encryption DEFAULT 0;
+GO
+
 ALTER TABLE pa_master_keypair ADD master_public_keys varchar(MAX);
 GO
 
@@ -48,3 +51,10 @@ GO
 ALTER TABLE pa_activation ADD knowledge_factor_key_next varchar(255);
 GO
 
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_activation ADD secret_key_base64 varchar(255);
+GO
+
+ALTER TABLE pa_activation ADD secret_key_encryption int CONSTRAINT DF_pa_activation_secret_key_encryption DEFAULT 0;
+GO

--- a/docs/sql/oracle/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/oracle/migration_1.9.0_2.0.0.sql
@@ -20,6 +20,8 @@ ALTER TABLE pa_activation ADD shared_secret_encryption INTEGER DEFAULT '0';
 -- Add columns for crypto4 keys to pa_master_keypair table
 ALTER TABLE pa_master_keypair ADD master_private_keys CLOB;
 
+ALTER TABLE pa_master_keypair ADD master_private_keys_encryption INTEGER DEFAULT '0';
+
 ALTER TABLE pa_master_keypair ADD master_public_keys CLOB;
 
 -- Changeset powerauth-java-server/2.0.x/20250318-crypto4-dynamic-keys.xml::1::Roman Strobl
@@ -33,3 +35,9 @@ ALTER TABLE pa_activation ADD biometric_factor_key_next VARCHAR2(255);
 ALTER TABLE pa_activation ADD knowledge_factor_key VARCHAR2(255);
 
 ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR2(255);
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_activation ADD secret_key_base64 VARCHAR2(255);
+
+ALTER TABLE pa_activation ADD secret_key_encryption INTEGER DEFAULT '0';

--- a/docs/sql/postgresql/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/postgresql/migration_1.9.0_2.0.0.sql
@@ -20,10 +20,12 @@ ALTER TABLE pa_activation ADD shared_secret_encryption INTEGER DEFAULT 0;
 -- Add columns for crypto4 keys to pa_master_keypair table
 ALTER TABLE pa_master_keypair ADD master_private_keys TEXT;
 
+ALTER TABLE pa_master_keypair ADD master_private_keys_encryption INTEGER DEFAULT 0;
+
 ALTER TABLE pa_master_keypair ADD master_public_keys TEXT;
 
 -- Changeset powerauth-java-server/2.0.x/20250318-crypto4-dynamic-keys.xml::1::Roman Strobl
--- Add columns for crypto4 keys to pa_activation table
+-- Add columns for crypto4 dynamic keys to pa_activation table
 ALTER TABLE pa_activation ADD biometric_factor_enabled BOOLEAN DEFAULT FALSE;
 
 ALTER TABLE pa_activation ADD biometric_factor_key VARCHAR(255);
@@ -33,3 +35,9 @@ ALTER TABLE pa_activation ADD biometric_factor_key_next VARCHAR(255);
 ALTER TABLE pa_activation ADD knowledge_factor_key VARCHAR(255);
 
 ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR(255);
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_activation ADD secret_key_base64 VARCHAR(255);
+
+ALTER TABLE pa_activation ADD secret_key_encryption INTEGER DEFAULT 0;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/KeyMapperConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/KeyMapperConfiguration.java
@@ -35,6 +35,8 @@ import java.security.PublicKey;
 
 /**
  * Object mapper configuration for serialization and deserialization of keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Configuration
 public class KeyMapperConfiguration {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/KeyMapperConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/KeyMapperConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.wultra.security.powerauth.app.server.converter.PrivateKeyRegistryDeserializer;
+import com.wultra.security.powerauth.app.server.converter.PrivateKeySerializer;
+import com.wultra.security.powerauth.app.server.converter.PublicKeyRegistryDeserializer;
+import com.wultra.security.powerauth.app.server.converter.PublicKeySerializer;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+
+/**
+ * Object mapper configuration for serialization and deserialization of keys.
+ */
+@Configuration
+public class KeyMapperConfiguration {
+
+    @Bean(name = "privateKeyObjectMapper")
+    public ObjectMapper privateKeyObjectMapper() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final SimpleModule module = new SimpleModule();
+        module.addSerializer(PrivateKey.class, new PrivateKeySerializer());
+        module.addDeserializer(PrivateKeyRegistry.class, new PrivateKeyRegistryDeserializer());
+        objectMapper.registerModule(module);
+        return objectMapper;
+    }
+
+    @Bean(name = "publicKeyObjectMapper")
+    public ObjectMapper publickeyObjectMapper() {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        final SimpleModule module = new SimpleModule();
+        module.addSerializer(PublicKey.class, new PublicKeySerializer());
+        module.addDeserializer(PublicKeyRegistry.class, new PublicKeyRegistryDeserializer());
+        objectMapper.registerModule(module);
+        return objectMapper;
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
@@ -87,7 +87,7 @@ public class MasterPrivateKeysConverter {
         return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
     }
 
-    public byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
+    byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
         return objectMapper.writeValueAsBytes(source);
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
@@ -1,0 +1,110 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Converter for master private keys which handles key conversion and encryption/decryption in case it is configured.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+public class MasterPrivateKeysConverter {
+
+    private final EncryptionService encryptionService;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public MasterPrivateKeysConverter(EncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
+        this.encryptionService = encryptionService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Convert master private keys from composite database value to object.
+     * @param masterPrivateKeys Master private keys composite database value for private keys and encryption mode.
+     * @param applicationId Application ID used for derivation of secret key.
+     * @return Decrypted master private keys.
+     * @throws GenericServiceException In case master private keys decryption fails.
+     */
+    public PrivateKeyRegistry fromDBValue(final PrivateKeys masterPrivateKeys, final String applicationId) throws GenericServiceException {
+        try {
+            final byte[] data = convertFromBase64(masterPrivateKeys.privateKeysBase64());
+            final byte[] decrypted = encryptionService.decrypt(data, masterPrivateKeys.encryptionMode(), createEncryptionKeyProvider(applicationId));
+            return deserialize(decrypted);
+        } catch (IOException e) {
+            logger.warn(e.getMessage(), e);
+            throw new GenericServiceException(ServiceError.DECRYPTION_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Convert master private keys to composite database value. Private key is encrypted
+     * in case master DB encryption key is configured in PA server configuration.
+     * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
+     * the transaction is not rolled back.
+     * @param masterPrivateKeysBytes Master private keys as byte array.
+     * @param applicationId Application ID used for derivation of secret key.
+     * @return Private key as composite database value.
+     * @throws GenericServiceException Thrown when private keys encryption fails.
+     */
+    public PrivateKeys toDBValue(final byte[] masterPrivateKeysBytes, final String applicationId) throws GenericServiceException {
+        final EncryptableData encryptable = encryptionService.encrypt(masterPrivateKeysBytes, createEncryptionKeyProvider(applicationId));
+        return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
+    }
+
+    public byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
+        return objectMapper.writeValueAsBytes(source);
+    }
+
+    private PrivateKeyRegistry deserialize(final byte[] source) throws IOException {
+        return objectMapper.readValue(source, PrivateKeyRegistry.class);
+    }
+
+    private String convertToBase64(final byte[] source) {
+        return Base64.getEncoder().encodeToString(source);
+    }
+
+    private byte[] convertFromBase64(final String source) {
+        return Base64.getDecoder().decode(source);
+    }
+
+    private static Supplier<List<String>> createEncryptionKeyProvider(final String applicationId) {
+        return () -> List.of(applicationId);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeyRegistryDeserializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeyRegistryDeserializer.java
@@ -1,0 +1,112 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Iterator;
+
+/**
+ * JSON deserializer for private keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Slf4j
+public class PrivateKeyRegistryDeserializer extends JsonDeserializer<PrivateKeyRegistry> {
+
+    private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private static final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Override
+    public PrivateKeyRegistry deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+        final JsonNode root = jsonParser.getCodec().readTree(jsonParser);
+        final PrivateKeyRegistry keyRegistry = new PrivateKeyRegistry();
+
+        final JsonNode privateKeysNode = root.get("privateKeys");
+        final Iterator<String> algorithmNames = privateKeysNode.fieldNames();
+        while (algorithmNames.hasNext()) {
+            final String algorithmName = algorithmNames.next();
+            final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(algorithmName);
+            final JsonNode algorithmNode = privateKeysNode.get(algorithmName);
+            if (algorithmNode == null || algorithmNode.isEmpty()) {
+                continue;
+            }
+            final Iterator<String> keyTypeNames = algorithmNode.fieldNames();
+            while (keyTypeNames.hasNext()) {
+                final String keyTypeName = keyTypeNames.next();
+                final KeyType keyType = KeyType.valueOf(keyTypeName);
+                final byte[] encodedKey = algorithmNode.get(keyTypeName).binaryValue();
+                final PrivateKey key = deserializePrivateKey(algorithm, keyType, encodedKey);
+                keyRegistry.storePrivateKey(algorithm, keyType, key);
+            }
+        }
+        return keyRegistry;
+    }
+
+    private PrivateKey deserializePrivateKey(SharedSecretAlgorithm algorithm, KeyType keyType, byte[] encodedKey) throws IOException {
+        try {
+            return switch (algorithm) {
+                case EC_P256, EC_P384 -> {
+                    if (keyType != KeyType.ECDSA) {
+                        throw new IOException("Unsupported key type: " + keyType + " for algorithm " + algorithm);
+                    }
+                    yield KEY_CONVERTOR_EC.convertBytesToPrivateKey(getCurve(algorithm), encodedKey);
+                }
+                case EC_P384_ML_L3 -> {
+                    switch (keyType) {
+                        case ECDSA -> {
+                            yield KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, encodedKey);
+                        }
+                        case MLDSA -> {
+                            yield KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(encodedKey);
+                        }
+                        default -> throw new IOException("Unsupported key type: " + keyType + " for algorithm " + algorithm);
+                    }
+                }
+            };
+        } catch (CryptoProviderException | InvalidKeySpecException | GenericCryptoException e) {
+            logger.debug("Key conversion failed: {}", e.getMessage(), e);
+            throw new IOException("Key conversion error", e);
+        }
+    }
+
+    private EcCurve getCurve(SharedSecretAlgorithm algorithm) {
+        return switch (algorithm) {
+            case EC_P256 -> EcCurve.P256;
+            case EC_P384, EC_P384_ML_L3 -> EcCurve.P384;
+        };
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeyRegistryDeserializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeyRegistryDeserializer.java
@@ -80,22 +80,15 @@ public class PrivateKeyRegistryDeserializer extends JsonDeserializer<PrivateKeyR
         try {
             return switch (algorithm) {
                 case EC_P256, EC_P384 -> {
-                    if (keyType != KeyType.ECDSA) {
-                        throw new IOException("Unsupported key type: " + keyType + " for algorithm " + algorithm);
+                    if (keyType == KeyType.ECDSA) {
+                        yield KEY_CONVERTOR_EC.convertBytesToPrivateKey(getCurve(algorithm), encodedKey);
                     }
-                    yield KEY_CONVERTOR_EC.convertBytesToPrivateKey(getCurve(algorithm), encodedKey);
+                    throw new IOException("Unsupported key type: " + keyType + " for algorithm " + algorithm);
                 }
-                case EC_P384_ML_L3 -> {
-                    switch (keyType) {
-                        case ECDSA -> {
-                            yield KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, encodedKey);
-                        }
-                        case MLDSA -> {
-                            yield KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(encodedKey);
-                        }
-                        default -> throw new IOException("Unsupported key type: " + keyType + " for algorithm " + algorithm);
-                    }
-                }
+                case EC_P384_ML_L3 -> switch (keyType) {
+                    case ECDSA -> KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, encodedKey);
+                    case MLDSA -> KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(encodedKey);
+                };
             };
         } catch (CryptoProviderException | InvalidKeySpecException | GenericCryptoException e) {
             logger.debug("Key conversion failed: {}", e.getMessage(), e);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeySerializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PrivateKeySerializer.java
@@ -1,0 +1,59 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+
+import java.io.IOException;
+import java.security.PrivateKey;
+import java.util.Base64;
+
+/**
+ * JSON serializer for private keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PrivateKeySerializer extends JsonSerializer<PrivateKey> {
+
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+
+    @Override
+    public void serialize(PrivateKey privateKey, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        if (privateKey == null) {
+            throw new IllegalArgumentException("Missing private key to serialize");
+        }
+        switch (privateKey.getAlgorithm()) {
+            case "EC": {
+                gen.writeString(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPrivateKeyToBytes(privateKey)));
+                break;
+            }
+            case "ML-DSA-65": {
+                gen.writeString(Base64.getEncoder().encodeToString(privateKey.getEncoded()));
+                break;
+            }
+            default:
+                throw new IOException("Unsupported algorithm: " + privateKey.getAlgorithm());
+        }
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeyRegistryDeserializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeyRegistryDeserializer.java
@@ -1,0 +1,113 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Iterator;
+
+/**
+ * JSON deserializer for public keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Slf4j
+public class PublicKeyRegistryDeserializer extends JsonDeserializer<PublicKeyRegistry> {
+
+    private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private static final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Override
+    public PublicKeyRegistry deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
+        final JsonNode root = jsonParser.getCodec().readTree(jsonParser);
+        final PublicKeyRegistry keyRegistry = new PublicKeyRegistry();
+
+        final JsonNode privateKeysNode = root.get("publicKeys");
+        final Iterator<String> algorithmNames = privateKeysNode.fieldNames();
+        while (algorithmNames.hasNext()) {
+            final String algorithmName = algorithmNames.next();
+            final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(algorithmName);
+            final JsonNode algorithmNode = privateKeysNode.get(algorithmName);
+            if (algorithmNode == null || algorithmNode.isEmpty()) {
+                continue;
+            }
+            final Iterator<String> keyTypeNames = algorithmNode.fieldNames();
+            while (keyTypeNames.hasNext()) {
+                final String keyTypeName = keyTypeNames.next();
+                final KeyType keyType = KeyType.valueOf(keyTypeName);
+                final byte[] encodedKey = algorithmNode.get(keyTypeName).binaryValue();
+                final PublicKey key = deserializePublicKey(algorithm, keyType, encodedKey);
+                keyRegistry.storePublicKey(algorithm, keyType, key);
+            }
+        }
+        return keyRegistry;
+    }
+
+    private PublicKey deserializePublicKey(SharedSecretAlgorithm algorithm, KeyType keyType, byte[] encodedKey) throws IOException {
+        try {
+            return switch (algorithm) {
+                case EC_P256, EC_P384 -> {
+                    if (keyType != KeyType.ECDSA) {
+                        throw new IOException("Unsupported key type: " + keyType + " for algorithm: " + algorithm);
+                    }
+                    yield KEY_CONVERTOR_EC.convertBytesToPublicKey(getCurve(algorithm), encodedKey);
+                }
+                case EC_P384_ML_L3 -> {
+                    switch (keyType) {
+                        case ECDSA -> {
+                            yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, encodedKey);
+                        }
+                        case MLDSA -> {
+                            yield KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(encodedKey);
+                        }
+                        default -> throw new IOException("Unsupported key type: " + keyType + " for algorithm: " + algorithm);
+                    }
+                }
+            };
+        } catch (CryptoProviderException | InvalidKeySpecException | GenericCryptoException e) {
+            logger.debug(e.getMessage(), e);
+            throw new IOException(e);
+        }
+    }
+
+    private EcCurve getCurve(SharedSecretAlgorithm algorithm) {
+        return switch (algorithm) {
+            case EC_P256 -> EcCurve.P256;
+            case EC_P384, EC_P384_ML_L3 -> EcCurve.P384;
+        };
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeyRegistryDeserializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeyRegistryDeserializer.java
@@ -55,12 +55,12 @@ public class PublicKeyRegistryDeserializer extends JsonDeserializer<PublicKeyReg
         final JsonNode root = jsonParser.getCodec().readTree(jsonParser);
         final PublicKeyRegistry keyRegistry = new PublicKeyRegistry();
 
-        final JsonNode privateKeysNode = root.get("publicKeys");
-        final Iterator<String> algorithmNames = privateKeysNode.fieldNames();
+        final JsonNode publicKeysNode = root.get("publicKeys");
+        final Iterator<String> algorithmNames = publicKeysNode.fieldNames();
         while (algorithmNames.hasNext()) {
             final String algorithmName = algorithmNames.next();
             final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(algorithmName);
-            final JsonNode algorithmNode = privateKeysNode.get(algorithmName);
+            final JsonNode algorithmNode = publicKeysNode.get(algorithmName);
             if (algorithmNode == null || algorithmNode.isEmpty()) {
                 continue;
             }
@@ -80,22 +80,15 @@ public class PublicKeyRegistryDeserializer extends JsonDeserializer<PublicKeyReg
         try {
             return switch (algorithm) {
                 case EC_P256, EC_P384 -> {
-                    if (keyType != KeyType.ECDSA) {
-                        throw new IOException("Unsupported key type: " + keyType + " for algorithm: " + algorithm);
+                    if (keyType == KeyType.ECDSA) {
+                        yield KEY_CONVERTOR_EC.convertBytesToPublicKey(getCurve(algorithm), encodedKey);
                     }
-                    yield KEY_CONVERTOR_EC.convertBytesToPublicKey(getCurve(algorithm), encodedKey);
+                    throw new IOException("Unsupported key type: " + keyType + " for algorithm: " + algorithm);
                 }
-                case EC_P384_ML_L3 -> {
-                    switch (keyType) {
-                        case ECDSA -> {
-                            yield KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, encodedKey);
-                        }
-                        case MLDSA -> {
-                            yield KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(encodedKey);
-                        }
-                        default -> throw new IOException("Unsupported key type: " + keyType + " for algorithm: " + algorithm);
-                    }
-                }
+                case EC_P384_ML_L3 -> switch (keyType) {
+                    case ECDSA -> KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, encodedKey);
+                    case MLDSA -> KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(encodedKey);
+                };
             };
         } catch (CryptoProviderException | InvalidKeySpecException | GenericCryptoException e) {
             logger.debug(e.getMessage(), e);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeySerializer.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeySerializer.java
@@ -1,0 +1,79 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+
+import java.io.IOException;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.EllipticCurve;
+import java.util.Base64;
+
+/**
+ * JSON serializer for public keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class PublicKeySerializer extends JsonSerializer<PublicKey> {
+
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+
+    @Override
+    public void serialize(PublicKey publicKey, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        try {
+            if (publicKey == null) {
+                throw new IllegalArgumentException("Missing public key to serialize");
+            }
+            switch (publicKey.getAlgorithm()) {
+                case "EC": {
+                    final ECPublicKey ecPublicKey = (ECPublicKey) publicKey;
+                    final EllipticCurve curve = ecPublicKey.getParams().getCurve();
+                    switch (curve.getField().getFieldSize()) {
+                        case 256: {
+                            gen.writeString(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P256, publicKey)));
+                            break;
+                        }
+                        case 384: {
+                            gen.writeString(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P384, publicKey)));
+                            break;
+                        }
+                        default: throw new IOException("Invalid EC curve during public key conversion");
+                    }
+                    break;
+                }
+                case "ML-DSA-65": {
+                    gen.writeString(Base64.getEncoder().encodeToString(publicKey.getEncoded()));
+                    break;
+                }
+                default:
+                    throw new IOException("Unsupported algorithm: " + publicKey.getAlgorithm());
+            }
+        } catch (CryptoProviderException e) {
+            throw new IOException("Public key conversion failed", e);
+        }
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
@@ -1,0 +1,108 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Base64;
+
+/**
+ * Converter for server public keys which handles key conversion.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+public class PublicKeysConverter {
+
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public PublicKeysConverter(@Qualifier("publicKeyObjectMapper") ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Convert server public keys from database value to object.
+     * @param serverPublicKeysBase64 Server public keys encoded in Base64-encoding.
+     * @return Server public keys
+     */
+    public PublicKeyRegistry fromDBValue(final String serverPublicKeysBase64) throws GenericServiceException {
+        try {
+            final byte[] data = convertFromBase64(serverPublicKeysBase64);
+            return deserialize(data);
+        } catch (IOException e) {
+            logger.warn(e.getMessage(), e);
+            throw new GenericServiceException(ServiceError.INVALID_KEY_FORMAT, e.getMessage());
+        }
+    }
+
+    /**
+     * Convert public keys to database value.
+     * @param publicKeys Public keys.
+     * @return Public keys database value.
+     * @throws GenericServiceException Thrown when public keys encryption fails.
+     */
+    public String toDBValue(final PublicKeyRegistry publicKeys) throws GenericServiceException {
+        try {
+            return convertToBase64(serialize(publicKeys));
+        } catch (IOException e) {
+            logger.warn(e.getMessage(), e);
+            throw new GenericServiceException(ServiceError.INVALID_KEY_FORMAT, e.getMessage());
+        }
+    }
+
+    /**
+     * Serialize public key registry to bytes.
+     * @param source Public key registry.
+     * @return Byte array with serialized JSON.
+     * @throws JsonProcessingException In case conversion fails.
+     */
+    public byte[] serialize(final PublicKeyRegistry source) throws JsonProcessingException {
+        return objectMapper.writeValueAsBytes(source);
+    }
+
+    /**
+     * Deserialize public key registry from bytes.
+     * @param source Byte array with JSON representation.
+     * @return Public key registry.
+     * @throws IOException In case conversion fails.
+     */
+    public PublicKeyRegistry deserialize(final byte[] source) throws IOException {
+        return objectMapper.readValue(source, PublicKeyRegistry.class);
+    }
+
+    private String convertToBase64(final byte[] source) {
+        return Base64.getEncoder().encodeToString(source);
+    }
+
+    private byte[] convertFromBase64(final String source) {
+        return Base64.getDecoder().decode(source);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
@@ -83,7 +83,7 @@ public class PublicKeysConverter {
      * @return Byte array with serialized JSON.
      * @throws JsonProcessingException In case conversion fails.
      */
-    public byte[] serialize(final PublicKeyRegistry source) throws JsonProcessingException {
+    byte[] serialize(final PublicKeyRegistry source) throws JsonProcessingException {
         return objectMapper.writeValueAsBytes(source);
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
@@ -89,7 +89,7 @@ public class ServerPrivateKeysConverter {
         return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
     }
 
-    public byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
+    byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
         return objectMapper.writeValueAsBytes(source);
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
@@ -1,0 +1,112 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Converter for server private keys which handles key conversion and encryption/decryption in case it is configured.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+public class ServerPrivateKeysConverter {
+
+    private final EncryptionService encryptionService;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public ServerPrivateKeysConverter(EncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
+        this.encryptionService = encryptionService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Convert private keys from composite database value to object.
+     * @param privateKeys Private keys composite database value for private keys and encryption mode.
+     * @param userId User ID used for derivation of secret key.
+     * @param activationId Activation ID used for derivation of secret key.
+     * @return Decrypted private keys.
+     * @throws GenericServiceException In case private keys decryption fails.
+     */
+    public PrivateKeyRegistry fromDBValue(final PrivateKeys privateKeys, final String userId, final String activationId) throws GenericServiceException {
+        try {
+            final byte[] data = convertFromBase64(privateKeys.privateKeysBase64());
+            final byte[] decrypted = encryptionService.decrypt(data, privateKeys.encryptionMode(), createEncryptionKeyProvider(userId, activationId));
+            return deserialize(decrypted);
+        } catch (IOException e) {
+            logger.warn(e.getMessage(), e);
+            throw new GenericServiceException(ServiceError.DECRYPTION_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Convert private keys to composite database value. Private keys are encrypted
+     * in case master DB encryption key is configured in PA server configuration.
+     * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
+     * the transaction is not rolled back.
+     * @param privateKeysBytes Private keys as byte array.
+     * @param userId User ID used for derivation of secret key.
+     * @param activationId Activation ID used for derivation of secret key.
+     * @return Private keys as composite database value.
+     * @throws GenericServiceException Thrown when private keys encryption fails.
+     */
+    public PrivateKeys toDBValue(final byte[] privateKeysBytes, final String userId, final String activationId) throws GenericServiceException {
+        final EncryptableData encryptable = encryptionService.encrypt(privateKeysBytes, createEncryptionKeyProvider(userId, activationId));
+        return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
+    }
+
+    public byte[] serialize(final PrivateKeyRegistry source) throws JsonProcessingException {
+        return objectMapper.writeValueAsBytes(source);
+    }
+
+    private PrivateKeyRegistry deserialize(final byte[] source) throws IOException {
+        return objectMapper.readValue(source, PrivateKeyRegistry.class);
+    }
+
+    private String convertToBase64(final byte[] source) {
+        return Base64.getEncoder().encodeToString(source);
+    }
+
+    private byte[] convertFromBase64(final String source) {
+        return Base64.getDecoder().decode(source);
+    }
+
+    private static Supplier<List<String>> createEncryptionKeyProvider(final String userId, final String activationId) {
+        return () -> List.of(userId, activationId);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverter.java
@@ -1,0 +1,87 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.wultra.security.powerauth.app.server.database.model.SharedSecret;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
+import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Converter for shared secret which handles key encryption and decryption in case it is configured.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Component
+@Slf4j
+@AllArgsConstructor
+public class SharedSecretConverter {
+
+    private final EncryptionService encryptionService;
+
+    /**
+     * Convert shared secret from composite database value to Base64-encoded string value.
+     * @param sharedSecret Shared secret composite database value shared secret and encryption mode.
+     * @param userId User ID used for derivation of secret key.
+     * @param activationId Activation ID used for derivation of secret key.
+     * @return Decrypted Base64-encoded shared secret.
+     * @throws GenericServiceException In case shared secret decryption fails.
+     */
+    public String fromDBValue(final SharedSecret sharedSecret, final String userId, final String activationId) throws GenericServiceException {
+        final byte[] data = convert(sharedSecret.sharedSecretBase64());
+        final byte[] decrypted = encryptionService.decrypt(data, sharedSecret.encryptionMode(), createEncryptionKeyProvider(userId, activationId));
+        return convert(decrypted);
+    }
+
+    /**
+     * Convert shared secret to composite database value. Shared secret is encrypted
+     * in case master DB encryption key is configured in PA server configuration.
+     * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
+     * the transaction is not rolled back.
+     * @param sharedSecret Shared secret value.
+     * @param userId User ID used for derivation of secret key.
+     * @param activationId Activation ID used for derivation of secret key.
+     * @return Shared secret as composite database value.
+     * @throws GenericServiceException Thrown when shared secret encryption fails.
+     */
+    public SharedSecret toDBValue(final byte[] sharedSecret, final String userId, final String activationId) throws GenericServiceException {
+        final EncryptableData encryptable = encryptionService.encrypt(sharedSecret, createEncryptionKeyProvider(userId, activationId));
+        return new SharedSecret(encryptable.encryptionMode(), convert(encryptable.encryptedData()));
+    }
+
+    private static String convert(final byte[] source) {
+        return Base64.getEncoder().encodeToString(source);
+    }
+
+    private static byte[] convert(final String source) {
+        return Base64.getDecoder().decode(source);
+    }
+
+    private static Supplier<List<String>> createEncryptionKeyProvider(final String userId, final String activationId) {
+        return () -> List.of(userId, activationId);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/KeyType.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/KeyType.java
@@ -1,0 +1,30 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.database.model;
+
+/**
+ * Enumeration of key types.
+ */
+public enum KeyType {
+
+    ECDSA,
+    MLDSA
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeyRegistry.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeyRegistry.java
@@ -1,0 +1,92 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.database.model;
+
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.Getter;
+
+import java.security.PrivateKey;
+import java.util.*;
+
+/**
+ * Registry for storing private keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Getter
+public class PrivateKeyRegistry {
+
+    final Map<SharedSecretAlgorithm, Map<KeyType, PrivateKey>> privateKeys = new LinkedHashMap<>();
+
+    /**
+     * Get a private key for given algorithm and key type.
+     * @param algorithm Shared secret algorithm.
+     * @param keyType Key type.
+     * @return Optional private key.
+     */
+    public Optional<PrivateKey> getPrivateKey(SharedSecretAlgorithm algorithm, KeyType keyType) {
+        final Map<KeyType, PrivateKey> keysForAlgorithm = privateKeys.get(algorithm);
+        if (keysForAlgorithm == null || keysForAlgorithm.isEmpty()) {
+            return Optional.empty();
+        }
+        final PrivateKey privateKey = keysForAlgorithm.get(keyType);
+        if (privateKey == null) {
+            return Optional.empty();
+        }
+        return Optional.of(privateKey);
+    }
+
+    /**
+     * Store a private key for given algorithm and key type.
+     * @param algorithm Shared secret algorithm.
+     * @param keyType Key type.
+     * @param key Private key to store.
+     */
+    public void storePrivateKey(SharedSecretAlgorithm algorithm, KeyType keyType, PrivateKey key) {
+        Map<KeyType, PrivateKey> keysForAlgorithm = privateKeys.get(algorithm);
+        if (keysForAlgorithm == null) {
+            keysForAlgorithm = new LinkedHashMap<>();
+            keysForAlgorithm.put(keyType, key);
+            privateKeys.put(algorithm, keysForAlgorithm);
+        } else {
+            keysForAlgorithm.put(keyType, key);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PrivateKeyRegistry that = (PrivateKeyRegistry) o;
+        return Objects.equals(privateKeys, that.privateKeys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(privateKeys);
+    }
+
+    @Override
+    public String toString() {
+        return "PrivateKeyRegistry{" +
+                "privateKeys=" + privateKeys +
+                '}';
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeyRegistry.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeyRegistry.java
@@ -42,15 +42,8 @@ public class PrivateKeyRegistry {
      * @return Optional private key.
      */
     public Optional<PrivateKey> getPrivateKey(SharedSecretAlgorithm algorithm, KeyType keyType) {
-        final Map<KeyType, PrivateKey> keysForAlgorithm = privateKeys.get(algorithm);
-        if (keysForAlgorithm == null || keysForAlgorithm.isEmpty()) {
-            return Optional.empty();
-        }
-        final PrivateKey privateKey = keysForAlgorithm.get(keyType);
-        if (privateKey == null) {
-            return Optional.empty();
-        }
-        return Optional.of(privateKey);
+        return Optional.ofNullable(privateKeys.get(algorithm))
+                .map(keysByKeyTypes -> keysByKeyTypes.get(keyType));
     }
 
     /**
@@ -60,14 +53,8 @@ public class PrivateKeyRegistry {
      * @param key Private key to store.
      */
     public void storePrivateKey(SharedSecretAlgorithm algorithm, KeyType keyType, PrivateKey key) {
-        Map<KeyType, PrivateKey> keysForAlgorithm = privateKeys.get(algorithm);
-        if (keysForAlgorithm == null) {
-            keysForAlgorithm = new LinkedHashMap<>();
-            keysForAlgorithm.put(keyType, key);
-            privateKeys.put(algorithm, keysForAlgorithm);
-        } else {
-            keysForAlgorithm.put(keyType, key);
-        }
+        privateKeys.computeIfAbsent(algorithm, k -> new LinkedHashMap<>())
+                .put(keyType, key);
     }
 
     @Override
@@ -85,8 +72,7 @@ public class PrivateKeyRegistry {
 
     @Override
     public String toString() {
-        return "PrivateKeyRegistry{" +
-                "privateKeys=" + privateKeys +
-                '}';
+        return "PrivateKeyRegistry";
     }
+
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeys.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeys.java
@@ -1,0 +1,32 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.database.model;
+
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+
+/**
+ * Compound value of private keys. Key can be stored encrypted or decrypted based on key encryption mode.
+ *
+ * @param encryptionMode    Key encryption mode.
+ * @param privateKeysBase64 Private keys encoded in Base-64 encoding.
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public record PrivateKeys(EncryptionMode encryptionMode, String privateKeysBase64) {
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeys.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PrivateKeys.java
@@ -29,4 +29,8 @@ import com.wultra.security.powerauth.app.server.database.model.enumeration.Encry
  */
 public record PrivateKeys(EncryptionMode encryptionMode, String privateKeysBase64) {
 
+    @Override
+    public String toString() {
+        return "PrivateKeys{encryptionMode=" + encryptionMode + "}";
+    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
@@ -44,15 +44,8 @@ public class PublicKeyRegistry {
      * @return Optional public key.
      */
     public Optional<PublicKey> getPublicKey(SharedSecretAlgorithm algorithm, KeyType keyType) {
-        final Map<KeyType, PublicKey> keysForAlgorithm = publicKeys.get(algorithm);
-        if (keysForAlgorithm == null || keysForAlgorithm.isEmpty()) {
-            return Optional.empty();
-        }
-        final PublicKey publicKey = keysForAlgorithm.get(keyType);
-        if (publicKey == null) {
-            return Optional.empty();
-        }
-        return Optional.of(publicKey);
+        return Optional.ofNullable(publicKeys.get(algorithm))
+                .map(keysByKeyTypes -> keysByKeyTypes.get(keyType));
     }
 
     /**
@@ -62,14 +55,8 @@ public class PublicKeyRegistry {
      * @param key Public key to store.
      */
     public void storePublicKey(SharedSecretAlgorithm algorithm, KeyType keyType, PublicKey key) {
-        Map<KeyType, PublicKey> keysForAlgorithm = publicKeys.get(algorithm);
-        if (keysForAlgorithm == null) {
-            keysForAlgorithm = new LinkedHashMap<>();
-            keysForAlgorithm.put(keyType, key);
-            publicKeys.put(algorithm, keysForAlgorithm);
-        } else {
-            keysForAlgorithm.put(keyType, key);
-        }
+        publicKeys.computeIfAbsent(algorithm, k -> new LinkedHashMap<>())
+                .put(keyType, key);
     }
 
     @Override

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
@@ -1,0 +1,92 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.database.model;
+
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.Getter;
+
+import java.security.PublicKey;
+import java.util.*;
+
+/**
+ * Registry for storing public keys.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Getter
+public class PublicKeyRegistry {
+
+    final Map<SharedSecretAlgorithm, Map<KeyType, PublicKey>> publicKeys = new LinkedHashMap<>();
+
+    /**
+     * Get a public key for given algorithm and key type.
+     * @param algorithm Shared secret algorithm.
+     * @param keyType Key type.
+     * @return Optional public key.
+     */
+    public Optional<PublicKey> getPublicKey(SharedSecretAlgorithm algorithm, KeyType keyType) {
+        final Map<KeyType, PublicKey> keysForAlgorithm = publicKeys.get(algorithm);
+        if (keysForAlgorithm == null || keysForAlgorithm.isEmpty()) {
+            return Optional.empty();
+        }
+        final PublicKey publicKey = keysForAlgorithm.get(keyType);
+        if (publicKey == null) {
+            return Optional.empty();
+        }
+        return Optional.of(publicKey);
+    }
+
+    /**
+     * Store a public key for given algorithm and key type.
+     * @param algorithm Shared secret algorithm.
+     * @param keyType Key type.
+     * @param key Public key to store.
+     */
+    public void storePublicKey(SharedSecretAlgorithm algorithm, KeyType keyType, PublicKey key) {
+        Map<KeyType, PublicKey> keysForAlgorithm = publicKeys.get(algorithm);
+        if (keysForAlgorithm == null) {
+            keysForAlgorithm = new LinkedHashMap<>();
+            keysForAlgorithm.put(keyType, key);
+            publicKeys.put(algorithm, keysForAlgorithm);
+        } else {
+            keysForAlgorithm.put(keyType, key);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PublicKeyRegistry that = (PublicKeyRegistry) o;
+        return Objects.equals(publicKeys, that.publicKeys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(publicKeys);
+    }
+
+    @Override
+    public String toString() {
+        return "PublicKeyKeyRegistry{" +
+                "publicKeys=" + publicKeys +
+                '}';
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/PublicKeyRegistry.java
@@ -21,6 +21,7 @@ package com.wultra.security.powerauth.app.server.database.model;
 
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.security.PublicKey;
 import java.util.*;
@@ -31,6 +32,7 @@ import java.util.*;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Getter
+@ToString
 public class PublicKeyRegistry {
 
     final Map<SharedSecretAlgorithm, Map<KeyType, PublicKey>> publicKeys = new LinkedHashMap<>();
@@ -83,10 +85,4 @@ public class PublicKeyRegistry {
         return Objects.hashCode(publicKeys);
     }
 
-    @Override
-    public String toString() {
-        return "PublicKeyKeyRegistry{" +
-                "publicKeys=" + publicKeys +
-                '}';
-    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/ServerPrivateKey.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/ServerPrivateKey.java
@@ -28,4 +28,9 @@ import com.wultra.security.powerauth.app.server.database.model.enumeration.Encry
  */
 public record ServerPrivateKey(EncryptionMode encryptionMode, String serverPrivateKeyBase64) {
 
+    @Override
+    public String toString() {
+        return "ServerPrivateKey{encryptionMode=" + encryptionMode + "}";
+    }
+
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/SharedSecret.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/SharedSecret.java
@@ -1,0 +1,32 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.database.model;
+
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+
+/**
+ * Compound value of shared secret. Key can be stored encrypted or decrypted based on key encryption mode.
+ *
+ * @param encryptionMode     Key encryption mode.
+ * @param sharedSecretBase64 Base64-encoded shared secret.
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public record SharedSecret(EncryptionMode encryptionMode, String sharedSecretBase64) {
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/SharedSecret.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/SharedSecret.java
@@ -29,4 +29,9 @@ import com.wultra.security.powerauth.app.server.database.model.enumeration.Encry
  */
 public record SharedSecret(EncryptionMode encryptionMode, String sharedSecretBase64) {
 
+    @Override
+    public String toString() {
+        return "SharedSecret{encryptionMode=" + encryptionMode + "}";
+    }
+
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/ActivationRecordEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/ActivationRecordEntity.java
@@ -23,9 +23,11 @@ import com.wultra.security.powerauth.app.server.database.model.converter.Activat
 import com.wultra.security.powerauth.app.server.database.model.converter.ActivationOtpValidationConverter;
 import com.wultra.security.powerauth.app.server.database.model.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.app.server.database.model.enumeration.*;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.util.ProxyUtils;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -220,6 +222,81 @@ public class ActivationRecordEntity implements Serializable {
     private EncryptionMode serverPrivateKeyEncryption;
 
     /**
+     * Cryptography algorithm used for shared secret computation.
+     */
+    @Column(name = "crypto_algorithm")
+    @Enumerated(EnumType.STRING)
+    private SharedSecretAlgorithm cryptoAlgorithm;
+
+    /**
+     * Device public keys for newer cryptography algorithms serialized into JSON.
+     */
+    @Column(name = "device_public_keys", columnDefinition = "CLOB")
+    private String devicePublicKeys;
+
+    /**
+     * Server private keys for newer cryptography algorithms serialized into JSON.
+     */
+    @Column(name = "server_private_keys", columnDefinition = "CLOB")
+    private String serverPrivateKeys;
+
+    /**
+     * Mode of server private keys encryption {@code (0 = NO_ENCRYPTION, 1 = AES_HMAC)}.
+     */
+    @Column(name = "server_private_keys_encryption")
+    @Enumerated
+    private EncryptionMode serverPrivateKeysEncryption;
+
+    /**
+     * Server public keys for newer cryptography algorithms serialized into JSON.
+     */
+    @Column(name = "server_public_keys", columnDefinition = "CLOB")
+    private String serverPublicKeys;
+
+    /**
+     * Pre-computed shared secret.
+     */
+    @Column(name = "shared_secret")
+    private String sharedSecret;
+
+    /**
+     * Mode of shared secret encryption {@code (0 = NO_ENCRYPTION, 1 = AES_HMAC)}.
+     */
+    @Column(name = "shared_secret_encryption")
+    @Enumerated
+    private EncryptionMode sharedSecretEncryption;
+
+    /**
+     * Whether biometric factor is enabled.
+     */
+    @Column(name = "biometric_factor_enabled")
+    private Boolean biometricFactorEnabled;
+
+    /**
+     * Current biometry factor key.
+     */
+    @Column(name = "biometric_factor_key")
+    private String biometricFactorKey;
+
+    /**
+     * Next biometry factor key.
+     */
+    @Column(name = "biometric_factor_key_next")
+    private String biometricFactorKeyNext;
+
+    /**
+     * Current knowledge factor key.
+     */
+    @Column(name = "knowledge_factor_key")
+    private String knowledgeFactorKey;
+
+    /**
+     * Next knowledge factor key.
+     */
+    @Column(name = "knowledge_factor_key_next")
+    private String knowledgeFactorKeyNext;
+
+    /**
      * PowerAuth protocol major version for activation.
      */
     // Version must be nullable, it is not known yet during init activation step
@@ -251,35 +328,7 @@ public class ActivationRecordEntity implements Serializable {
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 71 * hash + Objects.hashCode(this.activationId);
-        hash = 71 * hash + Objects.hashCode(this.activationCode);
-        hash = 71 * hash + Objects.hashCode(this.activationOtpValidation);
-        hash = 71 * hash + Objects.hashCode(this.activationOtp);
-        hash = 71 * hash + Objects.hashCode(this.userId);
-        hash = 71 * hash + Objects.hashCode(this.activationName);
-        hash = 71 * hash + Objects.hashCode(this.extras);
-        hash = 71 * hash + Objects.hashCode(this.platform);
-        hash = 71 * hash + Objects.hashCode(this.deviceInfo);
-        hash = 71 * hash + Objects.hashCode(this.flags);
-        hash = 71 * hash + Objects.hashCode(this.serverPrivateKeyBase64);
-        hash = 71 * hash + Objects.hashCode(this.serverPublicKeyBase64);
-        hash = 71 * hash + Objects.hashCode(this.devicePublicKeyBase64);
-        hash = 71 * hash + Objects.hashCode(this.counter);
-        hash = 71 * hash + Objects.hashCode(this.ctrDataBase64);
-        hash = 71 * hash + Objects.hashCode(this.failedAttempts);
-        hash = 71 * hash + Objects.hashCode(this.maxFailedAttempts);
-        hash = 71 * hash + Objects.hashCode(this.timestampCreated);
-        hash = 71 * hash + Objects.hashCode(this.timestampActivationExpire);
-        hash = 71 * hash + Objects.hashCode(this.timestampLastUsed);
-        hash = 71 * hash + Objects.hashCode(this.timestampLastChange);
-        hash = 71 * hash + Objects.hashCode(this.activationStatus);
-        hash = 71 * hash + Objects.hashCode(this.blockedReason);
-        hash = 71 * hash + Objects.hashCode(this.serverPrivateKeyEncryption);
-        hash = 71 * hash + Objects.hashCode(this.application);
-        hash = 71 * hash + Objects.hashCode(this.masterKeyPair);
-        hash = 71 * hash + Objects.hashCode(this.version);
-        return hash;
+        return Objects.hash(activationCode);
     }
 
     @Override
@@ -287,92 +336,11 @@ public class ActivationRecordEntity implements Serializable {
         if (this == obj) {
             return true;
         }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
+        if (obj == null || !this.getClass().equals(ProxyUtils.getUserClass(obj))) {
             return false;
         }
         final ActivationRecordEntity other = (ActivationRecordEntity) obj;
-        if (!Objects.equals(this.activationCode, other.activationCode)) {
-            return false;
-        }
-        if (this.activationOtpValidation != other.activationOtpValidation) {
-            return false;
-        }
-        if (!Objects.equals(this.activationOtp, other.activationOtp)) {
-            return false;
-        }
-        if (!Objects.equals(this.userId, other.userId)) {
-            return false;
-        }
-        if (!Objects.equals(this.activationName, other.activationName)) {
-            return false;
-        }
-        if (!Objects.equals(this.extras, other.extras)) {
-            return false;
-        }
-        if (!Objects.equals(this.platform, other.platform)) {
-            return false;
-        }
-        if (!Objects.equals(this.deviceInfo, other.deviceInfo)) {
-            return false;
-        }
-        if (!Objects.equals(this.flags, other.flags)) {
-            return false;
-        }
-        if (!Objects.equals(this.activationId, other.activationId)) {
-            return false;
-        }
-        if (!Objects.equals(this.serverPrivateKeyBase64, other.serverPrivateKeyBase64)) {
-            return false;
-        }
-        if (!Objects.equals(this.serverPublicKeyBase64, other.serverPublicKeyBase64)) {
-            return false;
-        }
-        if (!Objects.equals(this.devicePublicKeyBase64, other.devicePublicKeyBase64)) {
-            return false;
-        }
-        if (!Objects.equals(this.counter, other.counter)) {
-            return false;
-        }
-        if (!Objects.equals(this.ctrDataBase64, other.ctrDataBase64)) {
-            return false;
-        }
-        if (!Objects.equals(this.failedAttempts, other.failedAttempts)) {
-            return false;
-        }
-        if (!Objects.equals(this.maxFailedAttempts, other.maxFailedAttempts)) {
-            return false;
-        }
-        if (!Objects.equals(this.timestampCreated, other.timestampCreated)) {
-            return false;
-        }
-        if (!Objects.equals(this.timestampActivationExpire, other.timestampActivationExpire)) {
-            return false;
-        }
-        if (!Objects.equals(this.timestampLastUsed, other.timestampLastUsed)) {
-            return false;
-        }
-        if (!Objects.equals(this.timestampLastChange, other.timestampLastChange)) {
-            return false;
-        }
-        if (this.activationStatus != other.activationStatus) {
-            return false;
-        }
-        if (!Objects.equals(this.blockedReason, other.blockedReason)) {
-            return false;
-        }
-        if (!Objects.equals(this.serverPrivateKeyEncryption, other.serverPrivateKeyEncryption)) {
-            return false;
-        }
-        if (!Objects.equals(this.application, other.application)) {
-            return false;
-        }
-        if (!Objects.equals(this.masterKeyPair, other.masterKeyPair)) {
-            return false;
-        }
-        return Objects.equals(this.version, other.version);
+        return Objects.equals(this.activationCode, other.activationCode);
     }
 
     @Override

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
@@ -76,7 +76,7 @@ public class MasterKeyPairEntity implements Serializable {
     /**
      * Mode of master private keys encryption {@code (0 = NO_ENCRYPTION, 1 = AES_HMAC)}.
      */
-    @Column(name = "masterprivate_keys_encryption")
+    @Column(name = "master_private_keys_encryption")
     @Enumerated
     private EncryptionMode masterPrivateKeysEncryption;
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
@@ -102,12 +102,8 @@ public class MasterKeyPairEntity implements Serializable {
     @Override
     public int hashCode() {
         int hash = 3;
-        hash = 37 * hash + Objects.hashCode(this.name);
         hash = 37 * hash + Objects.hashCode(this.masterKeyPrivateBase64);
-        hash = 37 * hash + Objects.hashCode(this.masterKeyPublicBase64);
         hash = 37 * hash + Objects.hashCode(this.masterPrivateKeys);
-        hash = 37 * hash + Objects.hashCode(this.masterPrivateKeysEncryption);
-        hash = 37 * hash + Objects.hashCode(this.masterPublicKeys);
         hash = 37 * hash + Objects.hashCode(this.timestampCreated);
         hash = 37 * hash + Objects.hashCode(this.application);
         return hash;
@@ -125,22 +121,10 @@ public class MasterKeyPairEntity implements Serializable {
             return false;
         }
         final MasterKeyPairEntity other = (MasterKeyPairEntity) obj;
-        if (!Objects.equals(this.name, other.name)) {
-            return false;
-        }
         if (!Objects.equals(this.masterKeyPrivateBase64, other.masterKeyPrivateBase64)) {
             return false;
         }
-        if (!Objects.equals(this.masterKeyPublicBase64, other.masterKeyPublicBase64)) {
-            return false;
-        }
         if (!Objects.equals(this.masterPrivateKeys, other.masterPrivateKeys)) {
-            return false;
-        }
-        if (!Objects.equals(this.masterPrivateKeysEncryption, other.masterPrivateKeysEncryption)) {
-            return false;
-        }
-        if (!Objects.equals(this.masterPublicKeys, other.masterPublicKeys)) {
             return false;
         }
         if (!Objects.equals(this.timestampCreated, other.timestampCreated)) {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/MasterKeyPairEntity.java
@@ -17,6 +17,7 @@
  */
 package com.wultra.security.powerauth.app.server.database.model.entity;
 
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -67,6 +68,25 @@ public class MasterKeyPairEntity implements Serializable {
     private String masterKeyPublicBase64;
 
     /**
+     * Master private keys for newer cryptography algorithms serialized to JSON.
+     */
+    @Column(name = "master_private_keys", columnDefinition = "CLOB")
+    private String masterPrivateKeys;
+
+    /**
+     * Mode of master private keys encryption {@code (0 = NO_ENCRYPTION, 1 = AES_HMAC)}.
+     */
+    @Column(name = "masterprivate_keys_encryption")
+    @Enumerated
+    private EncryptionMode masterPrivateKeysEncryption;
+
+    /**
+     * Master public keys for newer cryptography algorithms serialized to JSON.
+     */
+    @Column(name = "master_public_keys", columnDefinition = "CLOB")
+    private String masterPublicKeys;
+
+    /**
      * Master key pair created timestamp.
      */
     @Column(name = "timestamp_created", nullable = false)
@@ -85,6 +105,9 @@ public class MasterKeyPairEntity implements Serializable {
         hash = 37 * hash + Objects.hashCode(this.name);
         hash = 37 * hash + Objects.hashCode(this.masterKeyPrivateBase64);
         hash = 37 * hash + Objects.hashCode(this.masterKeyPublicBase64);
+        hash = 37 * hash + Objects.hashCode(this.masterPrivateKeys);
+        hash = 37 * hash + Objects.hashCode(this.masterPrivateKeysEncryption);
+        hash = 37 * hash + Objects.hashCode(this.masterPublicKeys);
         hash = 37 * hash + Objects.hashCode(this.timestampCreated);
         hash = 37 * hash + Objects.hashCode(this.application);
         return hash;
@@ -111,6 +134,15 @@ public class MasterKeyPairEntity implements Serializable {
         if (!Objects.equals(this.masterKeyPublicBase64, other.masterKeyPublicBase64)) {
             return false;
         }
+        if (!Objects.equals(this.masterPrivateKeys, other.masterPrivateKeys)) {
+            return false;
+        }
+        if (!Objects.equals(this.masterPrivateKeysEncryption, other.masterPrivateKeysEncryption)) {
+            return false;
+        }
+        if (!Objects.equals(this.masterPublicKeys, other.masterPublicKeys)) {
+            return false;
+        }
         if (!Objects.equals(this.timestampCreated, other.timestampCreated)) {
             return false;
         }
@@ -122,7 +154,6 @@ public class MasterKeyPairEntity implements Serializable {
         return "MasterKeyPairEntity{"
                 + "id=" + id
                 + ", name=" + name
-                + ", masterKeyPublic=" + masterKeyPublicBase64
                 + ", timestampCreated=" + timestampCreated
                 + ", application=" + application.getRid()
                 + '}';

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/TemporaryKeyEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/TemporaryKeyEntity.java
@@ -81,6 +81,19 @@ public class TemporaryKeyEntity implements Serializable {
     private String publicKeyBase64;
 
     /**
+     * Secret key stored in Base-64 encoding.
+     */
+    @Column(name = "secret_key_base64")
+    private String secretKeyBase64;
+
+    /**
+     * Mode of secret key encryption {@code (0 = NO_ENCRYPTION, 1 = AES_HMAC)}.
+     */
+    @Column(name = "secret_key_encryption")
+    @Enumerated
+    private EncryptionMode secretKeyEncryption;
+
+    /**
      * Timestamp when operation expired.
      */
     @Column(name = "timestamp_expires", nullable = false)

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
@@ -113,8 +113,9 @@ class MasterPrivateKeysConverterTest {
         final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, APPLICATION_ID);
 
         assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
-        assertThrows(GenericServiceException.class, () ->
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () ->
             privateKeysConverter.fromDBValue(privateKeysEncrypted, "test2"));
+        assertEquals("Generic cryptography error occurred.", exception.getMessage());
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
@@ -1,0 +1,121 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link MasterPrivateKeysConverter}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class MasterPrivateKeysConverterTest {
+
+    private static final String ECDSA_PRIVATE_KEY = "APEKs9JvvLiNMOYoP9AB/ysrqa3NvTjGz5zdEZu0j2MjKxMyKKoTWtOtUHt6AfBAZg==";
+    private static final String MLDSA_PRIVATE_KEY = "MDICAQAwCwYJYIZIAWUDBAMSBCDjgy6AIFJt1eRaBN8FVmwaSQTtyMnFzcRJ5tCh8M+6SA==";
+
+    private static final String MASTER_PRIVATE_KEYS_JSON = "{\"privateKeys\":{\"EC_P384_ML_L3\":{\"ECDSA\":\"" + ECDSA_PRIVATE_KEY + "\",\"MLDSA\":\"" + MLDSA_PRIVATE_KEY + "\"}}}";
+    private static final String MASTER_PRIVATE_KEYS_ENCRYPTED = "j535AIE/smRhCbeZF8Xw40tim+7MbvWB8U6ITNIInYyHjN/Jq8blsaVfDc4CP5RPnfzzQHqJnqTqgd6qcQvJQFLIG8J6dwfx5RhY28vB/uSzMwAV8v1kF27I7yelVmIw6lFFFo0ctvbluVYelDFxdqZ3ng1DiJ6DuGLbPequSMbf1YjjLLoi8FbwUIKMLqqZeB8HqxEbdsA98DIYomAVXU9UsEOIUr4lOq2YnaCJIsrrFBlYXZyzFj01KaNvm94qLLNlgRe8Vbu5/5ro8/fNTOFID6BfuwKR7Am7R3Y7tow=";
+
+    private static final String APPLICATION_ID = "test";
+
+    @Autowired
+    private MasterPrivateKeysConverter privateKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Test
+    void testFromDbValueNoEncryption() throws Exception {
+        final PrivateKeyRegistry keyRegistry = new PrivateKeyRegistry();
+        final PrivateKey ecdsaPrivateKey = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        keyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, ecdsaPrivateKey);
+        final PrivateKey mlDsaPrivateKey = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        keyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, mlDsaPrivateKey);
+        final byte[] keyRegistryBytes = privateKeysConverter.serialize(keyRegistry);
+        final String keyRegistryBase64 = Base64.getEncoder().encodeToString(keyRegistryBytes);
+        final PrivateKeys privateKeysEncrypted = new PrivateKeys(EncryptionMode.NO_ENCRYPTION, keyRegistryBase64);
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, APPLICATION_ID);
+        final Optional<PrivateKey> ecdsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA);
+        assertFalse(ecdsaPrivateKeyActual.isEmpty());
+        final byte[] ecdsaPrivateKeyActualBytes = KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecdsaPrivateKeyActual.get());
+        final Optional<PrivateKey> mlDsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA);
+        assertFalse(mlDsaPrivateKeyActual.isEmpty());
+        final byte[] mlDsaPrivateKeyActualBytes = mlDsaPrivateKeyActual.get().getEncoded();
+        assertEquals(ECDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(ecdsaPrivateKeyActualBytes));
+        assertEquals(MLDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(mlDsaPrivateKeyActualBytes));
+    }
+
+    @Test
+    void testEncryptionAndDecryptionSuccess() throws Exception {
+        final byte[] serverPrivateKeysBytes = MASTER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8);
+        final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, APPLICATION_ID);
+        assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
+        assertNotEquals(MASTER_PRIVATE_KEYS_JSON, privateKeysEncrypted.privateKeysBase64());
+        System.out.println(privateKeysEncrypted.privateKeysBase64());
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, APPLICATION_ID);
+        final PrivateKey privateKeyEcExpected = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        assertEquals(privateKeyEcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA).get());
+        final PrivateKey privateKeyPqcExpected = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        assertEquals(privateKeyPqcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA).get());
+    }
+
+    @Test
+    void testFromDbValueEncryption() throws Exception {
+        final PrivateKeys privateKeysEncrypted = new PrivateKeys(EncryptionMode.AES_HMAC, MASTER_PRIVATE_KEYS_ENCRYPTED);
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, APPLICATION_ID);
+        assertArrayEquals(MASTER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8), privateKeysConverter.serialize(serverPrivateKeysActual));
+        final PrivateKey privateKeyEcExpected = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        assertEquals(privateKeyEcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA).get());
+        final PrivateKey privateKeyPqcExpected = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        assertEquals(privateKeyPqcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA).get());
+    }
+
+    @Test
+    void testEncryptionAndDecryptionDifferentApplicationIdFail() throws Exception {
+        final byte[] serverPrivateKeysBytes = MASTER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8);
+        final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, APPLICATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+            privateKeysConverter.fromDBValue(privateKeysEncrypted, "test2"));
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
@@ -89,7 +89,6 @@ class MasterPrivateKeysConverterTest {
         final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, APPLICATION_ID);
         assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
         assertNotEquals(MASTER_PRIVATE_KEYS_JSON, privateKeysEncrypted.privateKeysBase64());
-        System.out.println(privateKeysEncrypted.privateKeysBase64());
         final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, APPLICATION_ID);
         final PrivateKey privateKeyEcExpected = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
         assertEquals(privateKeyEcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA).get());

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverterTest.java
@@ -78,7 +78,7 @@ class MasterPrivateKeysConverterTest {
         final byte[] ecdsaPrivateKeyActualBytes = KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecdsaPrivateKeyActual.get());
         final Optional<PrivateKey> mlDsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA);
         assertFalse(mlDsaPrivateKeyActual.isEmpty());
-        final byte[] mlDsaPrivateKeyActualBytes = mlDsaPrivateKeyActual.get().getEncoded();
+        final byte[] mlDsaPrivateKeyActualBytes = KEY_CONVERTOR_PQC_DSA.convertPrivateKeyToBytes(mlDsaPrivateKeyActual.get());
         assertEquals(ECDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(ecdsaPrivateKeyActualBytes));
         assertEquals(MLDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(mlDsaPrivateKeyActualBytes));
     }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverterTest.java
@@ -1,0 +1,89 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@link PublicKeysConverter}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class PublicKeysConverterTest {
+
+    private static final String ECDSA_PUBLIC_KEY = "BKJPKNYKmOx7O2uR1k1wR9NHUQFQVNghid1cNaHJ0HfGTYXpttIAsUkOlkY0DyIuAOcs+zpGRP87NlcdJALMfkKcXb22SAfy/E3D8HDCT038pYfL+HiwWpBP+5VYsmk28A==";
+    private static final String MLDSA_PUBLIC_KEY = "MIIHsjALBglghkgBZQMEAxIDggehAKTi66ULAsxGZHhdqBCqvqxfAoLlLJH5/vDPZKPWCnG0RRaShY8plwvYP8AAvlfmbTjayd2UQuqGJozBsB/zawPPiYNo3Y2JkjM8smHZvAL1Edfl/T5lDmctdg77UE84sQ4TjlU/zorUZn2qUSy8MPoRKlqacS4R/7U0M1R++emL2S0CyMCPNUkDlpRA7f2kk+it6qCajrVnhHWB7hPGMmi3ieksBSjh+YvS9ksIV9vBdbh8ysyHyNgjMhE/cl8yooFHMW0hoMijvH7WVFOoPUL+QytXIuzhy1WfGk14LrlHyPL2wr0K6KCT1ueM2zruD2CpFEcdUuNXN0LEzeOtTCpyI9knmp1vZ3vGh6EAaEumq3Ci8s//d1x9bQ31iTAjsxT4dXJvLljoaBdNH8uXXOgdHP3nCI8GmiVfGDd3QUfLMM/4tpudrd1CLgbKVJa+kZtSEkivSa5iSVjr9pOyCGRV+IfzTCRQAneQMg4Tjo8HdfZMZkthh/Cb1+h07PEhofcDn9VxCwzJam91Bn2FqYAvpla1+pFfxFX90gm2J9Heix83wh60SFCRp93pm1rB7+dHZfuKbABLODvy2cXCaDrI8LVfLkNKBEXkKQJN3Q7xsBmWWAzahnsNrnQ8kw0DqvgSUJFqYIgtcsN8yYCOECHO/pCOkNXcES7vvpSiLBt7VvcVsevHiIrAbMUVY/8RSdLurvpIJbFoG+R/gykjBfR9OfFj9cBYZZyo1TaelN+TdrARG1dWdROJmeJXw2sUgUW0hL2U7+fAQBeNZ23IholTCdN6YZK2y9MBdvscRYrtzcxKzXdveHrmYTr0lUxgNiBh25uPynIbJr0eeikNeck8D1GMASwtDYCbFkcsP+m/nyvlTaRnMZeEX7rHzTDs0E0I0mrN0zytxBTKwW4ilEFf/e6d7LfaHh5FBl1Z3Nw9XAnxcJ2nIbgQRrvtLHyWc2LIcKkrioS8SVBNU1vHooNODamhMpQFtmkMUzYvjdZweJy362loPkEILq/0qTvg+vc/GZwP+415LW19Vdczl86ZK/Sr8FaG6mSBBXA0hgbd54SEsa/JQoVXCL7fxS5wo5V7dqdCYL5nP1aAmzJZqI/fHogkRAeQPtZIKMNyy26+lQzuE2zzUE6jWlJ1eiyOxhqG9DMYKK1XuBXhbOnu7Lw2Rgx1XjsK/TOqrN3n71XjEHgpDgYFvc+aG+JsGaOGdNPpBR1bP1T2m/Q0zp3bhuj5FX4oD2VYInkQJvsvnZdRjZMX1/IfQ2/pCouRGVA2Tw/IcKAJbOVz0NqGrM9zpRP5VQOXJAVSGKQHVybfOCYjcIBM6DuG2vSvE1sc9pm7Yv3N5tYxcDwllob40xARVlOYOSCm9sGpvcKA+G65CgJ6m11AqV4HGCea14XibMMBCsl8+hm3OuQCbvyKET/l/8bRRIdo68D35USbORH2mhx3lgxPSkktRgt6eWc/pdi7HST9ZRxWhzmtUkgbRSpMG9AEUm+ri4OPGeX6pnx5Kdp4zgFrYt8AjqX11iNw60aVz4hy+7vHDaP/79nD3UlKvt0SZGFe7uLSSGz0r5Bvjv3buNecXhP1GHVXX8k1/1ml5izla+UAmhnht2LFCAaUcZozv8XrRk5Onjj10rM3Df3mE+/jKHpsRviAV/SjN0RL4KcJsDgMx41gVJ5XMv/TITtDAEqn49RvRAnKy9dzfqrZrqPuklpOVybqcdGntE0qpUTW7v1m+EDsidzoZYjWVyy84aybsjxpCVjZT/5yeDV2l0xNUEJZsX55UeliiQS5t/3mJ2UJ8hSH/T9jVG7LqMHU1huFfNXN2YP2FyKGo2mTYS9DTG3nWWWIcoUoUCaVDQELyTl4LkXwH1RGxftlarNOzKatnUMTRddaTt1qDOsDpAquuKFpu33BZa3n/oVeb9WgXhUg8BM5f5kokhlWbIkLLHR1SrqjLsEsJUsZ5kVwDQZxMP6mMDyDP3snd+28MydLhHJXsadjktqhdqDqWzt7EKSwJe2BPxLqStD5FmsxOPaeNqcwRwq5BWSY7DA/DvvycW91kkUeVEm+uktvFGbo5z4Edn+XE4wkumcezJVSu/YJ32vCxy8ka47liAU9pRo+ZlmkDom50g9px1zFjYxX2iBD0GhKCl3TJORGNJCsNd8NKHGvlK3MwPv4DnYIK+tGvnbrSE8IFtz9i9wt8koh5GaXL0fPKBthzi162Tpbi8dNHROnUaYnH5sczNe+ctH0FG863QsIcAg3w+0v4Dr9eTOwDESgQQ89KYqHYHcFHjCqLbwhgwGsNuGvhJNB0sFRYMNqjtUsxvnWtbIuAUb/VmDLSWfyIp6fC3hik5KXHzju9kbUXuYFMy6r2FT0i14mnLR94UQCFVg/nWOQ0LeC/89Ye8MgNLb73+kDYJmuWglUbtY5fxzKMkWK4jWKI/0kAJk5u07ouN1yiZHz3qbcDnuvuT55HktIaSTyiXo0DXC94XuYVbH+t5G5ZVP9xvgsEyCI0emImvh4ainXsGEqH2HUScbLrKjkHLQkAFsPiIJM1AQMxODz6C+iL4YBEp7F8QUBRWWrM9kniki3Dh4FUzXYzchu4cc4VgTmBxm1";
+
+    private static final String SERVER_PUBLIC_KEYS_JSON = "{\"publicKeys\":{\"EC_P384_ML_L3\":{\"ECDSA\":\"" + ECDSA_PUBLIC_KEY + "\",\"MLDSA\":\"" + MLDSA_PUBLIC_KEY + "\"}}}";
+
+    @Autowired
+    private PublicKeysConverter serverPublicKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Test
+    void testFromDbValue() throws Exception {
+        final PublicKeyRegistry keyRegistry = new PublicKeyRegistry();
+        final PublicKey ecdsaPublicKey = KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PUBLIC_KEY));
+        keyRegistry.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, ecdsaPublicKey);
+        final PublicKey mldsaPublicKey = KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(Base64.getDecoder().decode(MLDSA_PUBLIC_KEY));
+        keyRegistry.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, mldsaPublicKey);
+        final byte[] keyRegistryBytes = serverPublicKeysConverter.serialize(keyRegistry);
+        assertEquals(SERVER_PUBLIC_KEYS_JSON, new String(keyRegistryBytes, StandardCharsets.UTF_8));
+        final String keyRegistryBase64 = Base64.getEncoder().encodeToString(keyRegistryBytes);
+        final PublicKeyRegistry serverPublicKeysActual = serverPublicKeysConverter.fromDBValue(keyRegistryBase64);
+        final Optional<PublicKey> ecdsaPublicKeyActual = serverPublicKeysActual.getPublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA);
+        assertFalse(ecdsaPublicKeyActual.isEmpty());
+        final byte[] ecdsaPublicKeyActualBytes = KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P384, ecdsaPublicKeyActual.get());
+        final Optional<PublicKey> mlDsaPublicKeyActual = serverPublicKeysActual.getPublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA);
+        assertFalse(mlDsaPublicKeyActual.isEmpty());
+        final byte[] mlDsaPublicKeyActualBytes = mlDsaPublicKeyActual.get().getEncoded();
+        assertEquals(ECDSA_PUBLIC_KEY, Base64.getEncoder().encodeToString(ecdsaPublicKeyActualBytes));
+        assertEquals(MLDSA_PUBLIC_KEY, Base64.getEncoder().encodeToString(mlDsaPublicKeyActualBytes));
+    }
+
+    @Test
+    void testConversionBothWays() throws Exception {
+        final PublicKeyRegistry keysExpected = serverPublicKeysConverter.deserialize(SERVER_PUBLIC_KEYS_JSON.getBytes(StandardCharsets.UTF_8));
+        final String serializedKeys = serverPublicKeysConverter.toDBValue(keysExpected);
+        final PublicKeyRegistry keysActual = serverPublicKeysConverter.fromDBValue(serializedKeys);
+        assertEquals(keysExpected, keysActual);
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2018 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,8 +14,9 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
-package com.wultra.security.powerauth.app.server;
+package com.wultra.security.powerauth.app.server.converter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -28,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeyConverter;
 import com.wultra.security.powerauth.app.server.database.model.ServerPrivateKey;
 import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
@@ -64,7 +64,7 @@ class ServerPrivateKeyConverterTest {
     @Test
     void testEncryptionAndDecryptionSuccess() throws Exception {
         byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(SERVER_PRIVATE_KEY_PLAIN);
-        final ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes,USER_ID, ACTIVATION_ID);
+        final ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, USER_ID, ACTIVATION_ID);
         assertEquals(EncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.encryptionMode());
         assertNotEquals(SERVER_PRIVATE_KEY_PLAIN, serverPrivateKeyEncrypted.serverPrivateKeyBase64());
 

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
@@ -96,12 +96,7 @@ class ServerPrivateKeyConverterTest {
 
         assertEquals(EncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.encryptionMode());
 
-        try {
-            String decryptedPrivateKeyBase64 = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-            assertNotEquals(decryptedPrivateKeyBase64, SERVER_PRIVATE_KEY_PLAIN);
-        } catch (GenericServiceException ex) {
-            assertEquals("Generic cryptography error occurred.", ex.getMessage());
-        }
+        assertThrows(GenericServiceException.class, () -> serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverterTest.java
@@ -85,8 +85,9 @@ class ServerPrivateKeyConverterTest {
         final ServerPrivateKey serverPrivateKeyEncrypted = serverPrivateKeyConverter.toDBValue(serverPrivateKeyBytes, USER_ID, ACTIVATION_ID);
 
         assertEquals(EncryptionMode.AES_HMAC, serverPrivateKeyEncrypted.encryptionMode());
-        assertThrows(GenericServiceException.class, () ->
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () ->
             serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, "test2", ACTIVATION_ID));
+        assertEquals("Generic cryptography error occurred.", exception.getMessage());
     }
 
     @Test

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
@@ -81,7 +81,7 @@ class ServerPrivateKeysConverterTest {
         final byte[] ecdsaPrivateKeyActualBytes = KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecdsaPrivateKeyActual.get());
         final Optional<PrivateKey> mlDsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA);
         assertFalse(mlDsaPrivateKeyActual.isEmpty());
-        final byte[] mlDsaPrivateKeyActualBytes = mlDsaPrivateKeyActual.get().getEncoded();
+        final byte[] mlDsaPrivateKeyActualBytes = KEY_CONVERTOR_PQC_DSA.convertPrivateKeyToBytes(mlDsaPrivateKeyActual.get());
         assertEquals(ECDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(ecdsaPrivateKeyActualBytes));
         assertEquals(MLDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(mlDsaPrivateKeyActualBytes));
     }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
@@ -127,12 +127,7 @@ class ServerPrivateKeysConverterTest {
 
         assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
 
-        try {
-            final PrivateKeyRegistry decryptedPrivateKeys = privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-            assertFalse(Arrays.equals(SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8), privateKeysConverter.serialize(decryptedPrivateKeys)));
-        } catch (GenericServiceException ex) {
-            assertEquals("Generic cryptography error occurred.", ex.getMessage());
-        }
+        assertThrows(GenericServiceException.class, () -> privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverterTest.java
@@ -1,0 +1,138 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.security.PrivateKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link ServerPrivateKeysConverter}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class ServerPrivateKeysConverterTest {
+
+    private static final String ECDSA_PRIVATE_KEY = "APud3uNeR8GEImzD1J5xNQLOhykQp/YgajkL1nmvprn0xLsFjFVKPy9Gxbr2EBqBgw==";
+    private static final String MLDSA_PRIVATE_KEY = "MDICAQAwCwYJYIZIAWUDBAMSBCDOgf2hERMl/CNLbwJCUlgQpB709Z0dxnmdAcs5k/PjvA==";
+
+    private static final String SERVER_PRIVATE_KEYS_JSON = "{\"privateKeys\":{\"EC_P384_ML_L3\":{\"ECDSA\":\"" + ECDSA_PRIVATE_KEY + "\",\"MLDSA\":\"" + MLDSA_PRIVATE_KEY + "\"}}}";
+    private static final String SERVER_PRIVATE_KEYS_ENCRYPTED = "8mYh1MO6WZUUwysE+a0ClyLaGgWtqjJ/NoBTeTL6+ftOTV2vEmvFjeqoDVSOursuvZFAZjKvCwSh0H9h4E5W0zujiUS57xO6NbQ7Vm8UFIUbBDg2Z+rdxU0Pa3EiEkeRQYbrI66KWmVqvtz0M9F1veh9yAxexu67Mo/02eBIRuw89DuAMBO9FN8YEm5a/NvFb4olasJwAKjsCyAaX8k+TcLfj0sa8wZYUWPtT6SdKcGF6V2O0euOKNbB2KyyV5Cz4OVZRj6AimlPaFLnsG8fjary8013Q+fkvRvxgI8dDRM=";
+
+    private static final String USER_ID = "test";
+
+    private static final String ACTIVATION_ID = "015286e0-e1c5-4ee1-8d1b-c6947cab0a56";
+
+    @Autowired
+    private ServerPrivateKeysConverter privateKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Test
+    void testFromDbValueNoEncryption() throws Exception {
+        final PrivateKeyRegistry keyRegistry = new PrivateKeyRegistry();
+        final PrivateKey ecdsaPrivateKey = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        keyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, ecdsaPrivateKey);
+        final PrivateKey mlDsaPrivateKey = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        keyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, mlDsaPrivateKey);
+        final byte[] keyRegistryBytes = privateKeysConverter.serialize(keyRegistry);
+        final String keyRegistryBase64 = Base64.getEncoder().encodeToString(keyRegistryBytes);
+        final PrivateKeys privateKeysEncrypted = new PrivateKeys(EncryptionMode.NO_ENCRYPTION, keyRegistryBase64);
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, ACTIVATION_ID);
+        final Optional<PrivateKey> ecdsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA);
+        assertFalse(ecdsaPrivateKeyActual.isEmpty());
+        final byte[] ecdsaPrivateKeyActualBytes = KEY_CONVERTOR_EC.convertPrivateKeyToBytes(ecdsaPrivateKeyActual.get());
+        final Optional<PrivateKey> mlDsaPrivateKeyActual = serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA);
+        assertFalse(mlDsaPrivateKeyActual.isEmpty());
+        final byte[] mlDsaPrivateKeyActualBytes = mlDsaPrivateKeyActual.get().getEncoded();
+        assertEquals(ECDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(ecdsaPrivateKeyActualBytes));
+        assertEquals(MLDSA_PRIVATE_KEY, Base64.getEncoder().encodeToString(mlDsaPrivateKeyActualBytes));
+    }
+
+    @Test
+    void testEncryptionAndDecryptionSuccess() throws Exception {
+        final byte[] serverPrivateKeysBytes = SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8);
+        final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, USER_ID, ACTIVATION_ID);
+        assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
+        assertNotEquals(SERVER_PRIVATE_KEYS_JSON, privateKeysEncrypted.privateKeysBase64());
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, ACTIVATION_ID);
+        final PrivateKey privateKeyEcExpected = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        assertEquals(privateKeyEcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA).get());
+        final PrivateKey privateKeyPqcExpected = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        assertEquals(privateKeyPqcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA).get());
+    }
+
+    @Test
+    void testFromDbValueEncryption() throws Exception {
+        final PrivateKeys privateKeysEncrypted = new PrivateKeys(EncryptionMode.AES_HMAC, SERVER_PRIVATE_KEYS_ENCRYPTED);
+        final PrivateKeyRegistry serverPrivateKeysActual = privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, ACTIVATION_ID);
+        assertArrayEquals(SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8), privateKeysConverter.serialize(serverPrivateKeysActual));
+        final PrivateKey privateKeyEcExpected = KEY_CONVERTOR_EC.convertBytesToPrivateKey(EcCurve.P384, Base64.getDecoder().decode(ECDSA_PRIVATE_KEY));
+        assertEquals(privateKeyEcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA).get());
+        final PrivateKey privateKeyPqcExpected = KEY_CONVERTOR_PQC_DSA.convertBytesToPrivateKey(Base64.getDecoder().decode(MLDSA_PRIVATE_KEY));
+        assertEquals(privateKeyPqcExpected, serverPrivateKeysActual.getPrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA).get());
+    }
+
+    @Test
+    void testEncryptionAndDecryptionDifferentUserFail() throws Exception {
+        final byte[] serverPrivateKeysBytes = SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8);
+        final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, USER_ID, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+            privateKeysConverter.fromDBValue(privateKeysEncrypted, "test2", ACTIVATION_ID));
+    }
+
+    @Test
+    void testEncryptionAndDecryptionDifferentActivationFailServerPrivateKeysConverter() throws Exception {
+        final byte[] serverPrivateKeysBytes = SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8);
+        final PrivateKeys privateKeysEncrypted = privateKeysConverter.toDBValue(serverPrivateKeysBytes, USER_ID, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, privateKeysEncrypted.encryptionMode());
+
+        try {
+            final PrivateKeyRegistry decryptedPrivateKeys = privateKeysConverter.fromDBValue(privateKeysEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+            assertFalse(Arrays.equals(SERVER_PRIVATE_KEYS_JSON.getBytes(StandardCharsets.UTF_8), privateKeysConverter.serialize(decryptedPrivateKeys)));
+        } catch (GenericServiceException ex) {
+            assertEquals("Generic cryptography error occurred.", ex.getMessage());
+        }
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
@@ -93,7 +93,8 @@ class SharedSecretConverterTest {
 
         assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
 
-        assertThrows(GenericServiceException.class, () -> sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
+        assertEquals("Generic cryptography error occurred.", exception.getMessage());
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
@@ -1,0 +1,104 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.converter;
+
+import com.wultra.security.powerauth.app.server.database.model.SharedSecret;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link com.wultra.security.powerauth.app.server.converter.SharedSecretConverter}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class SharedSecretConverterTest {
+
+    private static final String SHARED_SECRET_BASE64 = "G9Pa9bVMtZMTH04QQ+69yvaLGqeKFFan3bsfluA10qiYbc/kEsJK0oFINkyc19MMo1mr53BnrSpZ3IZre0MZVpxhq15cjDHJJ6lk/Q3dO8w=";
+
+    private static final String SHARED_SECRET_ENCRYPTED = "KzfTnYq9toTVkmJleGrx03u2XZX1ky9CBOSU/hP/TKOoZpwSawcIzzvhevYfVTRrw58CtumNsLPkEn0NNXDrUc1PdVpbF0FEo1cTVNvItoWe5LRQYEvMddBrQ/W/bpX0MlVWjTVQj2mZDhlaC7DHIQ==";
+
+    private static final String USER_ID = "test";
+
+    private static final String ACTIVATION_ID = "015286e0-e1c5-4ee1-8d1b-c6947cab0a56";
+
+    @Autowired
+    private SharedSecretConverter sharedSecretConverter;
+
+    @Test
+    void testFromDbValueNoEncryption() throws Exception {
+        final SharedSecret sharedSecret = new SharedSecret(EncryptionMode.NO_ENCRYPTION, SHARED_SECRET_BASE64);
+        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecret, USER_ID, ACTIVATION_ID);
+
+        assertEquals(SHARED_SECRET_BASE64, sharedSecretActual);
+    }
+
+    @Test
+    void testEncryptionAndDecryptionSuccess() throws Exception {
+        byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
+        assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+        assertNotEquals(SHARED_SECRET_BASE64, sharedSecretEncrypted.sharedSecretBase64());
+
+        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, ACTIVATION_ID);
+        assertEquals(SHARED_SECRET_BASE64, sharedSecretActual);
+    }
+
+    @Test
+    void testFromDbValueEncryption() throws Exception {
+        final SharedSecret sharedSecretEncrypted = new SharedSecret(EncryptionMode.AES_HMAC, SHARED_SECRET_ENCRYPTED);
+        final String result = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, ACTIVATION_ID);
+        assertEquals(SHARED_SECRET_BASE64, result);
+    }
+
+    @Test
+    void testEncryptionAndDecryptionDifferentUserFail() throws Exception {
+        final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, "test2", ACTIVATION_ID));
+    }
+
+    @Test
+    void testEncryptionAndDecryptionDifferentActivationFailServerSharedSecretConverter() throws Exception {
+        final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+
+        try {
+            String decryptedSharedSecretBase64 = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
+            assertNotEquals(decryptedSharedSecretBase64, SHARED_SECRET_BASE64);
+        } catch (GenericServiceException ex) {
+            assertEquals("Generic cryptography error occurred.", ex.getMessage());
+        }
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
@@ -93,12 +93,7 @@ class SharedSecretConverterTest {
 
         assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
 
-        try {
-            String decryptedSharedSecretBase64 = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56");
-            assertNotEquals(decryptedSharedSecretBase64, SHARED_SECRET_BASE64);
-        } catch (GenericServiceException ex) {
-            assertEquals("Generic cryptography error occurred.", ex.getMessage());
-        }
+        assertThrows(GenericServiceException.class, () -> sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
     }
 
 }


### PR DESCRIPTION
This PR contains following updates:

- updated entity classess for new DB schema
- private key and public key converters with optional encryption, to be used later on
- serialization and deserialization of multiple keys into a common JSON structure
- tests for conversions and encryption