### PR TITLE
Fix #1819: Implement E2EE for crypto4

### DIFF
--- a/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml
@@ -19,4 +19,16 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="2" logicalFilePath="powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <columnExists tableName="pa_temporary_key" columnName="private_key_base64" />
+                <columnExists tableName="pa_temporary_key" columnName="public_key_base64" />
+            </and>
+        </preConditions>
+        <comment>Change the temporary keypair columns to nullable in pa_temporary_key table</comment>
+        <dropNotNullConstraint tableName="pa_temporary_key" columnName="private_key_base64" columnDataType="varchar(255)" />
+        <dropNotNullConstraint tableName="pa_temporary_key" columnName="public_key_base64" columnDataType="varchar(255)" />
+    </changeSet>
+
 </databaseChangeLog>

--- a/docs/sql/mssql/create_schema.sql
+++ b/docs/sql/mssql/create_schema.sql
@@ -575,3 +575,18 @@ GO
 ALTER TABLE pa_activation ADD knowledge_factor_key_next varchar(255);
 GO
 
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_temporary_key ADD secret_key_base64 varchar(255);
+GO
+
+ALTER TABLE pa_temporary_key ADD secret_key_encryption int CONSTRAINT DF_pa_temporary_key_secret_key_encryption DEFAULT 0 NOT NULL;
+GO
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key ALTER COLUMN private_key_base64 varchar(255) NULL;
+GO
+
+ALTER TABLE pa_temporary_key ALTER COLUMN public_key_base64 varchar(255) NULL;
+GO

--- a/docs/sql/mssql/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/mssql/migration_1.9.0_2.0.0.sql
@@ -58,3 +58,11 @@ GO
 
 ALTER TABLE pa_temporary_key ADD secret_key_encryption int CONSTRAINT DF_pa_temporary_key_secret_key_encryption DEFAULT 0 NOT NULL;
 GO
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key ALTER COLUMN private_key_base64 varchar(255) NULL;
+GO
+
+ALTER TABLE pa_temporary_key ALTER COLUMN public_key_base64 varchar(255) NULL;
+GO

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -456,3 +456,15 @@ ALTER TABLE pa_activation ADD biometric_factor_key_next VARCHAR2(255);
 ALTER TABLE pa_activation ADD knowledge_factor_key VARCHAR2(255);
 
 ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR2(255);
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_temporary_key ADD secret_key_base64 VARCHAR2(255);
+
+ALTER TABLE pa_temporary_key ADD secret_key_encryption INTEGER DEFAULT '0' NOT NULL;
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key MODIFY private_key_base64 NULL;
+
+ALTER TABLE pa_temporary_key MODIFY public_key_base64 NULL;

--- a/docs/sql/oracle/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/oracle/migration_1.9.0_2.0.0.sql
@@ -41,3 +41,9 @@ ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR2(255);
 ALTER TABLE pa_temporary_key ADD secret_key_base64 VARCHAR2(255);
 
 ALTER TABLE pa_temporary_key ADD secret_key_encryption INTEGER DEFAULT '0' NOT NULL;
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key MODIFY private_key_base64 NULL;
+
+ALTER TABLE pa_temporary_key MODIFY public_key_base64 NULL;

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -456,3 +456,15 @@ ALTER TABLE pa_activation ADD biometric_factor_key_next VARCHAR(255);
 ALTER TABLE pa_activation ADD knowledge_factor_key VARCHAR(255);
 
 ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR(255);
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::1::Roman Strobl
+-- Add columns for crypto4 shared secret storage to pa_temporary_key table
+ALTER TABLE pa_temporary_key ADD secret_key_base64 VARCHAR(255);
+
+ALTER TABLE pa_temporary_key ADD secret_key_encryption INTEGER DEFAULT 0 NOT NULL;
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key ALTER COLUMN  private_key_base64 DROP NOT NULL;
+
+ALTER TABLE pa_temporary_key ALTER COLUMN  public_key_base64 DROP NOT NULL;

--- a/docs/sql/postgresql/migration_1.9.0_2.0.0.sql
+++ b/docs/sql/postgresql/migration_1.9.0_2.0.0.sql
@@ -41,3 +41,9 @@ ALTER TABLE pa_activation ADD knowledge_factor_key_next VARCHAR(255);
 ALTER TABLE pa_temporary_key ADD secret_key_base64 VARCHAR(255);
 
 ALTER TABLE pa_temporary_key ADD secret_key_encryption INTEGER DEFAULT 0 NOT NULL;
+
+-- Changeset powerauth-java-server/2.0.x/20250320-crypto4-temporary-keys.xml::2::Roman Strobl
+-- Change the temporary keypair columns to nullable in pa_temporary_key table
+ALTER TABLE pa_temporary_key ALTER COLUMN  private_key_base64 DROP NOT NULL;
+
+ALTER TABLE pa_temporary_key ALTER COLUMN  public_key_base64 DROP NOT NULL;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v3/TemporaryPublicKeyRequestClaims.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v3/TemporaryPublicKeyRequestClaims.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2025 Wultra s.r.o.
+ * Copyright (C) 2024 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,31 +14,24 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.client.model.entity.v3;
 
-import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
 import lombok.Data;
 import lombok.ToString;
 
-import java.security.PrivateKey;
-
 /**
- * Temporary key result.
+ * Class used for holding the request claims (V3).
  *
- * @author Roman Strobl, roman.strobl@wultra.com
+ * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-public class TemporaryKeyResult {
+public class TemporaryPublicKeyRequestClaims {
 
+    private String applicationKey;
+    private String activationId;
     @ToString.Exclude
-    private byte[] secretKeyBytes;
-
-    @ToString.Exclude
-    private PrivateKey privateKey;
-
-    private SharedSecretRequest sharedSecretRequest;
+    private String challenge;
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v3/TemporaryPublicKeyResponseClaims.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v3/TemporaryPublicKeyResponseClaims.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2025 Wultra s.r.o.
+ * Copyright (C) 2024 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,31 +14,29 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.client.model.entity.v3;
 
-import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
 import lombok.Data;
 import lombok.ToString;
 
-import java.security.PrivateKey;
+import java.util.Date;
 
 /**
- * Temporary key result.
+ * Class for holding the temporary key response claims (V3).
  *
- * @author Roman Strobl, roman.strobl@wultra.com
+ * @author Petr Dvorak, petr@wultra.com
  */
 @Data
-public class TemporaryKeyResult {
+public class TemporaryPublicKeyResponseClaims {
 
+    private String applicationKey;
+    private String activationId;
     @ToString.Exclude
-    private byte[] secretKeyBytes;
-
-    @ToString.Exclude
-    private PrivateKey privateKey;
-
-    private SharedSecretRequest sharedSecretRequest;
+    private String challenge;
+    private String keyId;
+    private String publicKey;
+    private Date expiration;
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/SharedSecretRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/SharedSecretRequest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,24 +14,23 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
-package com.wultra.security.powerauth.client.model.entity;
+package com.wultra.security.powerauth.client.model.entity.v4;
 
 import lombok.Data;
-import lombok.ToString;
 
 /**
- * Class used for holding the request claims.
+ * Model class for shared secret request.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
-public class TemporaryPublicKeyRequestClaims {
+public class SharedSecretRequest {
 
-    private String applicationKey;
-    private String activationId;
-    @ToString.Exclude
-    private String challenge;
+    private String algorithm;
+    private String ecdhe;
+    private String mlkem;
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/SharedSecretResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/SharedSecretResponse.java
@@ -17,28 +17,19 @@
  *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.client.model.entity.v4;
 
-import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
 import lombok.Data;
-import lombok.ToString;
-
-import java.security.PrivateKey;
 
 /**
- * Temporary key result.
+ * Model class for shared secret response.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
-public class TemporaryKeyResult {
+public class SharedSecretResponse {
 
-    @ToString.Exclude
-    private byte[] secretKeyBytes;
-
-    @ToString.Exclude
-    private PrivateKey privateKey;
-
-    private SharedSecretRequest sharedSecretRequest;
-
+    private String ecdhe;
+    private String mlkem;
+    
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/TemporaryPublicKeyRequestClaims.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/TemporaryPublicKeyRequestClaims.java
@@ -17,24 +17,23 @@
  *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.client.model.entity.v4;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.experimental.SuperBuilder;
-
-import java.security.PublicKey;
+import lombok.ToString;
 
 /**
- * Hybrid public key wrapper.
+ * Class used for holding the request claims (V4).
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
-@EqualsAndHashCode(callSuper = true)
-@SuperBuilder
-public class HybridPublicKey extends BasePublicKey {
+public class TemporaryPublicKeyRequestClaims {
 
-    private PublicKey ecPublicKey;
-    private PublicKey mlPublicKey;
+    private String applicationKey;
+    private String activationId;
+    @ToString.Exclude
+    private String challenge;
+    private SharedSecretRequest sharedSecretRequest;
+
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/TemporaryPublicKeyResponseClaims.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/entity/v4/TemporaryPublicKeyResponseClaims.java
@@ -17,28 +17,27 @@
  *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.client.model.entity.v4;
 
-import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
 import lombok.Data;
 import lombok.ToString;
 
-import java.security.PrivateKey;
+import java.util.Date;
 
 /**
- * Temporary key result.
+ * Class for holding the temporary key response claims (V4).
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
-public class TemporaryKeyResult {
+public class TemporaryPublicKeyResponseClaims {
 
+    private String applicationKey;
+    private String activationId;
     @ToString.Exclude
-    private byte[] secretKeyBytes;
-
-    @ToString.Exclude
-    private PrivateKey privateKey;
-
-    private SharedSecretRequest sharedSecretRequest;
+    private String challenge;
+    private String keyId;
+    private SharedSecretResponse sharedSecretResponse;
+    private Date expiration;
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v3/EciesController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v3/EciesController.java
@@ -23,12 +23,11 @@ import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRe
 import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
 import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
-import com.wultra.security.powerauth.app.server.service.behavior.tasks.EciesEncryptionBehavior;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.v3.EncryptionBehaviorEcies;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,7 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class EciesController {
 
-    private final EciesEncryptionBehavior service;
+    private final EncryptionBehaviorEcies service;
 
     /**
      * Create ECIES decryptor.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v3/TemporaryKeyController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v3/TemporaryKeyController.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.wultra.security.powerauth.app.server.controller.api;
+package com.wultra.security.powerauth.app.server.controller.api.v3;
 
 import com.wultra.security.powerauth.client.model.request.RemoveTemporaryPublicKeyRequest;
 import com.wultra.security.powerauth.client.model.request.TemporaryPublicKeyRequest;
@@ -24,12 +24,11 @@ import com.wultra.security.powerauth.client.model.response.RemoveTemporaryPublic
 import com.wultra.security.powerauth.client.model.response.TemporaryPublicKeyResponse;
 import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
-import com.wultra.security.powerauth.app.server.service.behavior.tasks.TemporaryKeyBehavior;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.v3.TemporaryKeyBehaviorEcies;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,15 +40,15 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * @author Petr Dvorak, petr@wultra.com
  */
-@RestController("temporaryKeyController")
-@RequestMapping({"/rest/v3/keystore", "/rest/v4/keystore"})
-@Tag(name = "PowerAuth ECIES Temporary Key Controller")
+@RestController("temporaryKeyControllerV3")
+@RequestMapping("/rest/v3/keystore")
+@Tag(name = "PowerAuth Temporary Key Controller (V3)")
 @AllArgsConstructor
 @Validated
 @Slf4j
 public class TemporaryKeyController {
 
-    private final TemporaryKeyBehavior service;
+    private final TemporaryKeyBehaviorEcies service;
 
     /**
      * Create temporary key.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/EncryptorController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/EncryptorController.java
@@ -21,14 +21,13 @@ package com.wultra.security.powerauth.app.server.controller.api.v4;
 
 import com.wultra.core.rest.model.base.request.ObjectRequest;
 import com.wultra.core.rest.model.base.response.ObjectResponse;
-import com.wultra.security.powerauth.app.server.service.behavior.tasks.EciesEncryptionBehavior;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.v4.EncryptionBehaviorAead;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -38,7 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * Controller managing the endpoints related to encryptor shared secret initialization.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @RestController("encryptorControllerV4")
 @RequestMapping("/rest/v4/encryptor")
@@ -48,8 +47,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class EncryptorController {
 
-    // TODO
-    private final EciesEncryptionBehavior service;
+    private final EncryptionBehaviorAead service;
 
     /**
      * Create AEAD encryptor.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/EncryptorController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/EncryptorController.java
@@ -59,11 +59,11 @@ public class EncryptorController {
     @PostMapping
     public ObjectResponse<ExtractEncryptorResponse> extractEncryptor(@Valid @RequestBody ObjectRequest<ExtractEncryptorRequest> request) throws Exception {
         final ExtractEncryptorRequest req = request.getRequestObject();
-        logger.info("action: getEncryptor, state: initiated, applicationKey: {}", req.getApplicationKey());
-        logger.debug("action: getEncryptor, state: initiated, request: {}", request);
+        logger.info("action: extractEncryptor, state: initiated, applicationKey: {}", req.getApplicationKey());
+        logger.debug("action: extractEncryptor, state: initiated, request: {}", request);
         final ObjectResponse<ExtractEncryptorResponse> response = new ObjectResponse<>(service.extractEncryptor(req));
-        logger.info("action: getEncryptor, state: succeeded");
-        logger.debug("action: getEncryptor, state: succeeded, response: {}", response);
+        logger.info("action: extractEncryptor, state: succeeded");
+        logger.debug("action: extractEncryptor, state: succeeded, response: {}", response);
         return response;
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/TemporaryKeyController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/TemporaryKeyController.java
@@ -1,0 +1,89 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.controller.api.v4;
+
+import com.wultra.core.rest.model.base.request.ObjectRequest;
+import com.wultra.core.rest.model.base.response.ObjectResponse;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.v4.TemporaryKeyBehaviorAead;
+import com.wultra.security.powerauth.client.model.request.RemoveTemporaryPublicKeyRequest;
+import com.wultra.security.powerauth.client.model.request.TemporaryPublicKeyRequest;
+import com.wultra.security.powerauth.client.model.response.RemoveTemporaryPublicKeyResponse;
+import com.wultra.security.powerauth.client.model.response.TemporaryPublicKeyResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller managing the endpoints related to temporary keys.
+ *
+ * @author Petr Dvorak, petr@wultra.com
+ */
+@RestController("temporaryKeyControllerV4")
+@RequestMapping("/rest/v4/keystore")
+@Tag(name = "PowerAuth Temporary Key Controller (V4)")
+@AllArgsConstructor
+@Validated
+@Slf4j
+public class TemporaryKeyController {
+
+    private final TemporaryKeyBehaviorAead service;
+
+    /**
+     * Create temporary key.
+     *
+     * @param request Get temporary key parameters for given request.
+     * @return Response with temporary key.
+     * @throws Exception In case the service throws exception.
+     */
+    @PostMapping("/create")
+    public ObjectResponse<TemporaryPublicKeyResponse> createTemporaryKey(@Valid @RequestBody ObjectRequest<TemporaryPublicKeyRequest> request) throws Exception {
+        final TemporaryPublicKeyRequest req = request.getRequestObject();
+        logger.info("action: createTemporaryKey, state: initiated");
+        logger.debug("action: createTemporaryKey, state: initiated, request: {}", request);
+        final ObjectResponse<TemporaryPublicKeyResponse> response = new ObjectResponse<>(service.requestTemporaryKey(req));
+        logger.info("action: createTemporaryKey, state: succeeded");
+        logger.debug("action: createTemporaryKey, state: succeeded, response: {}", response);
+        return response;
+    }
+
+    /**
+     * Delete temporary key.
+     *
+     * @param request Delete temporary key with given ID.
+     * @return Response with deletion result.
+     */
+    @PostMapping("/remove")
+    public ObjectResponse<RemoveTemporaryPublicKeyResponse> deleteTemporaryKey(@Valid @RequestBody ObjectRequest<RemoveTemporaryPublicKeyRequest> request) {
+        final RemoveTemporaryPublicKeyRequest req = request.getRequestObject();
+        logger.info("action: deleteTemporaryKey, state: initiated, temporaryKeyId: {}", req.getId());
+        logger.debug("action: deleteTemporaryKey, state: initiated, request: {}", request);
+        final ObjectResponse<RemoveTemporaryPublicKeyResponse> response = new ObjectResponse<>(service.removeTemporaryKey(req));
+        logger.info("action: deleteTemporaryKey, state: succeeded");
+        logger.debug("action: deleteTemporaryKey, state: succeeded, response: {}", response);
+        return response;
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/MasterPrivateKeysConverter.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
 import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import lombok.extern.slf4j.Slf4j;
@@ -45,11 +45,11 @@ import java.util.function.Supplier;
 @Slf4j
 public class MasterPrivateKeysConverter {
 
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public MasterPrivateKeysConverter(EncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
+    public MasterPrivateKeysConverter(DatabaseEncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
         this.encryptionService = encryptionService;
         this.objectMapper = objectMapper;
     }
@@ -67,8 +67,27 @@ public class MasterPrivateKeysConverter {
             final byte[] decrypted = encryptionService.decrypt(data, masterPrivateKeys.encryptionMode(), createEncryptionKeyProvider(applicationId));
             return deserialize(decrypted);
         } catch (IOException e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("Decryption failed", e);
             throw new GenericServiceException(ServiceError.DECRYPTION_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Convert master private keys to composite database value. Private key is encrypted
+     * in case master DB encryption key is configured in PA server configuration.
+     * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
+     * the transaction is not rolled back.
+     * @param masterPrivateKeys Master private key registry.
+     * @param applicationId Application ID used for derivation of secret key.
+     * @return Private key as composite database value.
+     * @throws GenericServiceException Thrown when private keys encryption fails.
+     */
+    public PrivateKeys toDBValue(final PrivateKeyRegistry masterPrivateKeys, final String applicationId) throws GenericServiceException {
+        try {
+            return toDBValue(serialize(masterPrivateKeys), applicationId);
+        } catch (IOException e) {
+            logger.warn("Encryption failed", e);
+            throw new GenericServiceException(ServiceError.ENCRYPTION_FAILED, e.getMessage());
         }
     }
 
@@ -82,7 +101,7 @@ public class MasterPrivateKeysConverter {
      * @return Private key as composite database value.
      * @throws GenericServiceException Thrown when private keys encryption fails.
      */
-    public PrivateKeys toDBValue(final byte[] masterPrivateKeysBytes, final String applicationId) throws GenericServiceException {
+    PrivateKeys toDBValue(final byte[] masterPrivateKeysBytes, final String applicationId) throws GenericServiceException {
         final EncryptableData encryptable = encryptionService.encrypt(masterPrivateKeysBytes, createEncryptionKeyProvider(applicationId));
         return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
     }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/PublicKeysConverter.java
@@ -57,7 +57,7 @@ public class PublicKeysConverter {
             final byte[] data = convertFromBase64(serverPublicKeysBase64);
             return deserialize(data);
         } catch (IOException e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("Deserialization failed", e);
             throw new GenericServiceException(ServiceError.INVALID_KEY_FORMAT, e.getMessage());
         }
     }
@@ -72,7 +72,7 @@ public class PublicKeysConverter {
         try {
             return convertToBase64(serialize(publicKeys));
         } catch (IOException e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("Serialization failed", e);
             throw new GenericServiceException(ServiceError.INVALID_KEY_FORMAT, e.getMessage());
         }
     }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeyConverter.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.app.server.converter;
 
 import com.wultra.security.powerauth.app.server.database.model.ServerPrivateKey;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 @AllArgsConstructor
 public class ServerPrivateKeyConverter {
 
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
 
     /**
      * Convert server private key from composite database value to Base64-encoded string value.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/ServerPrivateKeysConverter.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
 import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import lombok.extern.slf4j.Slf4j;
@@ -45,18 +45,18 @@ import java.util.function.Supplier;
 @Slf4j
 public class ServerPrivateKeysConverter {
 
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
     private final ObjectMapper objectMapper;
 
     @Autowired
-    public ServerPrivateKeysConverter(EncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
+    public ServerPrivateKeysConverter(DatabaseEncryptionService encryptionService, @Qualifier("privateKeyObjectMapper") ObjectMapper objectMapper) {
         this.encryptionService = encryptionService;
         this.objectMapper = objectMapper;
     }
 
     /**
-     * Convert private keys from composite database value to object.
-     * @param privateKeys Private keys composite database value for private keys and encryption mode.
+     * Convert server private keys from composite database value to object.
+     * @param privateKeys Server private keys composite database value for private keys and encryption mode.
      * @param userId User ID used for derivation of secret key.
      * @param activationId Activation ID used for derivation of secret key.
      * @return Decrypted private keys.
@@ -68,8 +68,28 @@ public class ServerPrivateKeysConverter {
             final byte[] decrypted = encryptionService.decrypt(data, privateKeys.encryptionMode(), createEncryptionKeyProvider(userId, activationId));
             return deserialize(decrypted);
         } catch (IOException e) {
-            logger.warn(e.getMessage(), e);
+            logger.warn("Decryption failed", e);
             throw new GenericServiceException(ServiceError.DECRYPTION_FAILED, e.getMessage());
+        }
+    }
+
+    /**
+     * Convert private keys to composite database value. Private keys are encrypted
+     * in case master DB encryption key is configured in PA server configuration.
+     * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
+     * the transaction is not rolled back.
+     * @param serverPrivateKeys Server private key registry.
+     * @param userId User ID used for derivation of secret key.
+     * @param activationId Activation ID used for derivation of secret key.
+     * @return Private keys as composite database value.
+     * @throws GenericServiceException Thrown when private keys encryption fails.
+     */
+    public PrivateKeys toDBValue(final PrivateKeyRegistry serverPrivateKeys, final String userId, final String activationId) throws GenericServiceException {
+        try {
+            return toDBValue(serialize(serverPrivateKeys), userId, activationId);
+        } catch (IOException e) {
+            logger.warn("Encryption failed", e);
+            throw new GenericServiceException(ServiceError.ENCRYPTION_FAILED, e.getMessage());
         }
     }
 
@@ -84,7 +104,7 @@ public class ServerPrivateKeysConverter {
      * @return Private keys as composite database value.
      * @throws GenericServiceException Thrown when private keys encryption fails.
      */
-    public PrivateKeys toDBValue(final byte[] privateKeysBytes, final String userId, final String activationId) throws GenericServiceException {
+    PrivateKeys toDBValue(final byte[] privateKeysBytes, final String userId, final String activationId) throws GenericServiceException {
         final EncryptableData encryptable = encryptionService.encrypt(privateKeysBytes, createEncryptionKeyProvider(userId, activationId));
         return new PrivateKeys(encryptable.encryptionMode(), convertToBase64(encryptable.encryptedData()));
     }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverter.java
@@ -20,7 +20,7 @@ package com.wultra.security.powerauth.app.server.converter;
 
 import com.wultra.security.powerauth.app.server.database.model.SharedSecret;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,19 +40,20 @@ import java.util.function.Supplier;
 @AllArgsConstructor
 public class SharedSecretConverter {
 
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
 
     /**
      * Convert shared secret from composite database value to Base64-encoded string value.
      * @param sharedSecret Shared secret composite database value shared secret and encryption mode.
-     * @param userId User ID used for derivation of secret key.
+     * @param keyId Key ID.
+     * @param appKey App key.
      * @param activationId Activation ID used for derivation of secret key.
      * @return Decrypted Base64-encoded shared secret.
      * @throws GenericServiceException In case shared secret decryption fails.
      */
-    public String fromDBValue(final SharedSecret sharedSecret, final String userId, final String activationId) throws GenericServiceException {
+    public String fromDBValue(final SharedSecret sharedSecret, final String keyId, final String appKey, final String activationId) throws GenericServiceException {
         final byte[] data = convert(sharedSecret.sharedSecretBase64());
-        final byte[] decrypted = encryptionService.decrypt(data, sharedSecret.encryptionMode(), createEncryptionKeyProvider(userId, activationId));
+        final byte[] decrypted = encryptionService.decrypt(data, sharedSecret.encryptionMode(), createSecretKeyDerivationInput(keyId, appKey, activationId));
         return convert(decrypted);
     }
 
@@ -62,13 +63,14 @@ public class SharedSecretConverter {
      * The method should be called before writing to the database because the GenericServiceException can be thrown. This could lead to a database inconsistency because
      * the transaction is not rolled back.
      * @param sharedSecret Shared secret value.
-     * @param userId User ID used for derivation of secret key.
+     * @param keyId Key ID.
+     * @param appKey App Key.
      * @param activationId Activation ID used for derivation of secret key.
      * @return Shared secret as composite database value.
      * @throws GenericServiceException Thrown when shared secret encryption fails.
      */
-    public SharedSecret toDBValue(final byte[] sharedSecret, final String userId, final String activationId) throws GenericServiceException {
-        final EncryptableData encryptable = encryptionService.encrypt(sharedSecret, createEncryptionKeyProvider(userId, activationId));
+    public SharedSecret toDBValue(final byte[] sharedSecret, String keyId, String appKey, String activationId) throws GenericServiceException {
+        final EncryptableData encryptable = encryptionService.encrypt(sharedSecret, createSecretKeyDerivationInput(keyId, appKey, activationId));
         return new SharedSecret(encryptable.encryptionMode(), convert(encryptable.encryptedData()));
     }
 
@@ -80,8 +82,12 @@ public class SharedSecretConverter {
         return Base64.getDecoder().decode(source);
     }
 
-    private static Supplier<List<String>> createEncryptionKeyProvider(final String userId, final String activationId) {
-        return () -> List.of(userId, activationId);
+    private static Supplier<List<String>> createSecretKeyDerivationInput(final String keyId, final String appKey, final String activationId) {
+        if (activationId != null) {
+            return () -> List.of(keyId, appKey, activationId);
+        } else {
+            return () -> List.of(keyId, appKey);
+        }
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/TemporaryPrivateKeyConverter.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/converter/TemporaryPrivateKeyConverter.java
@@ -19,7 +19,7 @@ package com.wultra.security.powerauth.app.server.converter;
 
 import com.wultra.security.powerauth.app.server.database.model.ServerPrivateKey;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableData;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +39,7 @@ import java.util.function.Supplier;
 @AllArgsConstructor
 public class TemporaryPrivateKeyConverter {
 
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
 
     /**
      * Convert server private key from composite database value to Base64-encoded string value.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/TemporaryKeyEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/TemporaryKeyEntity.java
@@ -71,13 +71,13 @@ public class TemporaryKeyEntity implements Serializable {
     /**
      * Temporary private key.
      */
-    @Column(name = "private_key_base64", nullable = false)
+    @Column(name = "private_key_base64")
     private String privateKeyBase64;
 
     /**
      * Temporary public key.
      */
-    @Column(name = "public_key_base64", nullable = false)
+    @Column(name = "public_key_base64")
     private String publicKeyBase64;
 
     /**

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -50,7 +50,6 @@ import com.wultra.security.powerauth.client.model.entity.Activation;
 import com.wultra.security.powerauth.client.model.enumeration.ActivationProtocol;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.request.v3.CreateActivationRequest;
-import com.wultra.security.powerauth.client.model.request.v3.PrepareActivationRequest;
 import com.wultra.security.powerauth.client.model.response.*;
 import com.wultra.security.powerauth.client.model.response.v3.CreateActivationResponse;
 import com.wultra.security.powerauth.client.model.response.v4.PrepareActivationResponse;
@@ -814,7 +813,7 @@ public class ActivationServiceBehavior {
             }
 
             // TODO - v4 support
-            cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).generateDeviceKeyPair(activation);
+            cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).generateServerKeyPair(activation);
 
             activationHistoryServiceBehavior.saveActivationAndLogChange(activation);
             callbackUrlBehavior.notifyCallbackListenersOnActivationChange(activation);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -25,6 +25,7 @@ import com.wultra.security.powerauth.app.server.converter.ActivationCommitPhaseC
 import com.wultra.security.powerauth.app.server.converter.ActivationOtpValidationConverter;
 import com.wultra.security.powerauth.app.server.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.app.server.database.model.AdditionalInformation;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
@@ -957,7 +958,7 @@ public class ActivationServiceBehavior {
             // TODO - v4 support
             BasePublicKey devicePublicKey = null;
             try {
-                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(devicePublicKeyBytes);
+                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(KeyType.ECDSA, devicePublicKeyBytes);
             } catch (GenericServiceException e) {
                 logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
                 logger.debug("Invalid public key, activation ID: {}", activation.getActivationId(), e);
@@ -1137,7 +1138,7 @@ public class ActivationServiceBehavior {
             // TODO - v4 support
             BasePublicKey devicePublicKey = null;
             try {
-                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(devicePublicKeyBytes);
+                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(KeyType.ECDSA, devicePublicKeyBytes);
             } catch (GenericServiceException e) {
                 logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
                 logger.debug("Invalid public key, activation ID: {}", activation.getActivationId(), e);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationServiceBehavior.java
@@ -36,6 +36,7 @@ import com.wultra.security.powerauth.app.server.database.repository.ActivationRe
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationRepository;
 import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.EncryptionServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.exceptions.RollbackingServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
@@ -120,6 +121,7 @@ public class ActivationServiceBehavior {
     private final ApplicationRepository applicationRepository;
     private final ActivationRepository activationRepository;
     private final CryptographyServiceFactory cryptographyServiceFactory;
+    private final EncryptionServiceEcies encryptionService;
 
     // Prepare converters
     private final ActivationStatusConverter activationStatusConverter = new ActivationStatusConverter();
@@ -901,7 +903,7 @@ public class ActivationServiceBehavior {
             // Decrypt activation data
             final EncryptionContext context = new EncryptionContext(protocolVersion, applicationKey, null, EncryptorId.ACTIVATION_LAYER_2);
             // TODO - v4 support
-            final DecryptionResult decryptionResult = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).decryptRequest(encryptedRequest, context);
+            final DecryptionResult decryptionResult = encryptionService.decryptRequest(encryptedRequest, context);
             final ApplicationEntity application = decryptionResult.getApplication();
 
             // Convert JSON data to activation layer 2 request object
@@ -1082,7 +1084,7 @@ public class ActivationServiceBehavior {
             // Decrypt activation data
             final EncryptionContext context = new EncryptionContext(protocolVersion, applicationKey, null, EncryptorId.ACTIVATION_LAYER_2);
             // TODO - v4 support
-            final DecryptionResult decryptionResult = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).decryptRequest(encryptedRequest, context);
+            final DecryptionResult decryptionResult = encryptionService.decryptRequest(encryptedRequest, context);
             final ApplicationEntity application = decryptionResult.getApplication();
 
             // Prepare activation OTP mode

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -27,7 +27,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.TokenEntit
 import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.app.server.database.model.enumeration.UniqueValueType;
 import com.wultra.security.powerauth.app.server.database.repository.TokenRepository;
-import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.EncryptionServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -40,9 +40,9 @@ import com.wultra.security.powerauth.app.server.service.validator.ActivationCont
 import com.wultra.security.powerauth.client.model.enumeration.SignatureType;
 import com.wultra.security.powerauth.client.model.request.RemoveTokenRequest;
 import com.wultra.security.powerauth.client.model.request.ValidateTokenRequest;
-import com.wultra.security.powerauth.client.model.response.v3.CreateTokenResponse;
 import com.wultra.security.powerauth.client.model.response.RemoveTokenResponse;
 import com.wultra.security.powerauth.client.model.response.ValidateTokenResponse;
+import com.wultra.security.powerauth.client.model.response.v3.CreateTokenResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
@@ -50,7 +50,6 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncrypte
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.crypto.server.token.ServerTokenGenerator;
 import com.wultra.security.powerauth.crypto.server.token.ServerTokenVerifier;
 import lombok.AllArgsConstructor;
@@ -79,7 +78,7 @@ public class TokenBehavior {
     private final ReplayVerificationService replayVerificationService;
     private final ActivationContextValidator activationValidator;
     private final TokenRepository tokenRepository;
-    private final CryptographyServiceFactory cryptographyServiceFactory;
+    private final EncryptionServiceEcies encryptionService;
 
     // Business logic implementation classes
     private final ServerTokenGenerator tokenGenerator = new ServerTokenGenerator();
@@ -297,7 +296,7 @@ public class TokenBehavior {
 
             // TODO - v4 support
             final EncryptionContext context = new EncryptionContext(version, applicationKey, activationId, EncryptorId.CREATE_TOKEN);
-            final DecryptionResult decryptionResult = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).decryptRequest(encryptedRequest, context);
+            final DecryptionResult decryptionResult = encryptionService.decryptRequest(encryptedRequest, context);
 
             // Generate unique token ID.
             String tokenId = null;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/UpgradeServiceBehavior.java
@@ -25,6 +25,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.Applicatio
 import com.wultra.security.powerauth.app.server.database.repository.ActivationRepository;
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.EncryptionServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -43,7 +44,6 @@ import com.wultra.security.powerauth.crypto.lib.enums.ProtocolVersion;
 import com.wultra.security.powerauth.crypto.lib.generator.HashBasedCounter;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -66,6 +66,7 @@ public class UpgradeServiceBehavior {
     private final ActivationContextValidator activationValidator;
     private final ApplicationVersionRepository applicationVersionRepository;
     private final ActivationRepository activationRepository;
+    private final EncryptionServiceEcies encryptionService;
 
     // Helper classes
     private final ObjectMapper objectMapper;
@@ -113,7 +114,7 @@ public class UpgradeServiceBehavior {
             // Try to decrypt request data, the data must not be empty. Currently only '{}' is sent in request data. Ignore result of decryption.
             final EncryptionContext context = new EncryptionContext(protocolVersion, applicationKey, activationId, EncryptorId.UPGRADE);
             // TODO - v4 support
-            final DecryptionResult decryptionResult = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).decryptRequest(encryptedRequest, context);
+            final DecryptionResult decryptionResult = encryptionService.decryptRequest(encryptedRequest, context);
 
             // Request is valid, generate hash based counter if it does not exist yet
             final String ctrDataBase64;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/VaultUnlockServiceBehavior.java
@@ -26,6 +26,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.Applicatio
 import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.EncryptionServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -45,7 +46,6 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncrypte
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedResponse;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.crypto.server.vault.PowerAuthServerVault;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,6 +77,7 @@ public class VaultUnlockServiceBehavior {
     private final PowerAuthServiceConfiguration powerAuthServiceConfiguration;
     private final CryptographyServiceFactory cryptographyServiceFactory;
     private final ApplicationVersionRepository applicationVersionRepository;
+    private final EncryptionServiceEcies encryptionService;
 
     // Helper classes
     private final PowerAuthServerVault powerAuthServerVault = new PowerAuthServerVault();
@@ -154,7 +155,7 @@ public class VaultUnlockServiceBehavior {
             // Decrypt request to obtain vault unlock reason
             // TODO - v4 support
             final EncryptionContext context = new EncryptionContext(signatureVersion, applicationKey, activationId, EncryptorId.VAULT_UNLOCK);
-            final DecryptionResultVaultUnlock decryptionResult = (DecryptionResultVaultUnlock) cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).decryptRequest(encryptedRequest, context);
+            final DecryptionResultVaultUnlock decryptionResult = (DecryptionResultVaultUnlock) encryptionService.decryptRequest(encryptedRequest, context);
 
             // Convert JSON data to vault unlock request object
             VaultUnlockRequestPayload vaultUnlockRequest;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
@@ -20,6 +20,7 @@ package com.wultra.security.powerauth.app.server.service.behavior.tasks.v3;
 
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.EncryptionServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -33,7 +34,6 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -63,6 +63,7 @@ public class EncryptionBehaviorEcies {
     private final ActivationQueryService activationQueryService;
     private final ActivationContextValidator activationValidator;
     private final CryptographyServiceFactory cryptographyServiceFactory;
+    private final EncryptionServiceEcies encryptionService;
 
     /**
      * Obtain ECIES decryptor parameters to allow decryption of ECIES-encrypted messages on intermediate server.
@@ -113,7 +114,7 @@ public class EncryptionBehaviorEcies {
                 request.getTimestamp()
         );
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(encryptedRequest, context);
+        final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(encryptedRequest, context);
         if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
             // ECIES V3.0, V3.1, V3.2
             final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
@@ -152,7 +153,7 @@ public class EncryptionBehaviorEcies {
         activationValidator.validateActiveStatus(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
 
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(
+        final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(
                 new EciesEncryptedRequest(
                         temporaryKeyId,
                         ephemeralPublicKey,

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
@@ -115,16 +115,7 @@ public class EncryptionBehaviorEcies {
         );
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
         final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(encryptedRequest, context);
-        if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
-            // ECIES V3.0, V3.1, V3.2
-            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
-            return response;
-        }
-        logger.error("Unsupported EncryptorSecrets object");
-        // Rollback is not required, database is not used for writing
-        throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        return generateResponse(encryptorSecrets);
     }
 
     /**
@@ -164,6 +155,10 @@ public class EncryptionBehaviorEcies {
                 ),
                 context
         );
+        return generateResponse(encryptorSecrets);
+    }
+
+    private GetEciesDecryptorResponse generateResponse(EncryptorSecrets encryptorSecrets) throws GenericServiceException {
         if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
             // ECIES V3.0, V3.1, V3.2
             final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/EncryptionBehaviorEcies.java
@@ -1,0 +1,178 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v3;
+
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
+import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
+import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRequest;
+import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Base64;
+
+/**
+ * Behavior class implementing the ECIES encryption service logic.
+ *
+ * <p><b>PowerAuth protocol versions:</b>
+ * <ul>
+ *     <li>3.0</li>
+ *     <li>3.1</li>
+ *     <li>3.2</li>
+ *     <li>3.3</li>
+ * </ul>
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class EncryptionBehaviorEcies {
+
+    private final LocalizationProvider localizationProvider;
+    private final ActivationQueryService activationQueryService;
+    private final ActivationContextValidator activationValidator;
+    private final CryptographyServiceFactory cryptographyServiceFactory;
+
+    /**
+     * Obtain ECIES decryptor parameters to allow decryption of ECIES-encrypted messages on intermediate server.
+     * This interface doesn't allow keys derivation, it only provides ECIES decryptor parameters used for generic
+     * encryption (sharedInfo1 = /pa/generic/**).
+     * <p>
+     * If activationId is not present, then it creates ECIES decryptor for application scope.
+     * If activationId is present, then it creates ECIES decryptor for activation scope.
+     *
+     * @return ECIES decryptor parameters.
+     */
+    @Transactional
+    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws GenericServiceException {
+        try {
+            if (request.getActivationId() == null) {
+                // Application scope
+                return getEciesDecryptorParametersForApplication(request);
+            } else {
+                // Activation scope
+                return getEciesDecryptorParametersForActivation(request);
+            }
+        } catch (GenericServiceException ex) {
+            // already logged
+            throw ex;
+        } catch (RuntimeException ex) {
+            logger.error("Runtime exception or error occurred, transaction will be rolled back", ex);
+            throw ex;
+        } catch (Exception ex) {
+            logger.error("Unknown error occurred", ex);
+            throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage());
+        }
+    }
+
+    /**
+     * Get ECIES decryptor parameters for application scope.
+     *
+     * @param request Request to get ECIES decryptor parameters.
+     * @return ECIES decryptor parameters for application scope.
+     * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
+     */
+    private GetEciesDecryptorResponse getEciesDecryptorParametersForApplication(GetEciesDecryptorRequest request) throws GenericServiceException {
+        final EncryptedRequest encryptedRequest = new EciesEncryptedRequest(
+                request.getTemporaryKeyId(),
+                request.getEphemeralPublicKey(),
+                null,
+                null,
+                request.getNonce(),
+                request.getTimestamp()
+        );
+        final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
+        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(encryptedRequest, context);
+        if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
+            // ECIES V3.0, V3.1, V3.2
+            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
+            response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
+            response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+            return response;
+        }
+        logger.error("Unsupported EncryptorSecrets object");
+        // Rollback is not required, database is not used for writing
+        throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+    }
+
+    /**
+     * Get ECIES decryptor parameters for activation scope.
+     *
+     * @param request Request to get ECIES decryptor parameters.
+     * @return ECIES decryptor parameters for activation scope.
+     * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
+     */
+    private GetEciesDecryptorResponse getEciesDecryptorParametersForActivation(GetEciesDecryptorRequest request) throws GenericServiceException {
+        final String temporaryKeyId = request.getTemporaryKeyId();
+        final String activationId = request.getActivationId();
+        final String ephemeralPublicKey = request.getEphemeralPublicKey();
+        final Long timestamp = request.getTimestamp();
+        final String nonce = request.getNonce();
+
+        // Lookup the activation
+        final ActivationRecordEntity activation = activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
+            logger.info("Activation does not exist, activation ID: {}", activationId);
+            // Rollback is not required, database is not used for writing
+            return localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+        });
+
+        activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
+
+        activationValidator.validateActiveStatus(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
+
+        final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
+        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(
+                new EciesEncryptedRequest(
+                        temporaryKeyId,
+                        ephemeralPublicKey,
+                        null,
+                        null,
+                        nonce,
+                        timestamp
+                ),
+                context
+        );
+        if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
+            // ECIES V3.0, V3.1, V3.2
+            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
+            response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
+            response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+            return response;
+        }
+        logger.error("Unsupported EncryptorSecrets object");
+        // Rollback is not required, database is not used for writing
+        throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/TemporaryKeyBehaviorEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/TemporaryKeyBehaviorEcies.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,64 +14,52 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
-package com.wultra.security.powerauth.app.server.service.behavior.tasks;
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v3;
 
-import com.wultra.security.powerauth.app.server.database.repository.TemporaryKeyRepository;
-import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v3.TemporaryKeyServiceEcies;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.persistence.TemporaryKeyPersistenceService;
 import com.wultra.security.powerauth.client.model.request.RemoveTemporaryPublicKeyRequest;
 import com.wultra.security.powerauth.client.model.request.TemporaryPublicKeyRequest;
 import com.wultra.security.powerauth.client.model.response.RemoveTemporaryPublicKeyResponse;
 import com.wultra.security.powerauth.client.model.response.TemporaryPublicKeyResponse;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-
 /**
- * Behavior class implementing the temporary key request related processes.
+ * Behavior class implementing the temporary key request related processes using ECIES encryption.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strob@wultra.com
  */
 @Service
 @Slf4j
 @AllArgsConstructor
-public class TemporaryKeyBehavior {
+public class TemporaryKeyBehaviorEcies {
 
-    private final TemporaryKeyRepository temporaryKeyRepository;
-    private final CryptographyServiceFactory cryptographyServiceFactory;
+    private final TemporaryKeyPersistenceService temporaryKeyPersistenceService;
+    private final TemporaryKeyServiceEcies temporaryKeyServiceEcies;
 
     @Transactional
     public TemporaryPublicKeyResponse requestTemporaryKey(TemporaryPublicKeyRequest request) throws GenericServiceException {
-        final String jwt = request.getJwt();
-        // TODO - v4 support
-        final String signedJwt = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).requestTemporaryKey(jwt);
-
-        final TemporaryPublicKeyResponse response = new TemporaryPublicKeyResponse();
-        response.setJwt(signedJwt);
-        return response;
+            final String jwt = request.getJwt();
+            final String signedJwt = temporaryKeyServiceEcies.requestTemporaryKey(jwt);
+            final TemporaryPublicKeyResponse response = new TemporaryPublicKeyResponse();
+            response.setJwt(signedJwt);
+            return response;
     }
 
     @Transactional
     public RemoveTemporaryPublicKeyResponse removeTemporaryKey(RemoveTemporaryPublicKeyRequest requestObject) {
-        temporaryKeyRepository.deleteById(requestObject.getId());
+        temporaryKeyPersistenceService.removeTemporaryKey(requestObject.getId());
         final RemoveTemporaryPublicKeyResponse response = new RemoveTemporaryPublicKeyResponse();
         response.setRemoved(true);
         response.setId(requestObject.getId());
         return response;
-    }
-
-    // Tasks for scheduling
-    @Transactional
-    public void expireTemporaryKeys() {
-        final Date currentTimestamp = new Date();
-        final int expiredCount = temporaryKeyRepository.deleteExpiredKeys(currentTimestamp);
-        logger.debug("Removed {} expired temporary keys", expiredCount);
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -27,10 +27,12 @@ import com.wultra.security.powerauth.app.server.service.model.request.Encryption
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
+import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
 import lombok.AllArgsConstructor;
@@ -101,16 +103,7 @@ public class EncryptionBehaviorAead {
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
 
         final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(encryptedRequest, context);
-        if (encryptorSecrets instanceof AeadSecrets aeadSecrets) {
-            // AEAD in V4
-            final ExtractEncryptorResponse response = new ExtractEncryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(aeadSecrets.getEnvelopeKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(aeadSecrets.getSharedInfo2()));
-            return response;
-        }
-        logger.error("Unsupported EncryptorSecrets object");
-        // Rollback is not required, database is not used for writing
-        throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        return generateResponse(encryptorSecrets);
     }
 
     private ExtractEncryptorResponse extractEncryptorParametersForActivation(ExtractEncryptorRequest request) throws GenericServiceException {
@@ -140,6 +133,10 @@ public class EncryptionBehaviorAead {
                 ),
                 context
         );
+        return generateResponse(encryptorSecrets);
+    }
+
+    private ExtractEncryptorResponse generateResponse(EncryptorSecrets encryptorSecrets) throws GenericServiceException {
         if (encryptorSecrets instanceof AeadSecrets aeadSecrets) {
             // AEAD V4.0
             final ExtractEncryptorResponse response = new ExtractEncryptorResponse();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2023 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,8 +14,9 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
-package com.wultra.security.powerauth.app.server.service.behavior.tasks;
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
@@ -25,15 +26,13 @@ import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
-import com.wultra.security.powerauth.client.model.request.v3.GetEciesDecryptorRequest;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
-import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.EciesEncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,11 +42,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Base64;
 
 /**
- * Behavior class implementing the ECIES service logic.
+ * Behavior class implementing the AEAD encryption service logic.
  *
  * <p><b>PowerAuth protocol versions:</b>
  * <ul>
- *     <li>3.0</li>
+ *     <li>4.0</li>
  * </ul>
  *
  * @author Roman Strobl, roman.strobl@wultra.com
@@ -55,7 +54,7 @@ import java.util.Base64;
 @Service
 @Slf4j
 @AllArgsConstructor
-public class EciesEncryptionBehavior {
+public class EncryptionBehaviorAead {
 
     private final LocalizationProvider localizationProvider;
     private final ActivationQueryService activationQueryService;
@@ -63,24 +62,23 @@ public class EciesEncryptionBehavior {
     private final CryptographyServiceFactory cryptographyServiceFactory;
 
     /**
-     * Obtain ECIES decryptor parameters to allow decryption of ECIES-encrypted messages on intermediate server.
-     * This interface doesn't allow keys derivation, it only provides ECIES decryptor parameters used for generic
-     * encryption (sharedInfo1 = /pa/generic/**).
+     * Extract AEAD encryptor parameters to allow decryption of AEAD-encrypted messages on intermediate server.
      * <p>
-     * If activationId is not present, then it creates ECIES decryptor for application scope.
-     * If activationId is present, then it creates ECIES decryptor for activation scope.
-     *
-     * @return ECIES decryptor parameters.
+     * If activationId is not present, then it creates AEAD encryptor for application scope.
+     * If activationId is present, then it creates AEAD encryptor for activation scope.
+     * @param request Extract encryptor parameters request.
+     * @return Extract encryptor parameters response.
+     * @throws GenericServiceException In case encryptor parameters could not be extracted.
      */
     @Transactional
-    public GetEciesDecryptorResponse getEciesDecryptor(GetEciesDecryptorRequest request) throws GenericServiceException {
+    public ExtractEncryptorResponse extractEncryptor(ExtractEncryptorRequest request) throws GenericServiceException {
         try {
             if (request.getActivationId() == null) {
                 // Application scope
-                return getEciesDecryptorParametersForApplication(request);
+                return extractEncryptorParametersForApplication(request);
             } else {
                 // Activation scope
-                return getEciesDecryptorParametersForActivation(request);
+                return extractEncryptorParametersForActivation(request);
             }
         } catch (GenericServiceException ex) {
             // already logged
@@ -94,37 +92,21 @@ public class EciesEncryptionBehavior {
         }
     }
 
-    @Transactional
-    public ExtractEncryptorResponse extractEncryptor(ExtractEncryptorRequest request) throws GenericServiceException {
-        // TODO - v4 support
-        return new ExtractEncryptorResponse();
-    }
-
-    /**
-     * Get ECIES decryptor parameters for application scope.
-     *
-     * @param request Request to get ECIES decryptor parameters.
-     * @return ECIES decryptor parameters for application scope.
-     * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
-     */
-    private GetEciesDecryptorResponse getEciesDecryptorParametersForApplication(GetEciesDecryptorRequest request) throws GenericServiceException {
-        // TODO - v4 support
-        final EncryptedRequest encryptedRequest = new EciesEncryptedRequest(
+    private ExtractEncryptorResponse extractEncryptorParametersForApplication(ExtractEncryptorRequest request) throws GenericServiceException {
+        final EncryptedRequest encryptedRequest = new AeadEncryptedRequest(
                 request.getTemporaryKeyId(),
-                request.getEphemeralPublicKey(),
-                null,
                 null,
                 request.getNonce(),
                 request.getTimestamp()
         );
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
-        // TODO - v4 support
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(encryptedRequest, context);
-        if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
-            // ECIES V3.0, V3.1, V3.2
-            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+
+        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).deriveSecrets(encryptedRequest, context);
+        if (encryptorSecrets instanceof AeadSecrets aeadSecrets) {
+            // AEAD in V4
+            final ExtractEncryptorResponse response = new ExtractEncryptorResponse();
+            response.setSecretKey(Base64.getEncoder().encodeToString(aeadSecrets.getEnvelopeKey()));
+            response.setSharedInfo2(Base64.getEncoder().encodeToString(aeadSecrets.getSharedInfo2()));
             return response;
         }
         logger.error("Unsupported EncryptorSecrets object");
@@ -132,17 +114,9 @@ public class EciesEncryptionBehavior {
         throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
     }
 
-    /**
-     * Get ECIES decryptor parameters for activation scope.
-     *
-     * @param request Request to get ECIES decryptor parameters.
-     * @return ECIES decryptor parameters for activation scope.
-     * @throws GenericServiceException In case ECIES decryptor parameters could not be extracted.
-     */
-    private GetEciesDecryptorResponse getEciesDecryptorParametersForActivation(GetEciesDecryptorRequest request) throws GenericServiceException {
+    private ExtractEncryptorResponse extractEncryptorParametersForActivation(ExtractEncryptorRequest request) throws GenericServiceException {
         final String temporaryKeyId = request.getTemporaryKeyId();
         final String activationId = request.getActivationId();
-        final String ephemeralPublicKey = request.getEphemeralPublicKey();
         final Long timestamp = request.getTimestamp();
         final String nonce = request.getNonce();
 
@@ -158,24 +132,20 @@ public class EciesEncryptionBehavior {
         activationValidator.validateActiveStatus(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
 
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
-        // TODO - v4 support
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).deriveSecrets(
-                new EciesEncryptedRequest(
+        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).deriveSecrets(
+                new AeadEncryptedRequest(
                         temporaryKeyId,
-                        ephemeralPublicKey,
-                        null,
                         null,
                         nonce,
                         timestamp
                 ),
                 context
         );
-        // TODO - v4 support
-        if (encryptorSecrets instanceof ServerEciesSecrets encryptorSecretsV3) {
-            // ECIES V3.0, V3.1, V3.2
-            final GetEciesDecryptorResponse response = new GetEciesDecryptorResponse();
-            response.setSecretKey(Base64.getEncoder().encodeToString(encryptorSecretsV3.getEnvelopeKey()));
-            response.setSharedInfo2(Base64.getEncoder().encodeToString(encryptorSecretsV3.getSharedInfo2Base()));
+        if (encryptorSecrets instanceof AeadSecrets aeadSecrets) {
+            // AEAD V4.0
+            final ExtractEncryptorResponse response = new ExtractEncryptorResponse();
+            response.setSecretKey(Base64.getEncoder().encodeToString(aeadSecrets.getEnvelopeKey()));
+            response.setSharedInfo2(Base64.getEncoder().encodeToString(aeadSecrets.getSharedInfo2()));
             return response;
         }
         logger.error("Unsupported EncryptorSecrets object");

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -19,7 +19,7 @@
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
-import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.v4.EncryptionServiceAead;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -33,7 +33,6 @@ import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -59,7 +58,7 @@ public class EncryptionBehaviorAead {
     private final LocalizationProvider localizationProvider;
     private final ActivationQueryService activationQueryService;
     private final ActivationContextValidator activationValidator;
-    private final CryptographyServiceFactory cryptographyServiceFactory;
+    private final EncryptionServiceAead encryptionService;
 
     /**
      * Extract AEAD encryptor parameters to allow decryption of AEAD-encrypted messages on intermediate server.
@@ -101,7 +100,7 @@ public class EncryptionBehaviorAead {
         );
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), null, EncryptorId.APPLICATION_SCOPE_GENERIC);
 
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).deriveSecrets(encryptedRequest, context);
+        final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(encryptedRequest, context);
         if (encryptorSecrets instanceof AeadSecrets aeadSecrets) {
             // AEAD in V4
             final ExtractEncryptorResponse response = new ExtractEncryptorResponse();
@@ -132,7 +131,7 @@ public class EncryptionBehaviorAead {
         activationValidator.validateActiveStatus(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
 
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
-        final EncryptorSecrets encryptorSecrets = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).deriveSecrets(
+        final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(
                 new AeadEncryptedRequest(
                         temporaryKeyId,
                         null,

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorAead.java
@@ -1,0 +1,65 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
+
+import com.wultra.security.powerauth.app.server.service.crypto.v4.TemporaryKeyServiceAead;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.persistence.TemporaryKeyPersistenceService;
+import com.wultra.security.powerauth.client.model.request.RemoveTemporaryPublicKeyRequest;
+import com.wultra.security.powerauth.client.model.request.TemporaryPublicKeyRequest;
+import com.wultra.security.powerauth.client.model.response.RemoveTemporaryPublicKeyResponse;
+import com.wultra.security.powerauth.client.model.response.TemporaryPublicKeyResponse;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Behavior class implementing the temporary key request related processes using AEAD encryption.
+ *
+ * @author Roman Strobl, roman.strob@wultra.com
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class TemporaryKeyBehaviorAead {
+
+    private final TemporaryKeyPersistenceService temporaryKeyPersistenceService;
+    private final TemporaryKeyServiceAead temporaryKeyServiceAead;
+
+    @Transactional
+    public TemporaryPublicKeyResponse requestTemporaryKey(TemporaryPublicKeyRequest request) throws GenericServiceException {
+        final String jwt = request.getJwt();
+        final String signedJwt = temporaryKeyServiceAead.requestTemporaryKey(jwt);
+        final TemporaryPublicKeyResponse response = new TemporaryPublicKeyResponse();
+        response.setJwt(signedJwt);
+        return response;
+    }
+
+    @Transactional
+    public RemoveTemporaryPublicKeyResponse removeTemporaryKey(RemoveTemporaryPublicKeyRequest requestObject) {
+        temporaryKeyPersistenceService.removeTemporaryKey(requestObject.getId());
+        final RemoveTemporaryPublicKeyResponse response = new RemoveTemporaryPublicKeyResponse();
+        response.setRemoved(true);
+        response.setId(requestObject.getId());
+        return response;
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/callbacks/CallbackUrlAuthenticationEncryptor.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/callbacks/CallbackUrlAuthenticationEncryptor.java
@@ -7,7 +7,7 @@ import com.wultra.security.powerauth.app.server.converter.CallbackAuthentication
 import com.wultra.security.powerauth.app.server.database.model.entity.CallbackUrlAuthentication;
 import com.wultra.security.powerauth.app.server.database.model.entity.CallbackUrlEntity;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableString;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 public final class CallbackUrlAuthenticationEncryptor {
 
     private CallbackAuthenticationConverter callbackAuthenticationConverter;
-    private EncryptionService encryptionService;
+    private DatabaseEncryptionService encryptionService;
 
     private final CallbackAuthenticationPublicConverter authenticationPublicConverter = new CallbackAuthenticationPublicConverter();
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
@@ -80,7 +80,7 @@ public abstract class CryptographyService {
      * @param activation Activation.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    public abstract void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract void generateServerKeyPair(ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Convert a device public key.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
@@ -19,15 +19,21 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto;
 
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BaseKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicKey;
 import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
 import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
+import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.crypto.SecretKey;
 
@@ -36,7 +42,12 @@ import javax.crypto.SecretKey;
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public interface CryptographyService {
+@Slf4j
+@AllArgsConstructor
+public abstract class CryptographyService {
+
+    private final LocalizationProvider localizationProvider;
+    private final EncryptionService encryptionService;
 
     /**
      * Generate a key pair for an application. The key pair can be composite in case of a hybrid algorithm.
@@ -44,7 +55,7 @@ public interface CryptographyService {
      * @param application Application.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException;
+    public abstract void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException;
 
     /**
      * Get a key pair for an application. The key pair can be composite in case of a hybrid algorithm.
@@ -53,7 +64,7 @@ public interface CryptographyService {
      * @return Key pair.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    BaseKeyPair getMasterKeyPair(ApplicationEntity application) throws GenericServiceException;
+    public abstract BaseKeyPair getMasterKeyPair(ApplicationEntity application) throws GenericServiceException;
 
     /**
      * Generate shared secret key.
@@ -61,7 +72,7 @@ public interface CryptographyService {
      * @return Shared secret key.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    SecretKey generateSharedSecretKey(ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract SecretKey generateSharedSecretKey(ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Generate a key pair for an activation. The key pair can be composite in case of a hybrid algorithm.
@@ -69,14 +80,15 @@ public interface CryptographyService {
      * @param activation Activation.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Convert a device public key.
+     * @param keyType Key type.
      * @param devicePublicKey Device public key bytes.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    BasePublicKey convertDevicePublicKey(byte[] devicePublicKey) throws GenericServiceException;
+    public abstract BasePublicKey convertDevicePublicKey(KeyType keyType, byte[] devicePublicKey) throws GenericServiceException;
 
     /**
      * Store a device public key for an activation.
@@ -84,7 +96,7 @@ public interface CryptographyService {
      * @param devicePublicKey Device public key.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    void storeDevicePublicKey(ActivationRecordEntity activation, BasePublicKey devicePublicKey) throws GenericServiceException;
+    public abstract void storeDevicePublicKey(ActivationRecordEntity activation, BasePublicKey devicePublicKey) throws GenericServiceException;
 
     /**
      * Generate an activation fingerprint.
@@ -92,7 +104,7 @@ public interface CryptographyService {
      * @return Activation fingerprint.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    String generateActivationFingerprint(ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract String generateActivationFingerprint(ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Generate an asymmetric signature for an application.
@@ -102,7 +114,7 @@ public interface CryptographyService {
      * @return Signature.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    byte[] generateSignatureForApplication(byte[] data, ApplicationEntity application) throws GenericServiceException;
+    public abstract byte[] generateSignatureForApplication(byte[] data, ApplicationEntity application) throws GenericServiceException;
 
     /**
      * Generate an asymmetric signature for an activation.
@@ -112,7 +124,7 @@ public interface CryptographyService {
      * @return Signature.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    byte[] generateSignatureForActivation(byte[] data, ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract byte[] generateSignatureForActivation(byte[] data, ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Verify an asymmetric signature for an activation.
@@ -123,7 +135,7 @@ public interface CryptographyService {
      * @return True in case signature is valid, false otherwise.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    boolean verifySignatureForActivation(byte[] data, byte[] signature, ActivationRecordEntity activation) throws GenericServiceException;
+    public abstract boolean verifySignatureForActivation(byte[] data, byte[] signature, ActivationRecordEntity activation) throws GenericServiceException;
 
     /**
      * Decrypt an encrypted request using server encryptor.
@@ -133,24 +145,49 @@ public interface CryptographyService {
      * @return Decrypted data and context.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException;
+    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
+        try {
+            final DecryptionResult decryptionResult = encryptionService.decrypt(
+                    encryptedRequest,
+                    context.getProtocolVersion(),
+                    context.getApplicationKey(),
+                    context.getActivationId(),
+                    context.getEncryptorId(),
+                    true
+            );
+            final byte[] decrypted = decryptionResult.getServerEncryptor().decryptRequest(encryptedRequest);
+            decryptionResult.setDecryptedData(decrypted);
+            return decryptionResult;
+        } catch (EncryptorException e) {
+            logger.error("Decryption failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        }
+    }
 
     /**
      * Derive encryptor secrets.
      *
-     * @param request Encrypted request without encrypted data.
+     * @param encryptedRequest Encrypted request without encrypted data.
      * @param context Encryption context.
      * @return Encryptor secrets.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    EncryptorSecrets deriveSecrets(EncryptedRequest request, EncryptionContext context) throws GenericServiceException;
-
-    /**
-     * Request a temporary key.
-     * @param jwt Temporary key request in JWT format.
-     * @return Temporary key in JWT format.
-     * @throws GenericServiceException In case of a cryptography error.
-     */
-    String requestTemporaryKey(String jwt) throws GenericServiceException;
-
+    public EncryptorSecrets deriveSecrets(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
+        try {
+            final DecryptionResult decryptionResult = encryptionService.decrypt(
+                    encryptedRequest,
+                    context.getProtocolVersion(),
+                    context.getApplicationKey(),
+                    context.getActivationId(),
+                    context.getEncryptorId(),
+                    false
+            );
+            return decryptionResult.getServerEncryptor().deriveSecretsForExternalEncryptor(encryptedRequest);
+        } catch (EncryptorException e) {
+            logger.error("Decryption failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        }
+    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/CryptographyService.java
@@ -24,14 +24,8 @@ import com.wultra.security.powerauth.app.server.database.model.entity.Activation
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
-import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BaseKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicKey;
-import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
-import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
-import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -137,57 +131,4 @@ public abstract class CryptographyService {
      */
     public abstract boolean verifySignatureForActivation(byte[] data, byte[] signature, ActivationRecordEntity activation) throws GenericServiceException;
 
-    /**
-     * Decrypt an encrypted request using server encryptor.
-     *
-     * @param encryptedRequest Encrypted request.
-     * @param context Encryption context.
-     * @return Decrypted data and context.
-     * @throws GenericServiceException In case of a cryptography error.
-     */
-    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        try {
-            final DecryptionResult decryptionResult = encryptionService.decrypt(
-                    encryptedRequest,
-                    context.getProtocolVersion(),
-                    context.getApplicationKey(),
-                    context.getActivationId(),
-                    context.getEncryptorId(),
-                    true
-            );
-            final byte[] decrypted = decryptionResult.getServerEncryptor().decryptRequest(encryptedRequest);
-            decryptionResult.setDecryptedData(decrypted);
-            return decryptionResult;
-        } catch (EncryptorException e) {
-            logger.error("Decryption failed", e);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        }
-    }
-
-    /**
-     * Derive encryptor secrets.
-     *
-     * @param encryptedRequest Encrypted request without encrypted data.
-     * @param context Encryption context.
-     * @return Encryptor secrets.
-     * @throws GenericServiceException In case of a cryptography error.
-     */
-    public EncryptorSecrets deriveSecrets(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        try {
-            final DecryptionResult decryptionResult = encryptionService.decrypt(
-                    encryptedRequest,
-                    context.getProtocolVersion(),
-                    context.getApplicationKey(),
-                    context.getActivationId(),
-                    context.getEncryptorId(),
-                    false
-            );
-            return decryptionResult.getServerEncryptor().deriveSecretsForExternalEncryptor(encryptedRequest);
-        } catch (EncryptorException e) {
-            logger.error("Decryption failed", e);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        }
-    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/EncryptionService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/EncryptionService.java
@@ -19,17 +19,31 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto;
 
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
+import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
+import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Service for handling encryption.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public interface EncryptionService {
+@Slf4j
+@AllArgsConstructor
+public abstract class EncryptionService {
+
+    private final LocalizationProvider localizationProvider;
+    private final ApplicationVersionRepository applicationVersionRepository;
+    private final ActivationQueryService activationQueryService;
 
     /**
      * Decrypt an encrypted request.
@@ -42,6 +56,39 @@ public interface EncryptionService {
      * @return Decryption result.
      * @throws GenericServiceException In case of a cryptography error.
      */
-    DecryptionResult decrypt(EncryptedRequest encryptedRequest, String protocolVersion, String applicationKey, String activationId, EncryptorId encryptorId, boolean validateRequest) throws GenericServiceException;
+    public abstract DecryptionResult decrypt(EncryptedRequest encryptedRequest, String protocolVersion, String applicationKey, String activationId, EncryptorId encryptorId, boolean validateRequest) throws GenericServiceException;
 
+    /**
+     * Helper method for finding application version by application key during decryption.
+     * @param applicationKey Application key.
+     * @return Application version entity.
+     * @throws GenericServiceException In case application version does not exist, or it is not supported.
+     */
+    protected ApplicationVersionEntity findApplicationVersion(String applicationKey) throws GenericServiceException {
+        // Find application by application key
+        final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
+        if (applicationVersion == null || !applicationVersion.getSupported() || applicationVersion.getApplication() == null) {
+            logger.warn("Application version is incorrect, application key: {}", applicationKey);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
+        }
+        return applicationVersion;
+    }
+
+    /**
+     * Helper method for finding activation during decryption.
+     * @param activationId Activation ID.
+     * @return Activation entity.
+     * @throws GenericServiceException In case activation does not exist.
+     */
+    protected ActivationRecordEntity findActivation(String activationId) throws GenericServiceException {
+        if (activationId == null) {
+            return null;
+        }
+        return activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
+            logger.info("Activation does not exist, activation ID: {}", activationId);
+            // Rollback is not required, database is not used for writing
+            return localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+        });
+    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/EncryptionService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/EncryptionService.java
@@ -25,10 +25,13 @@ import com.wultra.security.powerauth.app.server.database.repository.ApplicationV
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
 import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -57,6 +60,60 @@ public abstract class EncryptionService {
      * @throws GenericServiceException In case of a cryptography error.
      */
     public abstract DecryptionResult decrypt(EncryptedRequest encryptedRequest, String protocolVersion, String applicationKey, String activationId, EncryptorId encryptorId, boolean validateRequest) throws GenericServiceException;
+
+    /**
+     * Decrypt an encrypted request using server encryptor.
+     *
+     * @param encryptedRequest Encrypted request.
+     * @param context Encryption context.
+     * @return Decrypted data and context.
+     * @throws GenericServiceException In case of a cryptography error.
+     */
+    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
+        try {
+            final DecryptionResult decryptionResult = decrypt(
+                    encryptedRequest,
+                    context.getProtocolVersion(),
+                    context.getApplicationKey(),
+                    context.getActivationId(),
+                    context.getEncryptorId(),
+                    true
+            );
+            final byte[] decrypted = decryptionResult.getServerEncryptor().decryptRequest(encryptedRequest);
+            decryptionResult.setDecryptedData(decrypted);
+            return decryptionResult;
+        } catch (EncryptorException e) {
+            logger.error("Decryption failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        }
+    }
+
+    /**
+     * Derive encryptor secrets.
+     *
+     * @param encryptedRequest Encrypted request without encrypted data.
+     * @param context Encryption context.
+     * @return Encryptor secrets.
+     * @throws GenericServiceException In case of a cryptography error.
+     */
+    public EncryptorSecrets deriveSecrets(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
+        try {
+            final DecryptionResult decryptionResult = decrypt(
+                    encryptedRequest,
+                    context.getProtocolVersion(),
+                    context.getApplicationKey(),
+                    context.getActivationId(),
+                    context.getEncryptorId(),
+                    false
+            );
+            return decryptionResult.getServerEncryptor().deriveSecretsForExternalEncryptor(encryptedRequest);
+        } catch (EncryptorException e) {
+            logger.error("Decryption failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
+        }
+    }
 
     /**
      * Helper method for finding application version by application key during decryption.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/TemporaryKeyService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/TemporaryKeyService.java
@@ -19,16 +19,33 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto;
 
+import com.wultra.security.powerauth.app.server.database.model.entity.TemporaryKeyEntity;
+import com.wultra.security.powerauth.app.server.database.repository.TemporaryKeyRepository;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import javax.crypto.SecretKey;
 import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Date;
+import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Service for handling temporary keys.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
-public interface TemporaryKeyService {
+@AllArgsConstructor
+@Slf4j
+public abstract class TemporaryKeyService {
+
+    private final LocalizationProvider localizationProvider;
+    private final TemporaryKeyRepository temporaryKeyRepository;
 
     /**
      * Request a temporary key.
@@ -36,15 +53,59 @@ public interface TemporaryKeyService {
      * @return JWT temporary key response.
      * @throws GenericServiceException In case of cryptography error.
      */
-    String requestTemporaryKey(String jwt) throws GenericServiceException;
+    public abstract String requestTemporaryKey(String jwt) throws GenericServiceException;
 
     /**
-     * Fetch a temporary private key for given ID and application key.
+     * Fetch a temporary private key.
      * @param id Temporary key ID.
      * @param appKey Application key.
+     * @param activationId Activation ID.
      * @return Temporary private key.
      * @throws GenericServiceException In case of cryptography error.
      */
-    PrivateKey temporaryPrivateKey(String id, String appKey) throws GenericServiceException;
+    public abstract PrivateKey extractTemporaryPrivateKey(String id, String appKey, String activationId) throws GenericServiceException;
 
+    /**
+     * Fetch a temporary shared secret.
+     * @param id Temporary key ID.
+     * @param appKey Application key.
+     * @param activationId Activation ID.
+     * @return Temporary shared secret.
+     * @throws GenericServiceException In case of cryptography error.
+     */
+    public abstract SecretKey extractTemporarySharedSecret(String id, String appKey, String activationId) throws GenericServiceException;
+
+    /**
+     * Get the temporary private key, decrypt if required.
+     * @param id Key ID.
+     * @param appKey App key.
+     * @param activationId Activation ID.
+     * @return Temporary private key.
+     * @throws GenericServiceException In case some parameters did not match.
+     * @throws InvalidKeySpecException In case the private key could not be converted.
+     * @throws CryptoProviderException In case the crypto provider is not configured properly.
+     */
+    protected TemporaryKeyEntity fetchTemporaryKey(String id, String appKey, String activationId) throws GenericServiceException, InvalidKeySpecException, CryptoProviderException {
+        final Date currentTimestamp = new Date();
+        final Optional<TemporaryKeyEntity> temporaryKeyEntity = temporaryKeyRepository.findById(id);
+        if (temporaryKeyEntity.isEmpty()) {
+            logger.error("Missing temporary key pair with ID: {}", id);
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
+        }
+        final TemporaryKeyEntity temporaryKey = temporaryKeyEntity.get();
+        if (temporaryKey.getTimestampExpires().before(currentTimestamp)) {
+            logger.error("Requesting expired temporary key pair with ID: {}", id);
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
+        }
+        if (!Objects.equals(temporaryKey.getAppKey(), appKey) || !Objects.equals(temporaryKey.getActivationId(), activationId)) {
+            logger.error("Temporary key does not match request parameters, app key expected: {}, received: {}, activation ID expected: {}, received: {}",
+                    temporaryKey.getAppKey(), appKey,
+                    temporaryKey.getActivationId(), activationId);
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
+        }
+        return temporaryKey;
+    }
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
@@ -109,7 +109,6 @@ public class CryptographyServiceEc256 extends CryptographyService {
                 keyPair = new MasterKeyPairEntity();
                 privateKeyRegistry = new PrivateKeyRegistry();
                 publicKeyRegistry = new PublicKeyRegistry();
-                keyPair.setMasterPrivateKeysEncryption(EncryptionMode.NO_ENCRYPTION);
                 keyPair.setTimestampCreated(new Date());
                 keyPair.setName(application.getId() + " Default Keypair");
                 // Store empty registries for V4

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
@@ -19,8 +19,10 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto.v3;
 
+import com.wultra.security.powerauth.app.server.converter.MasterPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
 import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeyConverter;
-import com.wultra.security.powerauth.app.server.database.model.ServerPrivateKey;
+import com.wultra.security.powerauth.app.server.database.model.*;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
@@ -34,11 +36,6 @@ import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicK
 import com.wultra.security.powerauth.app.server.service.model.crypto.EcKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BaseKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.EcPublicKey;
-import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
-import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
-import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.ActivationVersion;
@@ -48,8 +45,8 @@ import com.wultra.security.powerauth.crypto.lib.util.ECPublicKeyFingerprint;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -68,15 +65,28 @@ import java.util.Date;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Service
-@AllArgsConstructor
 @Slf4j
-public class CryptographyServiceEc256 implements CryptographyService {
+public class CryptographyServiceEc256 extends CryptographyService {
 
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final LocalizationProvider localizationProvider;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
-    private final TemporaryKeyServiceEc256 temporaryKeyService;
-    private final EncryptionServiceEc256 encryptionService;
+    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+
+    @Autowired
+    public CryptographyServiceEc256(LocalizationProvider localizationProvider,
+                                    EncryptionServiceEcies encryptionService,
+                                    MasterKeyPairRepository masterKeyPairRepository,
+                                    LocalizationProvider localizationProvider1,
+                                    ServerPrivateKeyConverter serverPrivateKeyConverter, MasterPrivateKeysConverter masterPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
+        super(localizationProvider, encryptionService);
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.localizationProvider = localizationProvider1;
+        this.serverPrivateKeyConverter = serverPrivateKeyConverter;
+        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
+        this.publicKeysConverter = publicKeysConverter;
+    }
 
     private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private final KeyGenerator KEY_GENERATOR = new KeyGenerator();
@@ -91,12 +101,27 @@ public class CryptographyServiceEc256 implements CryptographyService {
             final PrivateKey privateKey = kp.getPrivate();
             final PublicKey publicKey = kp.getPublic();
 
-            final MasterKeyPairEntity keyPair = new MasterKeyPairEntity();
+            // Key pairs for multiple algorithms are stored for the same entity
+            final PrivateKeyRegistry privateKeyRegistry;
+            final PublicKeyRegistry publicKeyRegistry;
+            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+            if (keyPair == null) {
+                keyPair = new MasterKeyPairEntity();
+                privateKeyRegistry = new PrivateKeyRegistry();
+                publicKeyRegistry = new PublicKeyRegistry();
+                keyPair.setMasterPrivateKeysEncryption(EncryptionMode.NO_ENCRYPTION);
+                keyPair.setTimestampCreated(new Date());
+                keyPair.setName(application.getId() + " Default Keypair");
+                // Store empty registries for V4
+                final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
+                keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
+                keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
+                final String masterPublicKeys = publicKeysConverter.toDBValue(publicKeyRegistry);
+                keyPair.setMasterPublicKeys(masterPublicKeys);
+            }
             keyPair.setApplication(application);
             keyPair.setMasterKeyPrivateBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPrivateKeyToBytes(privateKey)));
             keyPair.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P256, publicKey)));
-            keyPair.setTimestampCreated(new Date());
-            keyPair.setName(application.getId() + " Default Keypair");
             masterKeyPairRepository.save(keyPair);
         } catch (CryptoProviderException e) {
             logger.error("Could not generate keypair", e);
@@ -177,7 +202,10 @@ public class CryptographyServiceEc256 implements CryptographyService {
     }
 
     @Override
-    public BasePublicKey convertDevicePublicKey(byte[] devicePublicKey) throws GenericServiceException {
+    public BasePublicKey convertDevicePublicKey(KeyType keyType, byte[] devicePublicKey) throws GenericServiceException {
+        if (keyType != KeyType.ECDSA) {
+            throw new IllegalArgumentException("Unsupported key type: " + keyType);
+        }
         try {
             final PublicKey convertedPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, devicePublicKey);
             return EcPublicKey.builder().ecPublicKey(convertedPublicKey).build();
@@ -264,51 +292,6 @@ public class CryptographyServiceEc256 implements CryptographyService {
             logger.error("Could not verify signature", e);
             throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
         }
-    }
-
-    @Override
-    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        try {
-            final DecryptionResult decryptionResult = encryptionService.decrypt(
-                    encryptedRequest,
-                    context.getProtocolVersion(),
-                    context.getApplicationKey(),
-                    context.getActivationId(),
-                    context.getEncryptorId(),
-                    true
-            );
-            final byte[] decrypted = decryptionResult.getServerEncryptor().decryptRequest(encryptedRequest);
-            decryptionResult.setDecryptedData(decrypted);
-            return decryptionResult;
-        } catch (EncryptorException e) {
-            logger.error("Decryption failed", e);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        }
-    }
-
-    @Override
-    public EncryptorSecrets deriveSecrets(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        try {
-            final DecryptionResult decryptionResult = encryptionService.decrypt(
-                    encryptedRequest,
-                    context.getProtocolVersion(),
-                    context.getApplicationKey(),
-                    context.getActivationId(),
-                    context.getEncryptorId(),
-                    false
-            );
-            return decryptionResult.getServerEncryptor().deriveSecretsForExternalEncryptor(encryptedRequest);
-        } catch (EncryptorException e) {
-            logger.error("Decryption failed", e);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.DECRYPTION_FAILED);
-        }
-    }
-
-    @Override
-    public String requestTemporaryKey(String jwt) throws GenericServiceException {
-        return temporaryKeyService.requestTemporaryKey(jwt);
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
@@ -181,7 +181,7 @@ public class CryptographyServiceEc256 extends CryptographyService {
     }
 
     @Override
-    public void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
+    public void generateServerKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
         try {
             final KeyPair serverKeyPair = KEY_GENERATOR.generateKeyPair(EcCurve.P256);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/EncryptionServiceEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/EncryptionServiceEcies.java
@@ -60,6 +60,11 @@ import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 import java.util.Date;
 
+/**
+ * Encryption service for ECIES (V3).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
 @Service
 @Slf4j
 public class EncryptionServiceEcies extends EncryptionService {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/EncryptionServiceEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/EncryptionServiceEcies.java
@@ -48,8 +48,8 @@ import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderEx
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -62,21 +62,29 @@ import java.util.Date;
 
 @Service
 @Slf4j
-@AllArgsConstructor
-public class EncryptionServiceEc256 implements EncryptionService {
+public class EncryptionServiceEcies extends EncryptionService {
 
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final ReplayVerificationService replayVerificationService;
-    private final ApplicationVersionRepository applicationVersionRepository;
     private final LocalizationProvider localizationProvider;
-    private final TemporaryKeyServiceEc256 temporaryKeyService;
+    private final TemporaryKeyServiceEcies temporaryKeyService;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
-    private final ActivationQueryService activationQueryService;
 
     private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
     private final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
 
+    @Autowired
+    public EncryptionServiceEcies(MasterKeyPairRepository masterKeyPairRepository, ReplayVerificationService replayVerificationService, ApplicationVersionRepository applicationVersionRepository, LocalizationProvider localizationProvider, TemporaryKeyServiceEcies temporaryKeyService, ServerPrivateKeyConverter serverPrivateKeyConverter, ActivationQueryService activationQueryService) {
+        super(localizationProvider, applicationVersionRepository, activationQueryService);
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.replayVerificationService = replayVerificationService;
+        this.localizationProvider = localizationProvider;
+        this.temporaryKeyService = temporaryKeyService;
+        this.serverPrivateKeyConverter = serverPrivateKeyConverter;
+    }
+
+    @Override
     public DecryptionResult decrypt(EncryptedRequest encryptedRequest, String protocolVersion, String applicationKey, String activationId, EncryptorId encryptorId, boolean validateRequest) throws GenericServiceException {
         try {
             // Validate encrypted request
@@ -123,7 +131,7 @@ public class EncryptionServiceEc256 implements EncryptionService {
     private DecryptionResult decryptInApplicationScope(EciesEncryptedRequest eciesRequest, String protocolVersion, ApplicationVersionEntity applicationVersion, EncryptorId encryptorId) throws GenericServiceException, InvalidKeySpecException, CryptoProviderException, EncryptorException {
         final PrivateKey privateKey;
         if (eciesRequest.getTemporaryKeyId() != null) {
-            privateKey = temporaryKeyService.temporaryPrivateKey(eciesRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey());
+            privateKey = temporaryKeyService.extractTemporaryPrivateKey(eciesRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey(), null);
         } else {
             final MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersion.getApplication().getId());
             if (masterKeyPairEntity == null) {
@@ -167,7 +175,7 @@ public class EncryptionServiceEc256 implements EncryptionService {
         final byte[] transportKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportKey);
 
         if (eciesRequest.getTemporaryKeyId() != null) {
-            privateKey = temporaryKeyService.temporaryPrivateKey(eciesRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey(), activation.getActivationId());
+            privateKey = temporaryKeyService.extractTemporaryPrivateKey(eciesRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey(), activation.getActivationId());
         } else {
             privateKey = serverPrivateKey;
         }
@@ -187,28 +195,6 @@ public class EncryptionServiceEc256 implements EncryptionService {
         ));
         decryptionResult.setApplication(applicationVersion.getApplication());
         return decryptionResult;
-    }
-
-    private ApplicationVersionEntity findApplicationVersion(String applicationKey) throws GenericServiceException {
-        // Find application by application key
-        final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(applicationKey);
-        if (applicationVersion == null || !applicationVersion.getSupported() || applicationVersion.getApplication() == null) {
-            logger.warn("Application version is incorrect, application key: {}", applicationKey);
-            // Rollback is not required, error occurs before writing to database
-            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_EXPIRED);
-        }
-        return applicationVersion;
-    }
-
-    private ActivationRecordEntity findActivation(String activationId) throws GenericServiceException {
-        if (activationId == null) {
-            return null;
-        }
-        return activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
-            logger.info("Activation does not exist, activation ID: {}", activationId);
-            // Rollback is not required, database is not used for writing
-            return localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-        });
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/TemporaryKeyServiceEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/TemporaryKeyServiceEcies.java
@@ -48,15 +48,14 @@ import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvide
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.crypto.TemporaryKeyResult;
 import com.wultra.security.powerauth.app.server.service.util.jwt.MACVerifier16B;
-import com.wultra.security.powerauth.client.model.entity.TemporaryPublicKeyRequestClaims;
-import com.wultra.security.powerauth.client.model.entity.TemporaryPublicKeyResponseClaims;
+import com.wultra.security.powerauth.client.model.entity.v3.TemporaryPublicKeyRequestClaims;
+import com.wultra.security.powerauth.client.model.entity.v3.TemporaryPublicKeyResponseClaims;
 import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -70,14 +69,13 @@ import java.text.ParseException;
 import java.util.*;
 
 /**
- * Service for handling temporary keys with EC curve P-256.
+ * Service for handling temporary keys with ECIES encryption on curve P-256.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Service
 @Slf4j
-@AllArgsConstructor
-public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
+public class TemporaryKeyServiceEcies extends TemporaryKeyService {
 
     private final ActivationRepository activationRepository;
     private final PowerAuthServiceConfiguration powerAuthServiceConfiguration;
@@ -92,12 +90,25 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
     private final KeyGenerator KEY_GENERATOR = new KeyGenerator();
     private final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
 
+    public TemporaryKeyServiceEcies(ActivationRepository activationRepository, PowerAuthServiceConfiguration powerAuthServiceConfiguration, TemporaryPrivateKeyConverter temporaryPrivateKeyConverter, TemporaryKeyRepository temporaryKeyRepository, LocalizationProvider localizationProvider, ApplicationVersionRepository applicationVersionRepository, MasterKeyPairRepository masterKeyPairRepository, ServerPrivateKeyConverter serverPrivateKeyConverter) {
+        super(localizationProvider, temporaryKeyRepository);
+        this.activationRepository = activationRepository;
+        this.powerAuthServiceConfiguration = powerAuthServiceConfiguration;
+        this.temporaryPrivateKeyConverter = temporaryPrivateKeyConverter;
+        this.temporaryKeyRepository = temporaryKeyRepository;
+        this.localizationProvider = localizationProvider;
+        this.applicationVersionRepository = applicationVersionRepository;
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.serverPrivateKeyConverter = serverPrivateKeyConverter;
+    }
+
     /**
      * Request a temporary key.
      * @param jwt Temporary key request in JWT format.
      * @return Temporary key in JWT format.
      * @throws GenericServiceException In case of a cryptography error.
      */
+    @Override
     public String requestTemporaryKey(String jwt) throws GenericServiceException {
         try {
             final SignedJWT decodedJWT = SignedJWT.parse(jwt);
@@ -122,7 +133,8 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
             final Date currentTimestamp = new Date();
 
             // Generate new key and store it
-            final TemporaryPublicKeyResponseClaims responseClaims = generateAndStoreNewKey(requestClaims, currentTimestamp);
+            final KeyPair temporaryKeyPair = KEY_GENERATOR.generateKeyPair(EcCurve.P256);
+            final TemporaryPublicKeyResponseClaims responseClaims = storeTemporaryKey(requestClaims, currentTimestamp, temporaryKeyPair);
 
             // Built and return the response claims
 
@@ -149,16 +161,16 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
         }
     }
 
-    /**
-     * Get the temporary private key, decrypt if required.
-     * @param id Key ID.
-     * @param appKey App key.
-     * @return Temporary private key.
-     * @throws GenericServiceException In case some parameters did not match.
-     */
-    public PrivateKey temporaryPrivateKey(String id, String appKey) throws GenericServiceException {
+    @Override
+    public PrivateKey extractTemporaryPrivateKey(String id, String appKey, String activationId) throws GenericServiceException {
         try {
-            return temporaryPrivateKey(id, appKey, null);
+            final TemporaryKeyEntity temporaryKey = fetchTemporaryKey(id, appKey, activationId);
+            final String serverPrivateKeyFromEntity = temporaryKey.getPrivateKeyBase64();
+            final EncryptionMode serverPrivateKeyEncryptionMode = temporaryKey.getPrivateKeyEncryption();
+            final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
+            final String serverPrivateKeyBase64 = temporaryPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, temporaryKey.getId(), temporaryKey.getAppKey(), temporaryKey.getActivationId());
+            final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
+            return KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
         } catch (InvalidKeySpecException e) {
             logger.error("Invalid key", e);
             // Rollback is not required, error occurs before writing to database
@@ -170,12 +182,27 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
         }
     }
 
-    private TemporaryPublicKeyRequestClaims buildTemporaryKeyClaims(SignedJWT source) throws ParseException {
+    @Override
+    public SecretKey extractTemporarySharedSecret(String id, String appKey, String activationId) throws GenericServiceException {
+        logger.error("Temporary shared secret extraction is not supported in cryptography protocol version 3");
+        // Rollback is not required, error occurs before writing to database
+        throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+    }
+
+    private TemporaryPublicKeyRequestClaims buildTemporaryKeyClaims(SignedJWT source) throws ParseException, GenericServiceException {
         final JWTClaimsSet jwtClaimsSet = source.getJWTClaimsSet();
         final TemporaryPublicKeyRequestClaims destination = new TemporaryPublicKeyRequestClaims();
-        destination.setApplicationKey(jwtClaimsSet.getStringClaim("applicationKey"));
-        destination.setActivationId(jwtClaimsSet.getStringClaim("activationId"));
-        destination.setChallenge(jwtClaimsSet.getStringClaim("challenge"));
+        final String applicationKey = jwtClaimsSet.getStringClaim("applicationKey");
+        final String activationId = jwtClaimsSet.getStringClaim("activationId");
+        final String challenge = jwtClaimsSet.getStringClaim("challenge");
+        if (applicationKey == null || challenge == null) {
+            logger.error("Temporary key request is invalid");
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        destination.setApplicationKey(applicationKey);
+        destination.setActivationId(activationId);
+        destination.setChallenge(challenge);
         return destination;
     }
 
@@ -200,10 +227,69 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
                 .build();
     }
 
-    private TemporaryPublicKeyResponseClaims generateAndStoreNewKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp) throws CryptoProviderException, GenericServiceException {
 
-        // Generate a temporary key pair
-        final KeyPair temporaryKeyPair = KEY_GENERATOR.generateKeyPair(EcCurve.P256);
+
+    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
+        final String applicationKey = requestClaims.getApplicationKey();
+        if (applicationKey != null) {
+            final ApplicationVersionEntity applicationVersionEntity = applicationVersionRepository.findByApplicationKey(applicationKey);
+            if (applicationVersionEntity == null || !applicationVersionEntity.getSupported()) {
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+            }
+            final String applicationSecret = applicationVersionEntity.getApplicationSecret();
+            if (requestClaims.getActivationId() == null) {
+
+                final MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersionEntity.getApplication().getId());
+
+                final PrivateKey privateKey = KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPrivateBase64()));
+
+                final byte[] secretKeyBytes = Base64.getDecoder().decode(applicationSecret);
+
+                final TemporaryKeyResult result = new TemporaryKeyResult();
+                result.setSecretKeyBytes(secretKeyBytes);
+                result.setPrivateKey(privateKey);
+                return result;
+            } else {
+
+                final Long appId = applicationVersionEntity.getApplication().getRid();
+
+                final Optional<ActivationRecordEntity> activationWithoutLock = activationRepository.findActivationWithoutLock(requestClaims.getActivationId());
+                if (activationWithoutLock.isEmpty()) {
+                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+                }
+                final ActivationRecordEntity activation = activationWithoutLock.get();
+                if ((activation.getActivationStatus() != ActivationStatus.ACTIVE && activation.getActivationStatus() != ActivationStatus.BLOCKED)
+                        || activation.getProtocol() == ActivationProtocol.FIDO2 // FIDO2 does not support temporary keys anywhere
+                        || !Objects.equals(appId, activation.getApplication().getRid())) {
+                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+                }
+
+                final EncryptionMode encryptionMode = activation.getServerPrivateKeyEncryption();
+                final String serverPrivateKeyBase64 = activation.getServerPrivateKeyBase64();
+                final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(encryptionMode, serverPrivateKeyBase64);
+                final String decryptedServerPrivateKey = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
+                final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(decryptedServerPrivateKey);
+                final PrivateKey serverPrivateKey = KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
+
+                final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
+                final PublicKey devicePublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
+                final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
+
+                final byte[] applicationSecretKeyBytes = Base64.getDecoder().decode(applicationSecret);
+                final SecretKey secretKey = KEY_GENERATOR.deriveSecretKeyHmac(transportKey, applicationSecretKeyBytes);
+                final byte[] secretKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(secretKey);
+
+                final TemporaryKeyResult result = new TemporaryKeyResult();
+                result.setSecretKeyBytes(secretKeyBytes);
+                result.setPrivateKey(serverPrivateKey);
+                return result;
+            }
+        } else {
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+        }
+    }
+
+    private TemporaryPublicKeyResponseClaims storeTemporaryKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp, KeyPair temporaryKeyPair) throws CryptoProviderException, GenericServiceException {
 
         // Prepare the parameters key pair
         final String keyId = UUID.randomUUID().toString();
@@ -231,6 +317,7 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
         temporaryKeyEntity.setPrivateKeyBase64(temporaryPrivateKey.serverPrivateKeyBase64());
         temporaryKeyEntity.setPublicKeyBase64(temporaryPublicKeyBase64);
         temporaryKeyEntity.setTimestampExpires(expirationDate);
+        temporaryKeyEntity.setSecretKeyEncryption(EncryptionMode.NO_ENCRYPTION);
         final TemporaryKeyEntity savedEntity = temporaryKeyRepository.save(temporaryKeyEntity);
 
         // Prepare and return the result
@@ -242,111 +329,6 @@ public class TemporaryKeyServiceEc256 implements TemporaryKeyService {
         result.setExpiration(savedEntity.getTimestampExpires());
         result.setChallenge(challenge);
         return result;
-    }
-
-    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
-        final String applicationKey = requestClaims.getApplicationKey();
-        if (applicationKey != null) {
-            final ApplicationVersionEntity applicationVersionEntity = applicationVersionRepository.findByApplicationKey(applicationKey);
-            if (applicationVersionEntity == null || !applicationVersionEntity.getSupported()) {
-                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
-            }
-            final String applicationSecret = applicationVersionEntity.getApplicationSecret();
-            if (requestClaims.getActivationId() == null) {
-
-                final MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersionEntity.getApplication().getId());
-
-                final PrivateKey privateKey = KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPrivateBase64()));
-                final PublicKey publicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(masterKeyPairEntity.getMasterKeyPublicBase64()));
-
-                final byte[] secretKeyBytes = Base64.getDecoder().decode(applicationSecret);
-
-                final TemporaryKeyResult result = new TemporaryKeyResult();
-                result.setSecretKeyBytes(secretKeyBytes);
-                result.setPrivateKey(privateKey);
-                result.setPublicKey(publicKey);
-                return result;
-            } else {
-
-                final Long appId = applicationVersionEntity.getApplication().getRid();
-
-                final Optional<ActivationRecordEntity> activationWithoutLock = activationRepository.findActivationWithoutLock(requestClaims.getActivationId());
-                if (activationWithoutLock.isEmpty()) {
-                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-                }
-                final ActivationRecordEntity activation = activationWithoutLock.get();
-                if ((activation.getActivationStatus() != ActivationStatus.ACTIVE && activation.getActivationStatus() != ActivationStatus.BLOCKED)
-                        || activation.getProtocol() == ActivationProtocol.FIDO2 // FIDO2 does not support temporary keys anywhere
-                        || !Objects.equals(appId, activation.getApplication().getRid())) {
-                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
-                }
-
-                final EncryptionMode encryptionMode = activation.getServerPrivateKeyEncryption();
-                final String serverPrivateKeyBase64 = activation.getServerPrivateKeyBase64();
-                final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(encryptionMode, serverPrivateKeyBase64);
-                final String decryptedServerPrivateKey = serverPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, activation.getUserId(), activation.getActivationId());
-                final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(decryptedServerPrivateKey);
-                final PrivateKey serverPrivateKey = KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
-
-                final byte[] serverPublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-                final PublicKey serverPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, serverPublicKeyBytes);
-
-                final byte[] devicePublicKeyBytes = Base64.getDecoder().decode(activation.getDevicePublicKeyBase64());
-                final PublicKey devicePublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, devicePublicKeyBytes);
-                final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
-
-                final byte[] applicationSecretKeyBytes = Base64.getDecoder().decode(applicationSecret);
-                final SecretKey secretKey = KEY_GENERATOR.deriveSecretKeyHmac(transportKey, applicationSecretKeyBytes);
-                final byte[] secretKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(secretKey);
-
-                final TemporaryKeyResult result = new TemporaryKeyResult();
-                result.setSecretKeyBytes(secretKeyBytes);
-                result.setPrivateKey(serverPrivateKey);
-                result.setPublicKey(serverPublicKey);
-                return result;
-            }
-        } else {
-            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
-        }
-    }
-
-    /**
-     * Get the temporary private key, decrypt if required.
-     * @param id Key ID.
-     * @param appKey App key.
-     * @param activationId Activation ID.
-     * @return Temporary private key.
-     * @throws GenericServiceException In case some parameters did not match.
-     * @throws InvalidKeySpecException In case the private key could not be converted.
-     * @throws CryptoProviderException In case the crypto provider is not configured properly.
-     */
-    public PrivateKey temporaryPrivateKey(String id, String appKey, String activationId) throws GenericServiceException, InvalidKeySpecException, CryptoProviderException {
-        final Date currentTimestamp = new Date();
-        final Optional<TemporaryKeyEntity> temporaryKeyEntity = temporaryKeyRepository.findById(id);
-        if (temporaryKeyEntity.isEmpty()) {
-            logger.error("Missing temporary key pair with ID: {}", id);
-            // Rollback is not required, database is not used for writing
-            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
-        }
-        final TemporaryKeyEntity temporaryKey = temporaryKeyEntity.get();
-        if (temporaryKey.getTimestampExpires().before(currentTimestamp)) {
-            logger.error("Requesting expired temporary key pair with ID: {}", id);
-            // Rollback is not required, database is not used for writing
-            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
-        }
-        if (!Objects.equals(temporaryKey.getAppKey(), appKey) || !Objects.equals(temporaryKey.getActivationId(), activationId)) {
-            logger.error("Temporary key does not match request parameters, app key expected: {}, received: {}, activation ID expected: {}, received: {}",
-                    temporaryKey.getAppKey(), appKey,
-                    temporaryKey.getActivationId(), activationId);
-            // Rollback is not required, database is not used for writing
-            throw localizationProvider.buildExceptionForCode(ServiceError.MISSING_TEMPORARY_KEY);
-        }
-        final String serverPrivateKeyFromEntity = temporaryKey.getPrivateKeyBase64();
-        final EncryptionMode serverPrivateKeyEncryptionMode = temporaryKey.getPrivateKeyEncryption();
-        final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
-        final String serverPrivateKeyBase64 = temporaryPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, temporaryKey.getId(), temporaryKey.getAppKey(), temporaryKey.getActivationId());
-        final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
-        return KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P256, serverPrivateKeyBytes);
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
@@ -19,19 +19,37 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto.v4;
 
+import com.wultra.security.powerauth.app.server.converter.MasterPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.database.model.*;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BaseKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicKey;
-import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
-import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import com.wultra.security.powerauth.app.server.service.model.crypto.EcPublicKey;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Date;
 
 /**
  * Cryptography Service V4 implementation based on EC curve P-384.
@@ -39,11 +57,71 @@ import javax.crypto.SecretKey;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Service
-public class CryptographyServiceEc384 implements CryptographyService {
+@Slf4j
+public class CryptographyServiceEc384 extends CryptographyService {
+
+    private final MasterKeyPairRepository masterKeyPairRepository;
+    private final LocalizationProvider localizationProvider;
+    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
+    private final ServerPrivateKeysConverter serverPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private final KeyGenerator KEY_GENERATOR_EC = new KeyGenerator();
+
+    @Autowired
+    public CryptographyServiceEc384(MasterKeyPairRepository masterKeyPairRepository, LocalizationProvider localizationProvider, EncryptionServiceAead encryptionService, MasterPrivateKeysConverter masterPrivateKeysConverter, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
+        super(localizationProvider, encryptionService);
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.localizationProvider = localizationProvider;
+        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
+        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
+        this.publicKeysConverter = publicKeysConverter;
+    }
 
     @Override
     public void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException {
-        // TODO
+        try {
+            // Generate P-384 key pair
+            final KeyPair kp = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
+            final PrivateKey privateKey = kp.getPrivate();
+            final PublicKey publicKey = kp.getPublic();
+
+            // Key pairs for multiple algorithms are stored for the same entity
+            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+            final PrivateKeyRegistry privateKeyRegistry;
+            final PublicKeyRegistry publicKeyRegistry;
+            if (keyPair == null) {
+                keyPair = new MasterKeyPairEntity();
+                privateKeyRegistry = new PrivateKeyRegistry();
+                publicKeyRegistry = new PublicKeyRegistry();
+                // Store empty values for v3
+                keyPair.setMasterKeyPrivateBase64("");
+                keyPair.setMasterKeyPublicBase64("");
+                keyPair.setApplication(application);
+                keyPair.setName(application.getId() + " Default Keypair");
+                keyPair.setTimestampCreated(new Date());
+            } else {
+                final PrivateKeys privateKeys = new PrivateKeys(keyPair.getMasterPrivateKeysEncryption(), keyPair.getMasterPrivateKeys());
+                privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(privateKeys, application.getId());
+                publicKeyRegistry = publicKeysConverter.fromDBValue(keyPair.getMasterPublicKeys());
+            }
+
+            // Store private and public keys for EC curve P-384 in JSON format
+            privateKeyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA, privateKey);
+            final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
+            keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
+            keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
+
+            publicKeyRegistry.storePublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA, publicKey);
+            final String publicKeys384Json = publicKeysConverter.toDBValue(publicKeyRegistry);
+            keyPair.setMasterPublicKeys(publicKeys384Json);
+
+            masterKeyPairRepository.save(keyPair);
+        } catch (CryptoProviderException e) {
+            logger.error("Could not generate keypair", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
     }
 
     @Override
@@ -60,18 +138,55 @@ public class CryptographyServiceEc384 implements CryptographyService {
 
     @Override
     public void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
-        // TODO
+        try {
+            final KeyPair serverKeyPair = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
+
+            // Store server public key in JSON format
+            final PublicKeyRegistry serverPublicKeys = new PublicKeyRegistry();
+            serverPublicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA, serverKeyPair.getPublic());
+            activation.setServerPublicKeys(publicKeysConverter.toDBValue(serverPublicKeys));
+
+            // Store server private key in JSON format
+            final PrivateKeyRegistry serverPrivateKeys = new PrivateKeyRegistry();
+            serverPrivateKeys.storePrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA, serverKeyPair.getPrivate());
+            final PrivateKeys privateKeys = serverPrivateKeysConverter.toDBValue(serverPrivateKeys, activation.getUserId(), activation.getActivationId());
+            activation.setServerPrivateKeysEncryption(privateKeys.encryptionMode());
+            activation.setServerPrivateKeys(privateKeys.privateKeysBase64());
+        } catch (CryptoProviderException e) {
+            logger.error("Could not generate keypair", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
     }
 
     @Override
-    public BasePublicKey convertDevicePublicKey(byte[] devicePublicKey) throws GenericServiceException {
-        // TODO
-        return null;
+    public BasePublicKey convertDevicePublicKey(KeyType keyType, byte[] devicePublicKey) throws GenericServiceException {
+        if (keyType != KeyType.ECDSA) {
+            throw new IllegalArgumentException("Unsupported key type: " + keyType);
+        }
+        try {
+            final PublicKey convertedPublicKey = KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, devicePublicKey);
+            return EcPublicKey.builder().ecPublicKey(convertedPublicKey).build();
+        } catch (InvalidKeySpecException e) {
+            logger.error("Invalid device public key", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (CryptoProviderException | GenericCryptoException e) {
+            logger.error("Key conversion failed", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
     }
 
     @Override
     public void storeDevicePublicKey(ActivationRecordEntity activation, BasePublicKey devicePublicKey) throws GenericServiceException {
-        // TODO
+        // The device public key is stored in JSON format in column device_public_keys
+        final PublicKey ecPublicKey = ((EcPublicKey) devicePublicKey).getEcPublicKey();
+        final PublicKeyRegistry publicKeys;
+        if (activation.getDevicePublicKeys() != null) {
+            publicKeys = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
+        } else {
+            publicKeys = new PublicKeyRegistry();
+        }
+        publicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA, ecPublicKey);
+        activation.setDevicePublicKeys(publicKeysConverter.toDBValue(publicKeys));
     }
 
     @Override
@@ -96,24 +211,6 @@ public class CryptographyServiceEc384 implements CryptographyService {
     public boolean verifySignatureForActivation(byte[] data, byte[] signature, ActivationRecordEntity activation) throws GenericServiceException {
         // TODO
         return false;
-    }
-
-    @Override
-    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public EncryptorSecrets deriveSecrets(EncryptedRequest request, EncryptionContext context) throws GenericServiceException {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String requestTemporaryKey(String jwt) throws GenericServiceException {
-        // TODO
-        return "";
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
@@ -137,7 +137,7 @@ public class CryptographyServiceEc384 extends CryptographyService {
     }
 
     @Override
-    public void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
+    public void generateServerKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
         try {
             final KeyPair serverKeyPair = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
@@ -152,7 +152,7 @@ public class CryptographyServiceHybrid extends CryptographyService {
     }
 
     @Override
-    public void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
+    public void generateServerKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
         try {
             final KeyPair serverKeyPairEc = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
             final KeyPair serverKeyPairPqc = PQC_DSA.generateKeyPair();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
@@ -19,19 +19,43 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto.v4;
 
+import com.wultra.security.powerauth.app.server.converter.MasterPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BaseKeyPair;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicKey;
-import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
-import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
+import com.wultra.security.powerauth.app.server.service.model.crypto.EcPublicKey;
+import com.wultra.security.powerauth.app.server.service.model.crypto.PqcPublicKey;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.PqcDsaKeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.PqcDsa;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Date;
 
 /**
  * Cryptography Service V4 implementation based on hybrid scheme with EC curve P-384 and ML-DSA-65.
@@ -39,11 +63,80 @@ import javax.crypto.SecretKey;
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Service
-public class CryptographyServiceHybrid implements CryptographyService {
+@Slf4j
+public class CryptographyServiceHybrid extends CryptographyService {
+
+    private final MasterKeyPairRepository masterKeyPairRepository;
+    private final LocalizationProvider localizationProvider;
+    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
+    private final ServerPrivateKeysConverter serverPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+    private final KeyGenerator KEY_GENERATOR_EC = new KeyGenerator();
+    private final PqcDsa PQC_DSA = new PqcDsa();
+    private final PqcDsaKeyConvertor KEY_CONVERTOR_PQC_DSA = new PqcDsaKeyConvertor();
+
+    @Autowired
+    public CryptographyServiceHybrid(MasterKeyPairRepository masterKeyPairRepository, LocalizationProvider localizationProvider, EncryptionServiceAead encryptionService, MasterPrivateKeysConverter masterPrivateKeysConverter, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
+        super(localizationProvider, encryptionService);
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.localizationProvider = localizationProvider;
+        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
+        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
+        this.publicKeysConverter = publicKeysConverter;
+    }
 
     @Override
     public void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException {
-        // TODO
+        try {
+            // Generate P-384 key pair
+            final KeyPair kp384 = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
+            final PrivateKey privateKey = kp384.getPrivate();
+            final PublicKey publicKey = kp384.getPublic();
+
+            // Generate PQC key pair
+            final KeyPair kpPqcDsa = PQC_DSA.generateKeyPair();
+            final PrivateKey privateKeyPqcDsa = kpPqcDsa.getPrivate();
+            final PublicKey publicKeyPqcDsa = kpPqcDsa.getPublic();
+
+            // Key pairs for multiple algorithms are stored for the same entity
+            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+            final PrivateKeyRegistry privateKeyRegistry;
+            final PublicKeyRegistry publicKeyRegistry;
+            if (keyPair == null) {
+                keyPair = new MasterKeyPairEntity();
+                privateKeyRegistry = new PrivateKeyRegistry();
+                publicKeyRegistry = new PublicKeyRegistry();
+                // Store empty values for v3
+                keyPair.setMasterKeyPrivateBase64("");
+                keyPair.setMasterKeyPublicBase64("");
+                keyPair.setApplication(application);
+                keyPair.setName(application.getId() + " Default Keypair");
+                keyPair.setTimestampCreated(new Date());
+            } else {
+                final PrivateKeys privateKeys = new PrivateKeys(keyPair.getMasterPrivateKeysEncryption(), keyPair.getMasterPrivateKeys());
+                privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(privateKeys, application.getId());
+                publicKeyRegistry = publicKeysConverter.fromDBValue(keyPair.getMasterPublicKeys());
+            }
+
+            // Store private and public keys for EC curve P-384 in JSON format
+            privateKeyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, privateKey);
+            privateKeyRegistry.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, privateKeyPqcDsa);
+            final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
+            keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
+            keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
+
+            publicKeyRegistry.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, publicKey);
+            publicKeyRegistry.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, publicKeyPqcDsa);
+            final String publicKeys384Json = publicKeysConverter.toDBValue(publicKeyRegistry);
+            keyPair.setMasterPublicKeys(publicKeys384Json);
+
+            masterKeyPairRepository.save(keyPair);
+        } catch (CryptoProviderException | GenericCryptoException e) {
+            logger.error("Could not generate keypair", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
     }
 
     @Override
@@ -60,18 +153,80 @@ public class CryptographyServiceHybrid implements CryptographyService {
 
     @Override
     public void generateDeviceKeyPair(ActivationRecordEntity activation) throws GenericServiceException {
-        // TODO
+        try {
+            final KeyPair serverKeyPairEc = KEY_GENERATOR_EC.generateKeyPair(EcCurve.P384);
+            final KeyPair serverKeyPairPqc = PQC_DSA.generateKeyPair();
+
+            // Store server public key in JSON format
+            final PublicKeyRegistry serverPublicKeys = new PublicKeyRegistry();
+            serverPublicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, serverKeyPairEc.getPublic());
+            serverPublicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, serverKeyPairPqc.getPublic());
+            activation.setServerPublicKeys(publicKeysConverter.toDBValue(serverPublicKeys));
+
+            // Store server private key in JSON format
+            final PrivateKeyRegistry serverPrivateKeys = new PrivateKeyRegistry();
+            serverPrivateKeys.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, serverKeyPairEc.getPrivate());
+            serverPrivateKeys.storePrivateKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, serverKeyPairPqc.getPrivate());
+            final PrivateKeys privateKeys = serverPrivateKeysConverter.toDBValue(serverPrivateKeys, activation.getUserId(), activation.getActivationId());
+            activation.setServerPrivateKeysEncryption(privateKeys.encryptionMode());
+            activation.setServerPrivateKeys(privateKeys.privateKeysBase64());
+        } catch (CryptoProviderException | GenericCryptoException e) {
+            logger.error("Could not generate keypair", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
     }
 
     @Override
-    public BasePublicKey convertDevicePublicKey(byte[] devicePublicKey) throws GenericServiceException {
-        // TODO
+    public BasePublicKey convertDevicePublicKey(KeyType keyType, byte[] devicePublicKey) throws GenericServiceException {
+        try {
+            switch (keyType) {
+                case ECDSA -> {
+                    final PublicKey convertedPublicKey = KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, devicePublicKey);
+                    return EcPublicKey.builder().ecPublicKey(convertedPublicKey).build();
+                }
+                case MLDSA -> {
+                    final PublicKey convertedPublicKey = KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(devicePublicKey);
+                    return PqcPublicKey.builder().pqcPublicKey(convertedPublicKey).build();
+                }
+            }
+        } catch (InvalidKeySpecException e) {
+            logger.error("Invalid device public key", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (CryptoProviderException | GenericCryptoException e) {
+            logger.error("Key conversion failed", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
         return null;
     }
 
     @Override
     public void storeDevicePublicKey(ActivationRecordEntity activation, BasePublicKey devicePublicKey) throws GenericServiceException {
-        // TODO
+        // The device public key is stored in JSON format in column device_public_keys
+        if (devicePublicKey instanceof EcPublicKey) {
+            final PublicKey ecPublicKey = ((EcPublicKey) devicePublicKey).getEcPublicKey();
+            final PublicKeyRegistry publicKeys;
+            if (activation.getDevicePublicKeys() != null) {
+                publicKeys = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
+            } else {
+                publicKeys = new PublicKeyRegistry();
+            }
+            publicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.ECDSA, ecPublicKey);
+            activation.setDevicePublicKeys(publicKeysConverter.toDBValue(publicKeys));
+            return;
+        }
+        if (devicePublicKey instanceof PqcPublicKey) {
+            final PublicKey pqcPublicKey = ((PqcPublicKey) devicePublicKey).getPqcPublicKey();
+            final PublicKeyRegistry publicKeys;
+            if (activation.getDevicePublicKeys() != null) {
+                publicKeys = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
+            } else {
+                publicKeys = new PublicKeyRegistry();
+            }
+            publicKeys.storePublicKey(SharedSecretAlgorithm.EC_P384_ML_L3, KeyType.MLDSA, pqcPublicKey);
+            activation.setDevicePublicKeys(publicKeysConverter.toDBValue(publicKeys));
+            return;
+        }
+        throw new IllegalArgumentException("Unsupported key type: " + devicePublicKey.getClass());
     }
 
     @Override
@@ -96,24 +251,6 @@ public class CryptographyServiceHybrid implements CryptographyService {
     public boolean verifySignatureForActivation(byte[] data, byte[] signature, ActivationRecordEntity activation) throws GenericServiceException {
         // TODO
         return false;
-    }
-
-    @Override
-    public DecryptionResult decryptRequest(EncryptedRequest encryptedRequest, EncryptionContext context) throws GenericServiceException {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public EncryptorSecrets deriveSecrets(EncryptedRequest request, EncryptionContext context) throws GenericServiceException {
-        // TODO
-        return null;
-    }
-
-    @Override
-    public String requestTemporaryKey(String jwt) throws GenericServiceException {
-        // TODO
-        return "";
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
@@ -202,8 +202,8 @@ public class CryptographyServiceHybrid extends CryptographyService {
     @Override
     public void storeDevicePublicKey(ActivationRecordEntity activation, BasePublicKey devicePublicKey) throws GenericServiceException {
         // The device public key is stored in JSON format in column device_public_keys
-        if (devicePublicKey instanceof EcPublicKey) {
-            final PublicKey ecPublicKey = ((EcPublicKey) devicePublicKey).getEcPublicKey();
+        if (devicePublicKey instanceof EcPublicKey ecDevicePublicKey) {
+            final PublicKey ecPublicKey = ecDevicePublicKey.getEcPublicKey();
             final PublicKeyRegistry publicKeys;
             if (activation.getDevicePublicKeys() != null) {
                 publicKeys = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
@@ -214,8 +214,8 @@ public class CryptographyServiceHybrid extends CryptographyService {
             activation.setDevicePublicKeys(publicKeysConverter.toDBValue(publicKeys));
             return;
         }
-        if (devicePublicKey instanceof PqcPublicKey) {
-            final PublicKey pqcPublicKey = ((PqcPublicKey) devicePublicKey).getPqcPublicKey();
+        if (devicePublicKey instanceof PqcPublicKey pqcDevicePublicKey) {
+            final PublicKey pqcPublicKey = pqcDevicePublicKey.getPqcPublicKey();
             final PublicKeyRegistry publicKeys;
             if (activation.getDevicePublicKeys() != null) {
                 publicKeys = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
@@ -61,6 +61,11 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Date;
 
+/**
+ * Encryption service for AEAD (V4).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
 @Service
 @Slf4j
 public class EncryptionServiceAead extends EncryptionService {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
@@ -1,0 +1,185 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.crypto.v4;
+
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.UniqueValueType;
+import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
+import com.wultra.security.powerauth.app.server.service.crypto.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResult;
+import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResultVaultUnlock;
+import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificationService;
+import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Date;
+
+@Service
+@Slf4j
+public class EncryptionServiceAead extends EncryptionService {
+
+    private final LocalizationProvider localizationProvider;
+    private final TemporaryKeyServiceAead temporaryKeyService;
+    private final ReplayVerificationService replayVerificationService;
+    private final ServerPrivateKeysConverter serverPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+
+    private final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
+    private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+    private final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
+
+    @Autowired
+    public EncryptionServiceAead(ApplicationVersionRepository applicationVersionRepository, LocalizationProvider localizationProvider, TemporaryKeyServiceAead temporaryKeyService, ActivationQueryService activationQueryService, ReplayVerificationService replayVerificationService, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
+        super(localizationProvider, applicationVersionRepository, activationQueryService);
+        this.localizationProvider = localizationProvider;
+        this.temporaryKeyService = temporaryKeyService;
+        this.replayVerificationService = replayVerificationService;
+        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
+        this.publicKeysConverter = publicKeysConverter;
+    }
+
+    @Override
+    public DecryptionResult decrypt(EncryptedRequest encryptedRequest, String protocolVersion, String applicationKey, String activationId, EncryptorId encryptorId, boolean validateRequest) throws GenericServiceException {
+        try {
+            // Validate encrypted request
+            if (validateRequest && !ENCRYPTOR_FACTORY.getRequestResponseValidator(protocolVersion).validateEncryptedRequest(encryptedRequest)) {
+                logger.warn("Invalid encrypted request parameters");
+                // Rollback is not required, error occurs before writing to database
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
+
+            final ApplicationVersionEntity applicationVersion = findApplicationVersion(applicationKey);
+            final ActivationRecordEntity activation = findActivation(activationId);
+
+            final AeadEncryptedRequest aeadRequest = (AeadEncryptedRequest) encryptedRequest;
+            final UniqueValueType uniqueValueType = switch (encryptorId) {
+                case APPLICATION_SCOPE_GENERIC, ACTIVATION_LAYER_2 -> UniqueValueType.ECIES_APPLICATION_SCOPE;
+                case ACTIVATION_SCOPE_GENERIC, UPGRADE, VAULT_UNLOCK, CREATE_TOKEN ->
+                        UniqueValueType.ECIES_ACTIVATION_SCOPE;
+            };
+            if (aeadRequest.getTimestamp() != null) {
+                // Check AEAD request for replay attacks and persist unique value from request
+                replayVerificationService.checkAndPersistUniqueValue(
+                        uniqueValueType,
+                        new Date(aeadRequest.getTimestamp()),
+                        null,
+                        aeadRequest.getNonce(),
+                        aeadRequest.getTemporaryKeyId(),
+                        protocolVersion);
+            }
+            if (activation == null) {
+                return decryptInApplicationScope(aeadRequest, protocolVersion, applicationVersion, encryptorId);
+            } else {
+                return decryptInActivationScope(aeadRequest, protocolVersion, applicationVersion, activation, encryptorId);
+            }
+        } catch (InvalidKeySpecException | InvalidKeyException e) {
+            logger.error("Invalid key", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (EncryptorException | CryptoProviderException | GenericCryptoException e) {
+            logger.error("Decryption failed", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
+    }
+
+    private DecryptionResult decryptInApplicationScope(AeadEncryptedRequest aeadRequest, String protocolVersion, ApplicationVersionEntity applicationVersion, EncryptorId encryptorId) throws GenericServiceException, InvalidKeySpecException, CryptoProviderException, EncryptorException {
+        final SecretKey sharedSecret = temporaryKeyService.extractTemporarySharedSecret(aeadRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey(), null);
+        final byte[] sharedSecretBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(sharedSecret);
+        final DecryptionResult decryptionResult = new DecryptionResult();
+        decryptionResult.setServerEncryptor(ENCRYPTOR_FACTORY.getServerEncryptor(
+                encryptorId,
+                new EncryptorParameters(protocolVersion, applicationVersion.getApplicationKey(), null, aeadRequest.getTemporaryKeyId()),
+                new AeadSecrets(sharedSecretBytes, applicationVersion.getApplicationSecret())
+        ));
+        decryptionResult.setApplication(applicationVersion.getApplication());
+        return decryptionResult;
+    }
+
+    private DecryptionResult decryptInActivationScope(AeadEncryptedRequest aeadRequest, String protocolVersion, ApplicationVersionEntity applicationVersion, ActivationRecordEntity activation, EncryptorId encryptorId) throws GenericServiceException, InvalidKeySpecException, CryptoProviderException, EncryptorException, GenericCryptoException, InvalidKeyException {
+        // Check that application key from request belongs to same application as activation ID from request
+        if (!applicationVersion.getApplication().getRid().equals(activation.getApplication().getRid())) {
+            logger.warn("Application version does not match, application key: {}", applicationVersion.getApplicationKey());
+            // Rollback is not required, database is not used for writing
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+        }
+        final SecretKey sharedSecret = temporaryKeyService.extractTemporarySharedSecret(aeadRequest.getTemporaryKeyId(), applicationVersion.getApplicationKey(), activation.getActivationId());
+
+        final String serverPrivateKeys = activation.getServerPrivateKeys();
+        final EncryptionMode encryptionMode = activation.getServerPrivateKeysEncryption();
+        final PrivateKeys privateKeys = new PrivateKeys(encryptionMode, serverPrivateKeys);
+        final PrivateKeyRegistry privateKeyRegistry = serverPrivateKeysConverter.fromDBValue(privateKeys, activation.getUserId(), activation.getActivationId());
+        final PrivateKey serverPrivateKey = privateKeyRegistry.getPrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+
+        final String devicePublicKeys = activation.getDevicePublicKeys();
+        final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(devicePublicKeys);
+        final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+
+        // Get application secret and transport key used in sharedInfo2 parameter of AEAD secrets
+        final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
+        final byte[] transportKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportKey);
+
+        final DecryptionResult decryptionResult;
+        if (encryptorId == EncryptorId.VAULT_UNLOCK) {
+            DecryptionResultVaultUnlock decryptionResultVaultUnlock = new DecryptionResultVaultUnlock();
+            decryptionResultVaultUnlock.setServerPrivateKey(serverPrivateKey);
+            decryptionResultVaultUnlock.setDevicePublicKey(devicePublicKey);
+            decryptionResult = decryptionResultVaultUnlock;
+        } else {
+            decryptionResult = new DecryptionResult();
+        }
+        decryptionResult.setServerEncryptor(ENCRYPTOR_FACTORY.getServerEncryptor(
+                encryptorId,
+                new EncryptorParameters(protocolVersion, applicationVersion.getApplicationKey(), activation.getActivationId(), aeadRequest.getTemporaryKeyId()),
+                new AeadSecrets(sharedSecret.getEncoded(), applicationVersion.getApplicationSecret(), transportKeyBytes)
+        ));
+        decryptionResult.setApplication(applicationVersion.getApplication());
+        return decryptionResult;
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
@@ -161,6 +161,7 @@ public class EncryptionServiceAead extends EncryptionService {
         final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
 
         // Get application secret and transport key used in sharedInfo2 parameter of AEAD secrets
+        // TODO - update sharedInfo2 calculation for crypto4 after server key factory is updated
         final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
         final byte[] transportKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportKey);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -254,6 +254,32 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
         if (requestClaims.getApplicationKey() == null && requestClaims.getActivationId() == null) {
             return "Either app key or activation ID must be specified.";
         }
+        if (requestClaims.getChallenge() == null) {
+            return "Challenge must be specified.";
+        }
+        if (requestClaims.getSharedSecretRequest() == null) {
+            return "Shared secret request must be specified.";
+        }
+        if (requestClaims.getSharedSecretRequest().getAlgorithm() == null) {
+            return "Shared secret algorithm must be specified.";
+        }
+        if (!SharedSecretAlgorithm.EC_P384.toString().equals(requestClaims.getSharedSecretRequest().getAlgorithm())
+                && !SharedSecretAlgorithm.EC_P384_ML_L3.toString().equals(requestClaims.getSharedSecretRequest().getAlgorithm())) {
+            return "Invalid shared secret algorithm value.";
+        }
+        if (SharedSecretAlgorithm.EC_P384.toString().equals(requestClaims.getSharedSecretRequest().getAlgorithm())) {
+            if (requestClaims.getSharedSecretRequest().getEcdhe() == null) {
+                return "Shared secret ecdhe value must be specified for algorithm EC_P384.";
+            }
+        }
+        if (SharedSecretAlgorithm.EC_P384_ML_L3.toString().equals(requestClaims.getSharedSecretRequest().getAlgorithm())) {
+            if (requestClaims.getSharedSecretRequest().getEcdhe() == null) {
+                return "Shared secret ecdhe value must be specified for algorithm EC_P384_ML_L3.";
+            }
+            if (requestClaims.getSharedSecretRequest().getMlkem() == null) {
+                return "Shared secret mlkem value must be specified for algorithm EC_P384_ML_L3.";
+            }
+        }
         return null;
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -1,0 +1,420 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.crypto.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wultra.security.powerauth.app.server.configuration.PowerAuthServiceConfiguration;
+import com.wultra.security.powerauth.app.server.converter.*;
+import com.wultra.security.powerauth.app.server.database.model.*;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.TemporaryKeyEntity;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationProtocol;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.database.repository.ActivationRepository;
+import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
+import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
+import com.wultra.security.powerauth.app.server.database.repository.TemporaryKeyRepository;
+import com.wultra.security.powerauth.app.server.service.crypto.TemporaryKeyService;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.model.crypto.TemporaryKeyResult;
+import com.wultra.security.powerauth.app.server.service.util.jwt.MACVerifier16B;
+import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
+import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretResponse;
+import com.wultra.security.powerauth.client.model.entity.v4.TemporaryPublicKeyRequestClaims;
+import com.wultra.security.powerauth.client.model.entity.v4.TemporaryPublicKeyResponseClaims;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.crypto.lib.v4.model.request.SharedSecretRequestEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.model.request.SharedSecretRequestHybrid;
+import com.wultra.security.powerauth.crypto.lib.v4.model.response.ResponseCryptogram;
+import com.wultra.security.powerauth.crypto.lib.v4.model.response.SharedSecretResponseEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.model.response.SharedSecretResponseHybrid;
+import com.wultra.security.powerauth.crypto.lib.v4.sharedsecret.SharedSecretEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.sharedsecret.SharedSecretHybrid;
+import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.text.ParseException;
+import java.util.*;
+
+/**
+ * Service for handling temporary keys with AEAD encryption on curve P-384 with optional PQC KEM.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+@Slf4j
+public class TemporaryKeyServiceAead extends TemporaryKeyService {
+
+    private final ActivationRepository activationRepository;
+    private final PowerAuthServiceConfiguration powerAuthServiceConfiguration;
+    private final TemporaryPrivateKeyConverter temporaryPrivateKeyConverter;
+    private final SharedSecretConverter sharedSecretConverter;
+    private final TemporaryKeyRepository temporaryKeyRepository;
+    private final LocalizationProvider localizationProvider;
+    private final ApplicationVersionRepository applicationVersionRepository;
+    private final MasterKeyPairRepository masterKeyPairRepository;
+    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
+    private final ServerPrivateKeysConverter serverPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+    private final ObjectMapper objectMapper;
+
+    private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+    private final KeyGenerator KEY_GENERATOR = new KeyGenerator();
+    private final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
+    private final SharedSecretEcdhe SHARED_SECRET_ECDHE = new SharedSecretEcdhe();
+    private final SharedSecretHybrid SHARED_SECRET_HYBRID = new SharedSecretHybrid();
+
+    @Autowired
+    public TemporaryKeyServiceAead(ActivationRepository activationRepository, PowerAuthServiceConfiguration powerAuthServiceConfiguration, TemporaryPrivateKeyConverter temporaryPrivateKeyConverter, SharedSecretConverter sharedSecretConverter, TemporaryKeyRepository temporaryKeyRepository, LocalizationProvider localizationProvider, ApplicationVersionRepository applicationVersionRepository, MasterKeyPairRepository masterKeyPairRepository, MasterPrivateKeysConverter masterPrivateKeysConverter, ObjectMapper objectMapper, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
+        super(localizationProvider, temporaryKeyRepository);
+        this.activationRepository = activationRepository;
+        this.powerAuthServiceConfiguration = powerAuthServiceConfiguration;
+        this.temporaryPrivateKeyConverter = temporaryPrivateKeyConverter;
+        this.sharedSecretConverter = sharedSecretConverter;
+        this.temporaryKeyRepository = temporaryKeyRepository;
+        this.localizationProvider = localizationProvider;
+        this.applicationVersionRepository = applicationVersionRepository;
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
+        this.objectMapper = objectMapper;
+        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
+        this.publicKeysConverter = publicKeysConverter;
+    }
+
+    /**
+     * Request a temporary key.
+     * @param jwt Temporary key request in JWT format.
+     * @return Temporary key in JWT format.
+     * @throws GenericServiceException In case of a cryptography error.
+     */
+    @Override
+    public String requestTemporaryKey(String jwt) throws GenericServiceException {
+        try {
+            final SignedJWT decodedJWT = SignedJWT.parse(jwt);
+            final TemporaryPublicKeyRequestClaims requestClaims = buildTemporaryKeyClaims(decodedJWT);
+
+            // Validate claims
+            final String error = validateDecodedClaims(requestClaims);
+            if (error != null) {
+                logger.warn("Error occurred while decoding JWT claims: {}", error);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
+
+            // Obtain verifier secret and check JWT signature
+            final TemporaryKeyResult temporaryKeyResult = obtainTemporaryKeyResult(requestClaims);
+            // TODO - switch to standard ECDSA verifier after key derived with KMAC-256 is used
+            final MACVerifier16B verifier = new MACVerifier16B(temporaryKeyResult.getSecretKeyBytes());
+            boolean verified = decodedJWT.verify(verifier);
+            if (!verified) {
+                logger.debug("JWT token verification failed.");
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
+
+            final Date currentTimestamp = new Date();
+
+            // Derive shared secret using SharedSecret algorithm
+            final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(requestClaims.getSharedSecretRequest().getAlgorithm());
+            final ResponseCryptogram sharedSecretResponse = deriveSharedSecret(temporaryKeyResult.getSharedSecretRequest(), algorithm);
+
+            // Generate new key and store it
+            final KeyPair temporaryKeyPair = KEY_GENERATOR.generateKeyPair(EcCurve.P384);
+            final TemporaryPublicKeyResponseClaims responseClaims = storeTemporaryKey(requestClaims, currentTimestamp, temporaryKeyPair, sharedSecretResponse, algorithm);
+
+            // Built and return the response claims
+            // TODO - add Dilithium signature using custom signer
+            final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).type(JOSEObjectType.JWT).build();
+            final JWTClaimsSet claimsSet = buildClaims(responseClaims, currentTimestamp);
+
+            final ECDSASigner signer = new ECDSASigner(temporaryKeyResult.getPrivateKey(), Curve.P_384);
+
+            final SignedJWT signedJWT = new SignedJWT(header, claimsSet);
+            signedJWT.sign(signer);
+            return signedJWT.serialize();
+        } catch (ParseException | JOSEException e) {
+            logger.error("Temporary key request is invalid", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        } catch (InvalidKeySpecException | InvalidKeyException e) {
+            logger.error("Invalid key", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (CryptoProviderException | GenericCryptoException e) {
+            logger.error("Temporary key request failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
+    }
+
+    @Override
+    public PrivateKey extractTemporaryPrivateKey(String id, String appKey, String activationId) throws GenericServiceException {
+        try {
+            final TemporaryKeyEntity temporaryKey = fetchTemporaryKey(id, appKey, activationId);
+            final String serverPrivateKeyFromEntity = temporaryKey.getPrivateKeyBase64();
+            final EncryptionMode serverPrivateKeyEncryptionMode = temporaryKey.getPrivateKeyEncryption();
+            final ServerPrivateKey serverPrivateKeyEncrypted = new ServerPrivateKey(serverPrivateKeyEncryptionMode, serverPrivateKeyFromEntity);
+            final String serverPrivateKeyBase64 = temporaryPrivateKeyConverter.fromDBValue(serverPrivateKeyEncrypted, temporaryKey.getId(), temporaryKey.getAppKey(), temporaryKey.getActivationId());
+            final byte[] serverPrivateKeyBytes = Base64.getDecoder().decode(serverPrivateKeyBase64);
+            return KEY_CONVERTOR.convertBytesToPrivateKey(EcCurve.P384, serverPrivateKeyBytes);
+        } catch (InvalidKeySpecException e) {
+            logger.error("Invalid key", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (CryptoProviderException e) {
+            logger.error("Temporary key request failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
+    }
+
+    @Override
+    public SecretKey extractTemporarySharedSecret(String id, String appKey, String activationId) throws GenericServiceException {
+        try {
+            final TemporaryKeyEntity temporaryKey = fetchTemporaryKey(id, appKey, activationId);
+            final String secretKeyBase64 = temporaryKey.getSecretKeyBase64();
+            final EncryptionMode secretKeyEncryption = temporaryKey.getSecretKeyEncryption();
+            final SharedSecret sharedSecretEncrypted = new SharedSecret(secretKeyEncryption, secretKeyBase64);
+            final String sharedSecretBase64 = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, temporaryKey.getId(), temporaryKey.getAppKey(), temporaryKey.getActivationId());
+            final byte[] sharedSecretBytes = Base64.getDecoder().decode(sharedSecretBase64);
+            return KEY_CONVERTOR.convertBytesToSharedSecretKey(sharedSecretBytes);
+        } catch (InvalidKeySpecException e) {
+            logger.error("Invalid key", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_KEY_FORMAT);
+        } catch (CryptoProviderException e) {
+            logger.error("Temporary key request failed", e);
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
+    }
+
+    private TemporaryPublicKeyRequestClaims buildTemporaryKeyClaims(SignedJWT source) throws ParseException, GenericServiceException {
+        final JWTClaimsSet jwtClaimsSet = source.getJWTClaimsSet();
+        final TemporaryPublicKeyRequestClaims destination = new TemporaryPublicKeyRequestClaims();
+        final String applicationKey = jwtClaimsSet.getStringClaim("applicationKey");
+        final String activationId = jwtClaimsSet.getStringClaim("activationId");
+        final String challenge = jwtClaimsSet.getStringClaim("challenge");
+        final Object sharedSecretRequestClaim = jwtClaimsSet.getClaim("sharedSecretRequest");
+        if (applicationKey == null || challenge == null || sharedSecretRequestClaim == null) {
+            logger.error("Temporary key request is invalid");
+            // Rollback is not required, error occurs before writing to database
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+        destination.setApplicationKey(applicationKey);
+        destination.setActivationId(activationId);
+        destination.setChallenge(challenge);
+        final SharedSecretRequest sharedSecretRequest = objectMapper.convertValue(sharedSecretRequestClaim, SharedSecretRequest.class);
+        destination.setSharedSecretRequest(sharedSecretRequest);
+        return destination;
+    }
+
+    private String validateDecodedClaims(TemporaryPublicKeyRequestClaims requestClaims) {
+        if (requestClaims.getApplicationKey() == null && requestClaims.getActivationId() == null) {
+            return "Either app key or activation ID must be specified.";
+        }
+        return null;
+    }
+
+    private JWTClaimsSet buildClaims(TemporaryPublicKeyResponseClaims source, Date currentTimestamp) {
+        return new JWTClaimsSet.Builder()
+                .subject(source.getKeyId())
+                .expirationTime(source.getExpiration())
+                .issueTime(currentTimestamp)
+                .claim("applicationKey", source.getApplicationKey())
+                .claim("activationId", source.getActivationId())
+                .claim("challenge", source.getChallenge())
+                .claim("sharedSecretResponse", source.getSharedSecretResponse())
+                .claim("iat_ms", currentTimestamp.getTime())
+                .claim("exp_ms", source.getExpiration().getTime())
+                .build();
+    }
+
+    private TemporaryPublicKeyResponseClaims storeTemporaryKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp, KeyPair temporaryKeyPair, ResponseCryptogram responseCryptogram, SharedSecretAlgorithm algorithm) throws CryptoProviderException, GenericServiceException {
+        // Prepare the parameters key pair
+        final String keyId = UUID.randomUUID().toString();
+        final String applicationKey = requestClaims.getApplicationKey();
+        final String activationId = requestClaims.getActivationId();
+        final String challenge = requestClaims.getChallenge();
+        final byte[] privateKeyBytes = KEY_CONVERTOR.convertPrivateKeyToBytes(temporaryKeyPair.getPrivate());
+        final String temporaryPublicKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P384, temporaryKeyPair.getPublic()));
+        final Date expirationDate = Date.from(currentTimestamp.toInstant().plusMillis(powerAuthServiceConfiguration.getTemporaryKeyValidity().toMillis()));
+
+        // Prepare encrypted temporary private key, if encryption is enabled
+        final ServerPrivateKey temporaryPrivateKey = temporaryPrivateKeyConverter.toDBValue(
+                privateKeyBytes, keyId, applicationKey, activationId);
+
+        // Prepare encrypted shard secret, if encryption is enabled
+        final SharedSecret sharedSecretConverted = sharedSecretConverter.toDBValue(
+                responseCryptogram.getSecretKey().getEncoded(), keyId, applicationKey, activationId);
+
+        // Prepare and store the entity
+        final TemporaryKeyEntity temporaryKeyEntity = new TemporaryKeyEntity();
+        temporaryKeyEntity.setId(keyId);
+        temporaryKeyEntity.setAppKey(applicationKey);
+        temporaryKeyEntity.setActivationId(activationId);
+        temporaryKeyEntity.setPrivateKeyEncryption(temporaryPrivateKey.encryptionMode());
+        temporaryKeyEntity.setPrivateKeyBase64(temporaryPrivateKey.serverPrivateKeyBase64());
+        temporaryKeyEntity.setPublicKeyBase64(temporaryPublicKeyBase64);
+        temporaryKeyEntity.setSecretKeyEncryption(sharedSecretConverted.encryptionMode());
+        temporaryKeyEntity.setSecretKeyBase64(sharedSecretConverted.sharedSecretBase64());
+        temporaryKeyEntity.setTimestampExpires(expirationDate);
+        final TemporaryKeyEntity savedEntity = temporaryKeyRepository.save(temporaryKeyEntity);
+
+        // Prepare and return the result
+        final SharedSecretResponse sharedSecretResponse = prepareSharedSecretResponse(algorithm, responseCryptogram);
+        final TemporaryPublicKeyResponseClaims result = new TemporaryPublicKeyResponseClaims();
+        result.setApplicationKey(savedEntity.getAppKey());
+        result.setActivationId(savedEntity.getActivationId());
+        result.setKeyId(savedEntity.getId());
+        result.setSharedSecretResponse(sharedSecretResponse);
+        result.setExpiration(savedEntity.getTimestampExpires());
+        result.setChallenge(challenge);
+        return result;
+    }
+
+    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
+        final String applicationKey = requestClaims.getApplicationKey();
+        if (applicationKey != null) {
+            final ApplicationVersionEntity applicationVersionEntity = applicationVersionRepository.findByApplicationKey(applicationKey);
+            if (applicationVersionEntity == null || !applicationVersionEntity.getSupported()) {
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+            }
+            final String applicationSecret = applicationVersionEntity.getApplicationSecret();
+            if (requestClaims.getActivationId() == null) {
+
+                final MasterKeyPairEntity masterKeyPairEntity = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersionEntity.getApplication().getId());
+                final String masterPrivateKeysBase64 = masterKeyPairEntity.getMasterPrivateKeys();
+                final EncryptionMode encryptionMode = masterKeyPairEntity.getMasterPrivateKeysEncryption();
+                final PrivateKeys masterPrivateKeys = new PrivateKeys(encryptionMode, masterPrivateKeysBase64);
+                final PrivateKeyRegistry privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(masterPrivateKeys, applicationVersionEntity.getApplication().getId());
+                final PrivateKey privateKey = privateKeyRegistry.getPrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA)
+                        .orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR));
+
+                final byte[] secretKeyBytes = Base64.getDecoder().decode(applicationSecret);
+
+                final TemporaryKeyResult result = new TemporaryKeyResult();
+                result.setSecretKeyBytes(secretKeyBytes);
+                result.setPrivateKey(privateKey);
+                result.setSharedSecretRequest(requestClaims.getSharedSecretRequest());
+                return result;
+            } else {
+
+                final Long appId = applicationVersionEntity.getApplication().getRid();
+
+                final Optional<ActivationRecordEntity> activationWithoutLock = activationRepository.findActivationWithoutLock(requestClaims.getActivationId());
+                if (activationWithoutLock.isEmpty()) {
+                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+                }
+                final ActivationRecordEntity activation = activationWithoutLock.get();
+                if ((activation.getActivationStatus() != ActivationStatus.ACTIVE && activation.getActivationStatus() != ActivationStatus.BLOCKED)
+                        || activation.getProtocol() == ActivationProtocol.FIDO2 // FIDO2 does not support temporary keys anywhere
+                        || !Objects.equals(appId, activation.getApplication().getRid())) {
+                    throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+                }
+
+                final String serverPrivateKeys = activation.getServerPrivateKeys();
+                final EncryptionMode encryptionMode = activation.getServerPrivateKeysEncryption();
+                final PrivateKeys privateKeys = new PrivateKeys(encryptionMode, serverPrivateKeys);
+                final PrivateKeyRegistry privateKeyRegistry = serverPrivateKeysConverter.fromDBValue(privateKeys, activation.getUserId(), activation.getActivationId());
+                final PrivateKey serverPrivateKey = privateKeyRegistry.getPrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+
+                final String devicePublicKeys = activation.getDevicePublicKeys();
+                final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(devicePublicKeys);
+                final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+                // TODO - switch to a key derived with KMAC-256 after activation is implemented
+                final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
+
+                final byte[] applicationSecretKeyBytes = Base64.getDecoder().decode(applicationSecret);
+                final SecretKey secretKey = KEY_GENERATOR.deriveSecretKeyHmac(transportKey, applicationSecretKeyBytes);
+                final byte[] secretKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(secretKey);
+
+                final TemporaryKeyResult result = new TemporaryKeyResult();
+                result.setSecretKeyBytes(secretKeyBytes);
+                result.setPrivateKey(serverPrivateKey);
+                result.setSharedSecretRequest(requestClaims.getSharedSecretRequest());
+                return result;
+            }
+        } else {
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
+        }
+    }
+
+
+    private ResponseCryptogram deriveSharedSecret(SharedSecretRequest request, SharedSecretAlgorithm algorithm) throws GenericCryptoException {
+        switch (algorithm) {
+            case EC_P384 -> {
+                final SharedSecretRequestEcdhe requestEcdhe = new SharedSecretRequestEcdhe();
+                requestEcdhe.setEcClientPublicKey(request.getEcdhe());
+                return SHARED_SECRET_ECDHE.generateResponseCryptogram(requestEcdhe);
+            }
+            case EC_P384_ML_L3 -> {
+                final SharedSecretRequestHybrid requestHybrid = new SharedSecretRequestHybrid();
+                requestHybrid.setEcClientPublicKey(request.getEcdhe());
+                requestHybrid.setPqcEncapsulationKey(request.getMlkem());
+                return SHARED_SECRET_HYBRID.generateResponseCryptogram(requestHybrid);
+            }
+            default -> throw new IllegalArgumentException("Unsupported shared secret algorithm: " + algorithm);
+        }
+    }
+
+    private SharedSecretResponse prepareSharedSecretResponse(SharedSecretAlgorithm algorithm, ResponseCryptogram responseCryptogram) {
+        final SharedSecretResponse sharedSecretResponse = new SharedSecretResponse();
+        switch (algorithm) {
+            case EC_P384 -> {
+                final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = (SharedSecretResponseEcdhe) responseCryptogram.getSharedSecretResponse();
+                sharedSecretResponse.setEcdhe(sharedSecretResponseEcdhe.getEcServerPublicKey());
+                return sharedSecretResponse;
+            }
+            case EC_P384_ML_L3 -> {
+                final SharedSecretResponseHybrid sharedSecretResponseHybrid = (SharedSecretResponseHybrid) responseCryptogram.getSharedSecretResponse();
+                sharedSecretResponse.setEcdhe(sharedSecretResponseHybrid.getEcServerPublicKey());
+                sharedSecretResponse.setMlkem(sharedSecretResponseHybrid.getPqcEncapsulation());
+                return sharedSecretResponse;
+            }
+            default -> throw new IllegalArgumentException("Unsupported shared secret algorithm: " + algorithm);
+        }
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -72,7 +72,6 @@ import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
 import java.security.InvalidKeyException;
-import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -160,8 +159,7 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
             final ResponseCryptogram sharedSecretResponse = deriveSharedSecret(temporaryKeyResult.getSharedSecretRequest(), algorithm);
 
             // Generate new key and store it
-            final KeyPair temporaryKeyPair = KEY_GENERATOR.generateKeyPair(EcCurve.P384);
-            final TemporaryPublicKeyResponseClaims responseClaims = storeTemporaryKey(requestClaims, currentTimestamp, temporaryKeyPair, sharedSecretResponse, algorithm);
+            final TemporaryPublicKeyResponseClaims responseClaims = storeTemporaryKey(requestClaims, currentTimestamp, sharedSecretResponse, algorithm);
 
             // Built and return the response claims
             // TODO - add Dilithium signature using custom signer
@@ -297,19 +295,13 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
                 .build();
     }
 
-    private TemporaryPublicKeyResponseClaims storeTemporaryKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp, KeyPair temporaryKeyPair, ResponseCryptogram responseCryptogram, SharedSecretAlgorithm algorithm) throws CryptoProviderException, GenericServiceException {
+    private TemporaryPublicKeyResponseClaims storeTemporaryKey(TemporaryPublicKeyRequestClaims requestClaims, Date currentTimestamp, ResponseCryptogram responseCryptogram, SharedSecretAlgorithm algorithm) throws CryptoProviderException, GenericServiceException {
         // Prepare the parameters key pair
         final String keyId = UUID.randomUUID().toString();
         final String applicationKey = requestClaims.getApplicationKey();
         final String activationId = requestClaims.getActivationId();
         final String challenge = requestClaims.getChallenge();
-        final byte[] privateKeyBytes = KEY_CONVERTOR.convertPrivateKeyToBytes(temporaryKeyPair.getPrivate());
-        final String temporaryPublicKeyBase64 = Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P384, temporaryKeyPair.getPublic()));
         final Date expirationDate = Date.from(currentTimestamp.toInstant().plusMillis(powerAuthServiceConfiguration.getTemporaryKeyValidity().toMillis()));
-
-        // Prepare encrypted temporary private key, if encryption is enabled
-        final ServerPrivateKey temporaryPrivateKey = temporaryPrivateKeyConverter.toDBValue(
-                privateKeyBytes, keyId, applicationKey, activationId);
 
         // Prepare encrypted shard secret, if encryption is enabled
         final SharedSecret sharedSecretConverted = sharedSecretConverter.toDBValue(
@@ -320,9 +312,10 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
         temporaryKeyEntity.setId(keyId);
         temporaryKeyEntity.setAppKey(applicationKey);
         temporaryKeyEntity.setActivationId(activationId);
-        temporaryKeyEntity.setPrivateKeyEncryption(temporaryPrivateKey.encryptionMode());
-        temporaryKeyEntity.setPrivateKeyBase64(temporaryPrivateKey.serverPrivateKeyBase64());
-        temporaryKeyEntity.setPublicKeyBase64(temporaryPublicKeyBase64);
+        // Temporary keypair is no longer stored for V4
+        temporaryKeyEntity.setPrivateKeyEncryption(EncryptionMode.NO_ENCRYPTION);
+        temporaryKeyEntity.setPrivateKeyBase64(null);
+        temporaryKeyEntity.setPublicKeyBase64(null);
         temporaryKeyEntity.setSecretKeyEncryption(sharedSecretConverted.encryptionMode());
         temporaryKeyEntity.setSecretKeyBase64(sharedSecretConverted.sharedSecretBase64());
         temporaryKeyEntity.setTimestampExpires(expirationDate);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/encryption/DatabaseEncryptionService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/encryption/DatabaseEncryptionService.java
@@ -50,7 +50,7 @@ import java.util.function.Supplier;
 @Service
 @Slf4j
 @AllArgsConstructor
-public class EncryptionService {
+public class DatabaseEncryptionService {
 
     private final PowerAuthServiceConfiguration powerAuthServiceConfiguration;
     private final LocalizationProvider localizationProvider;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
@@ -25,6 +25,7 @@ import com.wultra.core.audit.base.model.AuditDetail;
 import com.wultra.core.audit.base.model.AuditLevel;
 import com.wultra.powerauth.fido2.errorhandling.Fido2AuthenticationFailedException;
 import com.wultra.powerauth.fido2.service.provider.AuthenticatorProvider;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
 import com.wultra.security.powerauth.app.server.service.model.crypto.BasePublicKey;
 import com.wultra.security.powerauth.client.model.entity.Activation;
@@ -195,7 +196,7 @@ public class PowerAuthAuthenticatorProvider implements AuthenticatorProvider {
             // TODO - v4 support
             BasePublicKey devicePublicKey = null;
             try {
-                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(devicePublicKeyBytes);
+                devicePublicKey = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).convertDevicePublicKey(KeyType.ECDSA, devicePublicKeyBytes);
             } catch (GenericServiceException e) {
                 logger.warn("Invalid public key, activation ID: {}", activation.getActivationId());
                 logger.debug("Invalid public key, activation ID: {}", activation.getActivationId(), e);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/PqcPublicKey.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/PqcPublicKey.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,29 +14,27 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
-package com.wultra.security.powerauth.client.model.entity;
+package com.wultra.security.powerauth.app.server.service.model.crypto;
 
 import lombok.Data;
-import lombok.ToString;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
 
-import java.util.Date;
+import java.security.PublicKey;
 
 /**
- * Class for holding the temporary key response claims.
+ * Pqc public key wrapper.
  *
- * @author Petr Dvorak, petr@wultra.com
+ * @author Roman Strobl, roman.strobl@wultra.com
  */
 @Data
-public class TemporaryPublicKeyResponseClaims {
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+public class PqcPublicKey extends BasePublicKey {
 
-    private String applicationKey;
-    private String activationId;
-    @ToString.Exclude
-    private String challenge;
-    private String keyId;
-    private String publicKey;
-    private Date expiration;
+    private PublicKey pqcPublicKey;
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigService.java
@@ -22,7 +22,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.Applicatio
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationConfigRepository;
 import com.wultra.security.powerauth.app.server.service.encryption.EncryptableString;
-import com.wultra.security.powerauth.app.server.service.encryption.EncryptionService;
+import com.wultra.security.powerauth.app.server.service.encryption.DatabaseEncryptionService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,7 +45,7 @@ public class ApplicationConfigService {
 
     private final ApplicationConfigRepository applicationConfigRepository;
     private final ListToJsonConverter listToJsonConverter;
-    private final EncryptionService encryptionService;
+    private final DatabaseEncryptionService encryptionService;
 
     /**
      * Find application configuration by application ID.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/persistence/TemporaryKeyPersistenceService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/persistence/TemporaryKeyPersistenceService.java
@@ -1,0 +1,53 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.security.powerauth.app.server.service.persistence;
+
+import com.wultra.security.powerauth.app.server.database.repository.TemporaryKeyRepository;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+
+/**
+ * Service for management of temporary keys
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class TemporaryKeyPersistenceService {
+
+    private final TemporaryKeyRepository temporaryKeyRepository;
+
+    @Transactional
+    public void removeTemporaryKey(String temporaryKeyId) {
+        temporaryKeyRepository.deleteById(temporaryKeyId);
+    }
+
+    // Tasks for scheduling
+    @Transactional
+    public void expireTemporaryKeys() {
+        final Date currentTimestamp = new Date();
+        final int expiredCount = temporaryKeyRepository.deleteExpiredKeys(currentTimestamp);
+        logger.debug("Removed {} expired temporary keys", expiredCount);
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/task/CleaningTask.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/task/CleaningTask.java
@@ -22,7 +22,7 @@ package com.wultra.security.powerauth.app.server.task;
 import com.wultra.security.powerauth.app.server.service.callbacks.CallbackUrlEventService;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.ActivationServiceBehavior;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.OperationServiceBehavior;
-import com.wultra.security.powerauth.app.server.service.behavior.tasks.TemporaryKeyBehavior;
+import com.wultra.security.powerauth.app.server.service.persistence.TemporaryKeyPersistenceService;
 import com.wultra.security.powerauth.app.server.service.replay.ReplayPersistenceService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,7 +47,7 @@ public class CleaningTask {
 
     private final ActivationServiceBehavior activationServiceBehavior;
 
-    private final TemporaryKeyBehavior temporaryKeyBehavior;
+    private final TemporaryKeyPersistenceService temporaryKeyPersistenceService;
 
     private final CallbackUrlEventService callbackUrlEventService;
 
@@ -88,7 +88,7 @@ public class CleaningTask {
     public void expireTemporaryKeys() {
         LockAssert.assertLocked();
         logger.debug("Calling scheduled expiration of temporary keys");
-        temporaryKeyBehavior.expireTemporaryKeys();
+        temporaryKeyPersistenceService.expireTemporaryKeys();
     }
 
     @Scheduled(fixedRateString = "${powerauth.service.scheduled.job.dispatchPendingCallbackUrlEvents:3000}")

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/converter/SharedSecretConverterTest.java
@@ -41,9 +41,11 @@ class SharedSecretConverterTest {
 
     private static final String SHARED_SECRET_BASE64 = "G9Pa9bVMtZMTH04QQ+69yvaLGqeKFFan3bsfluA10qiYbc/kEsJK0oFINkyc19MMo1mr53BnrSpZ3IZre0MZVpxhq15cjDHJJ6lk/Q3dO8w=";
 
-    private static final String SHARED_SECRET_ENCRYPTED = "KzfTnYq9toTVkmJleGrx03u2XZX1ky9CBOSU/hP/TKOoZpwSawcIzzvhevYfVTRrw58CtumNsLPkEn0NNXDrUc1PdVpbF0FEo1cTVNvItoWe5LRQYEvMddBrQ/W/bpX0MlVWjTVQj2mZDhlaC7DHIQ==";
+    private static final String SHARED_SECRET_ENCRYPTED = "NRyCX0zwu5Idd5i2mwsvs/RL9uVnZE7sVyvurjeNcIf6ZwhYsl/TbuLrHFL03FicXjhv17n729jHIh341zi9iOJcr3RDKBo3jWGC6TxiPBvU7OlH+Sd3KfcsZ4QSO68OJQvhD4eSN9uhXjdajn+x6w==";
 
-    private static final String USER_ID = "test";
+    private static final String KEY_ID = "c2079c74-9650-43f9-93d3-5f5af7181ecd";
+
+    private static final String APP_KEY = "Z19gyYaW5kb521fYWN0aXZ==";
 
     private static final String ACTIVATION_ID = "015286e0-e1c5-4ee1-8d1b-c6947cab0a56";
 
@@ -53,7 +55,7 @@ class SharedSecretConverterTest {
     @Test
     void testFromDbValueNoEncryption() throws Exception {
         final SharedSecret sharedSecret = new SharedSecret(EncryptionMode.NO_ENCRYPTION, SHARED_SECRET_BASE64);
-        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecret, USER_ID, ACTIVATION_ID);
+        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecret, KEY_ID, APP_KEY, ACTIVATION_ID);
 
         assertEquals(SHARED_SECRET_BASE64, sharedSecretActual);
     }
@@ -61,40 +63,58 @@ class SharedSecretConverterTest {
     @Test
     void testEncryptionAndDecryptionSuccess() throws Exception {
         byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
-        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, KEY_ID, APP_KEY, ACTIVATION_ID);
         assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
         assertNotEquals(SHARED_SECRET_BASE64, sharedSecretEncrypted.sharedSecretBase64());
 
-        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, ACTIVATION_ID);
+        final String sharedSecretActual = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, KEY_ID, APP_KEY, ACTIVATION_ID);
         assertEquals(SHARED_SECRET_BASE64, sharedSecretActual);
     }
 
     @Test
     void testFromDbValueEncryption() throws Exception {
         final SharedSecret sharedSecretEncrypted = new SharedSecret(EncryptionMode.AES_HMAC, SHARED_SECRET_ENCRYPTED);
-        final String result = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, ACTIVATION_ID);
+        final String result = sharedSecretConverter.fromDBValue(sharedSecretEncrypted, KEY_ID, APP_KEY, ACTIVATION_ID);
         assertEquals(SHARED_SECRET_BASE64, result);
     }
 
     @Test
-    void testEncryptionAndDecryptionDifferentUserFail() throws Exception {
+    void testEncryptionAndDecryptionDifferentKeyIdFail() throws Exception {
         final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
-        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
-
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, KEY_ID, APP_KEY, ACTIVATION_ID);
         assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
         assertThrows(GenericServiceException.class, () ->
-                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, "test2", ACTIVATION_ID));
+                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, "1839c333-f61a-4be0-8d34-75b7cb79ab76", APP_KEY, ACTIVATION_ID));
     }
 
     @Test
-    void testEncryptionAndDecryptionDifferentActivationFailServerSharedSecretConverter() throws Exception {
+    void testEncryptionAndDecryptionDifferentAppKeyFail() throws Exception {
         final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
-        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, USER_ID, ACTIVATION_ID);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, KEY_ID, APP_KEY, ACTIVATION_ID);
 
         assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, KEY_ID, "UNfS0VZX3JhbmRvbQ==", ACTIVATION_ID));
+    }
 
-        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> sharedSecretConverter.fromDBValue(sharedSecretEncrypted, USER_ID, "115286e0-e1c5-4ee1-8d1b-c6947cab0a56"));
-        assertEquals("Generic cryptography error occurred.", exception.getMessage());
+    @Test
+    void testEncryptionAndDecryptionDifferentActivationIdFail() throws Exception {
+        final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, KEY_ID, APP_KEY, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, KEY_ID, APP_KEY, "01e9deb4-a0e0-4204-b8a6-925e76b7b3d3"));
+    }
+
+    @Test
+    void testEncryptionAndDecryptionNoActivationIdFail() throws Exception {
+        final byte[] sharedSecretBytes = Base64.getDecoder().decode(SHARED_SECRET_BASE64);
+        final SharedSecret sharedSecretEncrypted = sharedSecretConverter.toDBValue(sharedSecretBytes, KEY_ID, APP_KEY, ACTIVATION_ID);
+
+        assertEquals(EncryptionMode.AES_HMAC, sharedSecretEncrypted.encryptionMode());
+        assertThrows(GenericServiceException.class, () ->
+                sharedSecretConverter.fromDBValue(sharedSecretEncrypted, KEY_ID, APP_KEY, null));
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/TemporaryKeyBehaviorTest.java
@@ -1,6 +1,6 @@
 /*
  * PowerAuth Server and related software components
- * Copyright (C) 2024 Wultra s.r.o.
+ * Copyright (C) 2025 Wultra s.r.o.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published
@@ -14,8 +14,9 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
-package com.wultra.security.powerauth.app.server.service.behavior.tasks;
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v3;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -23,6 +24,8 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.ActivationServiceBehavior;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.ApplicationServiceBehavior;
 import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
 import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.request.v3.CreateActivationRequest;
@@ -49,6 +52,7 @@ import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import org.bouncycastle.asn1.ASN1EncodableVector;
 import org.bouncycastle.asn1.ASN1Integer;
@@ -68,6 +72,7 @@ import java.security.PublicKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
@@ -75,14 +80,14 @@ import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Test for {@link TemporaryKeyBehavior}.
+ * Test for {@link TemporaryKeyBehaviorEcies}, version 3 requests and responses.
  *
  * @author Roman Strobl, roman.strobl@wultra.com
  */
 @SpringBootTest
 @Transactional
 @ActiveProfiles("test")
-class TemporaryKeyBehaviourTest {
+class TemporaryKeyBehaviorTest {
 
     private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
     private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
@@ -90,14 +95,14 @@ class TemporaryKeyBehaviourTest {
     private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
     private static final PowerAuthServerKeyFactory PA_SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
 
-    private final TemporaryKeyBehavior temporaryKeyBehavior;
+    private final TemporaryKeyBehaviorEcies temporaryKeyBehavior;
     private final ApplicationServiceBehavior applicationServiceBehavior;
     private final ActivationServiceBehavior activationServiceBehavior;
     private final ActivationRepository activationRepository;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
 
     @Autowired
-    TemporaryKeyBehaviourTest(TemporaryKeyBehavior temporaryKeyBehavior, ApplicationServiceBehavior applicationServiceBehavior, ActivationServiceBehavior activationServiceBehavior, ActivationRepository activationRepository, ServerPrivateKeyConverter serverPrivateKeyConverter) {
+    TemporaryKeyBehaviorTest(TemporaryKeyBehaviorEcies temporaryKeyBehavior, ApplicationServiceBehavior applicationServiceBehavior, ActivationServiceBehavior activationServiceBehavior, ActivationRepository activationRepository, ServerPrivateKeyConverter serverPrivateKeyConverter) {
         this.temporaryKeyBehavior = temporaryKeyBehavior;
         this.applicationServiceBehavior = applicationServiceBehavior;
         this.activationServiceBehavior = activationServiceBehavior;
@@ -132,10 +137,10 @@ class TemporaryKeyBehaviourTest {
         request.setJwt(jwtRequest);
         final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
         assertNotNull(response.getJwt());
-        final SignedJWT decodedJWT = SignedJWT.parse(request.getJwt());
+        final SignedJWT decodedJWT = SignedJWT.parse(response.getJwt());
         final String masterPublicKeyBase64 = SdkConfigurationSerializer.deserialize(defaultVersion.getMobileSdkConfig()).masterPublicKeyBase64();
         final PublicKey masterPublicKey = KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(masterPublicKeyBase64));
-        validateJwtSignature(decodedJWT, masterPublicKey);
+        assertTrue(validateJwtSignature(decodedJWT, masterPublicKey));
         assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
         assertEquals(challenge, decodedJWT.getJWTClaimsSet().getClaim("challenge"));
         assertNull(decodedJWT.getJWTClaimsSet().getClaim("activationId"));
@@ -187,7 +192,7 @@ class TemporaryKeyBehaviourTest {
         final TemporaryPublicKeyResponse responseTempKeyActivation = temporaryKeyBehavior.requestTemporaryKey(requestTempKeyActivation);
         assertNotNull(responseTempKeyActivation.getJwt());
         final SignedJWT decodedJWTActivation = SignedJWT.parse(responseTempKeyActivation.getJwt());
-        validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId));
+        assertTrue(validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId)));
         assertEquals(defaultVersion.getApplicationKey(), decodedJWTActivation.getJWTClaimsSet().getClaim("applicationKey"));
         assertEquals(challengeActivation, decodedJWTActivation.getJWTClaimsSet().getClaim("challenge"));
         assertEquals(activationId, decodedJWTActivation.getJWTClaimsSet().getClaim("activationId"));
@@ -254,13 +259,13 @@ class TemporaryKeyBehaviourTest {
     }
 
     private PublicKey getServerPublicKey(String activationId) throws Exception {
-        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).get();
+        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
         final String serverPublicKeyBase64 = activation.getServerPublicKeyBase64();
         return KEY_CONVERTOR.convertBytesToPublicKey(EcCurve.P256, Base64.getDecoder().decode(serverPublicKeyBase64));
     }
 
     private SecretKey getMasterTransportKey(String activationId) throws Exception {
-        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).get();
+        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
         // Get the server private key, decrypt it if required
         final String serverPrivateKeyFromEntity = activation.getServerPrivateKeyBase64();
         final EncryptionMode serverPrivateKeyEncryptionMode = activation.getServerPrivateKeyEncryption();

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
@@ -1,0 +1,496 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
+import com.wultra.security.powerauth.app.server.database.repository.ActivationRepository;
+import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
+import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.ActivationServiceBehavior;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.ApplicationServiceBehavior;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.model.request.ActivationLayer2Request;
+import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
+import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretRequest;
+import com.wultra.security.powerauth.client.model.entity.v4.SharedSecretResponse;
+import com.wultra.security.powerauth.client.model.request.*;
+import com.wultra.security.powerauth.client.model.request.v4.CreateActivationRequest;
+import com.wultra.security.powerauth.client.model.response.CreateApplicationResponse;
+import com.wultra.security.powerauth.client.model.response.GetApplicationDetailResponse;
+import com.wultra.security.powerauth.client.model.response.RemoveTemporaryPublicKeyResponse;
+import com.wultra.security.powerauth.client.model.response.TemporaryPublicKeyResponse;
+import com.wultra.security.powerauth.client.model.response.v4.CreateActivationResponse;
+import com.wultra.security.powerauth.crypto.lib.encryptor.ClientEncryptor;
+import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorParameters;
+import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorScope;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
+import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.api.SharedSecretClientContext;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
+import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.response.AeadEncryptedResponse;
+import com.wultra.security.powerauth.crypto.lib.v4.model.SharedSecretClientContextEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.model.SharedSecretClientContextHybrid;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import com.wultra.security.powerauth.crypto.lib.v4.model.request.RequestCryptogram;
+import com.wultra.security.powerauth.crypto.lib.v4.model.request.SharedSecretRequestEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.model.request.SharedSecretRequestHybrid;
+import com.wultra.security.powerauth.crypto.lib.v4.model.response.SharedSecretResponseEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.model.response.SharedSecretResponseHybrid;
+import com.wultra.security.powerauth.crypto.lib.v4.sharedsecret.SharedSecretEcdhe;
+import com.wultra.security.powerauth.crypto.lib.v4.sharedsecret.SharedSecretHybrid;
+import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
+import org.bouncycastle.asn1.ASN1EncodableVector;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.DLSequence;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.SecretKey;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link TemporaryKeyBehaviorAead}, version 4 requests and responses.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class TemporaryKeyBehaviorTest {
+
+    private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+    private static final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
+
+    private static final SharedSecretEcdhe SHARED_SECRET_ECDHE = new SharedSecretEcdhe();
+    private static final SharedSecretHybrid SHARED_SECRET_HYBRID = new SharedSecretHybrid();
+
+    private final TemporaryKeyBehaviorAead temporaryKeyBehavior;
+    private final ApplicationServiceBehavior applicationServiceBehavior;
+    private final ActivationServiceBehavior activationServiceBehavior;
+    private final ActivationRepository activationRepository;
+    private final ServerPrivateKeysConverter serverPrivateKeysConverter;
+    private final ApplicationVersionRepository applicationVersionRepository;
+    private final MasterKeyPairRepository masterKeyPairRepository;
+    private final PublicKeysConverter publicKeysConverter;
+
+    @Autowired
+    TemporaryKeyBehaviorTest(TemporaryKeyBehaviorAead temporaryKeyBehavior, ApplicationServiceBehavior applicationServiceBehavior, ActivationServiceBehavior activationServiceBehavior, ActivationRepository activationRepository, ServerPrivateKeysConverter serverPrivateKeysConverter, ApplicationVersionRepository applicationVersionRepository, MasterKeyPairRepository masterKeyPairRepository, PublicKeysConverter publicKeysConverter) {
+        this.temporaryKeyBehavior = temporaryKeyBehavior;
+        this.applicationServiceBehavior = applicationServiceBehavior;
+        this.activationServiceBehavior = activationServiceBehavior;
+        this.activationRepository = activationRepository;
+        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
+        this.applicationVersionRepository = applicationVersionRepository;
+        this.masterKeyPairRepository = masterKeyPairRepository;
+        this.publicKeysConverter = publicKeysConverter;
+    }
+
+    @Test
+    void testJwtRequestEmpty() {
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt("");
+        assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+    }
+
+    @Test
+    void testJwtRequestInvalidClaims() throws Exception {
+        final JWTClaimsSet jwtClaims = new JWTClaimsSet.Builder().build();
+        final byte[] secretKey = getSecretKey(EncryptorScope.APPLICATION_SCOPE, "test", null);
+        final String jwtRequest = signJwt(jwtClaims, secretKey);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+    }
+
+    @Test
+    void testJwtRequestEcdheValidApplicationScope() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, defaultVersion.getApplicationSecret(), null, requestCryptogram);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
+        assertNotNull(response.getJwt());
+        final SignedJWT decodedJWT = SignedJWT.parse(response.getJwt());
+
+        // TODO - use serialized keys instead of querying database after serialization of new keys is available
+        final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(defaultVersion.getApplicationKey());
+        final MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersion.getApplication().getId());
+        final String masterPublicKeys = masterKeyPair.getMasterPublicKeys();
+        final PublicKeyRegistry publicKeys = publicKeysConverter.fromDBValue(masterPublicKeys);
+        final PublicKey masterPublicKeyEc384 = publicKeys.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> new IllegalStateException("Missing public key"));
+
+        assertTrue(validateJwtSignature(decodedJWT, masterPublicKeyEc384));
+        assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
+        assertEquals(challenge, decodedJWT.getJWTClaimsSet().getClaim("challenge"));
+        assertNull(decodedJWT.getJWTClaimsSet().getClaim("activationId"));
+        assertNotNull(decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse"));
+    }
+
+    @Test
+    void testJwtRequestHybridValidApplicationScope() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, defaultVersion.getApplicationSecret(), null, requestCryptogram);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
+        assertNotNull(response.getJwt());
+        final SignedJWT decodedJWT = SignedJWT.parse(response.getJwt());
+
+        // TODO - use serialized keys instead of querying database after serialization of new keys is available
+        final ApplicationVersionEntity applicationVersion = applicationVersionRepository.findByApplicationKey(defaultVersion.getApplicationKey());
+        final MasterKeyPairEntity masterKeyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(applicationVersion.getApplication().getId());
+        final String masterPublicKeys = masterKeyPair.getMasterPublicKeys();
+        final PublicKeyRegistry publicKeys = publicKeysConverter.fromDBValue(masterPublicKeys);
+        final PublicKey masterPublicKeyEc384 = publicKeys.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> new IllegalStateException("Missing public key"));
+
+        // TODO - validate Dilithium signature after it is available
+        assertTrue(validateJwtSignature(decodedJWT, masterPublicKeyEc384));
+
+        assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
+        assertEquals(challenge, decodedJWT.getJWTClaimsSet().getClaim("challenge"));
+        assertNull(decodedJWT.getJWTClaimsSet().getClaim("activationId"));
+        assertNotNull(decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse"));
+        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
+        assertNotNull(serverResponse.getEcdhe());
+        assertNotNull(serverResponse.getMlkem());
+    }
+
+    @Test
+    void testJwtRequestValidApplicationScopeWithRemove() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, defaultVersion.getApplicationSecret(), null, requestCryptogram);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
+        assertNotNull(response.getJwt());
+        final String jwtResponse = response.getJwt();
+        final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
+        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
+        final RemoveTemporaryPublicKeyRequest removeRequest = new RemoveTemporaryPublicKeyRequest();
+        removeRequest.setId(temporaryKeyId);
+        final RemoveTemporaryPublicKeyResponse removeResponse = temporaryKeyBehavior.removeTemporaryKey(removeRequest);
+        assertEquals(temporaryKeyId, removeResponse.getId());
+        assertTrue(removeResponse.isRemoved());
+    }
+
+    @Test
+    void testJwtRequestEcdheValidActivationScope() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, defaultVersion.getApplicationSecret(), null, requestCryptogram);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
+        assertNotNull(response.getJwt());
+        final String jwtResponse = response.getJwt();
+        final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
+        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
+        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
+        assertNotNull(serverResponse.getEcdhe());
+        // extract temporary key and use it during an activation
+        final String activationId = createActivation(defaultVersion, temporaryKeyId, requestCryptogram.getSharedSecretClientContext(), serverResponse);
+        final byte[] challengeBytesActivation = KEY_GENERATOR.generateRandomBytes(18);
+        final String challengeActivation = Base64.getEncoder().encodeToString(challengeBytesActivation);
+        final SecretKey transportMasterKey = getMasterTransportKey(activationId);
+        final RequestCryptogram requestCryptogramActivation = SHARED_SECRET_ECDHE.generateRequestCryptogram();
+        final String jwtRequestActivation = createJwtRequest(EncryptorScope.ACTIVATION_SCOPE, defaultVersion.getApplicationKey(), activationId, challengeActivation, defaultVersion.getApplicationSecret(), transportMasterKey, requestCryptogramActivation);
+        final TemporaryPublicKeyRequest requestTempKeyActivation = new TemporaryPublicKeyRequest();
+        requestTempKeyActivation.setJwt(jwtRequestActivation);
+        final TemporaryPublicKeyResponse responseTempKeyActivation = temporaryKeyBehavior.requestTemporaryKey(requestTempKeyActivation);
+        assertNotNull(responseTempKeyActivation.getJwt());
+        final SignedJWT decodedJWTActivation = SignedJWT.parse(responseTempKeyActivation.getJwt());
+        assertTrue(validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId)));
+        assertEquals(defaultVersion.getApplicationKey(), decodedJWTActivation.getJWTClaimsSet().getClaim("applicationKey"));
+        assertEquals(challengeActivation, decodedJWTActivation.getJWTClaimsSet().getClaim("challenge"));
+        assertEquals(activationId, decodedJWTActivation.getJWTClaimsSet().getClaim("activationId"));
+        assertNotNull(decodedJWTActivation.getJWTClaimsSet().getClaim("sharedSecretResponse"));
+        final Object claimActivation = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final SharedSecretResponse serverResponseActivation = OBJECT_MAPPER.convertValue(claimActivation, SharedSecretResponse.class);
+        assertNotNull(serverResponseActivation.getEcdhe());
+    }
+
+    @Test
+    void testJwtRequestHybridValidActivationScope() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, defaultVersion.getApplicationSecret(), null, requestCryptogram);
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        request.setJwt(jwtRequest);
+        final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
+        assertNotNull(response.getJwt());
+        final String jwtResponse = response.getJwt();
+        final SignedJWT decodedJWT = SignedJWT.parse(jwtResponse);
+        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
+        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
+        assertNotNull(serverResponse.getEcdhe());
+        assertNotNull(serverResponse.getMlkem());
+        // extract temporary key and use it during an activation
+        final String activationId = createActivation(defaultVersion, temporaryKeyId, requestCryptogram.getSharedSecretClientContext(), serverResponse);
+        final byte[] challengeBytesActivation = KEY_GENERATOR.generateRandomBytes(18);
+        final String challengeActivation = Base64.getEncoder().encodeToString(challengeBytesActivation);
+        final SecretKey transportMasterKey = getMasterTransportKey(activationId);
+        final RequestCryptogram requestCryptogramActivation = SHARED_SECRET_HYBRID.generateRequestCryptogram();
+        final String jwtRequestActivation = createJwtRequest(EncryptorScope.ACTIVATION_SCOPE, defaultVersion.getApplicationKey(), activationId, challengeActivation, defaultVersion.getApplicationSecret(), transportMasterKey, requestCryptogramActivation);
+        final TemporaryPublicKeyRequest requestTempKeyActivation = new TemporaryPublicKeyRequest();
+        requestTempKeyActivation.setJwt(jwtRequestActivation);
+        final TemporaryPublicKeyResponse responseTempKeyActivation = temporaryKeyBehavior.requestTemporaryKey(requestTempKeyActivation);
+        assertNotNull(responseTempKeyActivation.getJwt());
+        final SignedJWT decodedJWTActivation = SignedJWT.parse(responseTempKeyActivation.getJwt());
+        assertTrue(validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId)));
+        assertEquals(defaultVersion.getApplicationKey(), decodedJWTActivation.getJWTClaimsSet().getClaim("applicationKey"));
+        assertEquals(challengeActivation, decodedJWTActivation.getJWTClaimsSet().getClaim("challenge"));
+        assertEquals(activationId, decodedJWTActivation.getJWTClaimsSet().getClaim("activationId"));
+        assertNotNull(decodedJWTActivation.getJWTClaimsSet().getClaim("sharedSecretResponse"));
+        final Object claimActivation = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final SharedSecretResponse serverResponseActivation = OBJECT_MAPPER.convertValue(claimActivation, SharedSecretResponse.class);
+        assertNotNull(serverResponseActivation.getEcdhe());
+        assertNotNull(serverResponseActivation.getMlkem());
+    }
+
+    @Test
+    void testJwtRequestInvalidSignature() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
+        final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
+        final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
+        final String appSecretInvalid = Base64.getEncoder().encodeToString(KEY_GENERATOR.generateRandomBytes(8));
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
+        final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, defaultVersion.getApplicationKey(), null, challenge, appSecretInvalid, null, requestCryptogram);
+        request.setJwt(jwtRequest);
+        assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+    }
+
+    private ApplicationVersion createApplication() throws GenericServiceException {
+        final CreateApplicationRequest appRequest = new CreateApplicationRequest();
+        appRequest.setApplicationId(UUID.randomUUID().toString());
+        final CreateApplicationResponse appResponse = applicationServiceBehavior.createApplication(appRequest);
+        final GetApplicationDetailRequest appDetailRequest = new GetApplicationDetailRequest();
+        appDetailRequest.setApplicationId(appResponse.getApplicationId());
+        final GetApplicationDetailResponse appDetailResponse = applicationServiceBehavior.getApplicationDetail(appDetailRequest);
+        return appDetailResponse.getVersions().get(0);
+    }
+
+    private String createActivation(ApplicationVersion applicationVersion, String temporaryKeyId, SharedSecretClientContext clientContext, SharedSecretResponse serverResponse) throws Exception {
+        final String publicKeyBytes = generatePublicKey();
+        final ActivationLayer2Request activationLayer2Request = new ActivationLayer2Request();
+        activationLayer2Request.setDevicePublicKey(publicKeyBytes);
+
+        final String applicationKey = applicationVersion.getApplicationKey();
+        final String applicationSecret = applicationVersion.getApplicationSecret();
+        final SecretKey sharedSecret;
+        if (clientContext instanceof SharedSecretClientContextEcdhe contextEcdhe) {
+            final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
+            sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());
+            sharedSecret = SHARED_SECRET_ECDHE.computeSharedSecret(contextEcdhe, sharedSecretResponseEcdhe);
+        } else if (clientContext instanceof SharedSecretClientContextHybrid contextHybrid) {
+            final SharedSecretResponseHybrid sharedSecretResponseHybrid = new SharedSecretResponseHybrid();
+            sharedSecretResponseHybrid.setEcServerPublicKey(serverResponse.getEcdhe());
+            sharedSecretResponseHybrid.setPqcEncapsulation(serverResponse.getMlkem());
+            sharedSecret = SHARED_SECRET_HYBRID.computeSharedSecret(contextHybrid, sharedSecretResponseHybrid);
+        } else {
+            throw new IllegalStateException("Invalid client context");
+        }
+        final ClientEncryptor<AeadEncryptedRequest, AeadEncryptedResponse> clientEncryptor = new EncryptorFactory().getClientEncryptor(
+                EncryptorId.ACTIVATION_LAYER_2,
+                new EncryptorParameters("4.0", applicationKey, null, temporaryKeyId),
+                new AeadSecrets(sharedSecret.getEncoded(), applicationSecret));
+        final AeadEncryptedRequest encryptedRequest = clientEncryptor.encryptRequest(OBJECT_MAPPER.writeValueAsBytes(activationLayer2Request));
+
+        final CreateActivationRequest activationRequest = new CreateActivationRequest();
+        activationRequest.setUserId(UUID.randomUUID().toString());
+        activationRequest.setApplicationKey(applicationKey);
+        activationRequest.setProtocolVersion("4.0");
+        activationRequest.setTemporaryKeyId(temporaryKeyId);
+        activationRequest.setEncryptedData(encryptedRequest.getEncryptedData());
+        activationRequest.setNonce(encryptedRequest.getNonce());
+        activationRequest.setTimestamp(encryptedRequest.getTimestamp());
+        final CreateActivationResponse response = activationServiceBehavior.createActivation(activationRequest);
+        final CommitActivationRequest commitRequest = new CommitActivationRequest();
+        commitRequest.setActivationId(response.getActivationId());
+        activationServiceBehavior.commitActivation(commitRequest);
+        return response.getActivationId();
+    }
+
+    private String generatePublicKey() throws Exception {
+        final KeyGenerator keyGenerator = new KeyGenerator();
+        final KeyPair keyPair = keyGenerator.generateKeyPair(EcCurve.P384);
+        final byte[] publicKeyBytes = KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P384, keyPair.getPublic());
+        return Base64.getEncoder().encodeToString(publicKeyBytes);
+    }
+
+    private PublicKey getServerPublicKey(String activationId) throws Exception {
+        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
+        final String serverPublicKeys = activation.getServerPublicKeys();
+        final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(serverPublicKeys);
+        return publicKeyRegistry.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> new IllegalStateException("Missing public key"));
+    }
+
+    private SecretKey getMasterTransportKey(String activationId) throws Exception {
+        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
+        // Get the server private key, decrypt it if required
+
+        final String serverPrivateKeys = activation.getServerPrivateKeys();
+        final EncryptionMode encryptionMode = activation.getServerPrivateKeysEncryption();
+        final PrivateKeys privateKeys = new PrivateKeys(encryptionMode, serverPrivateKeys);
+        final PrivateKeyRegistry privateKeyRegistry = serverPrivateKeysConverter.fromDBValue(privateKeys, activation.getUserId(), activation.getActivationId());
+        final PrivateKey serverPrivateKey = privateKeyRegistry.getPrivateKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> new IllegalStateException("Missing private key"));
+
+        final String devicePublicKeys = activation.getDevicePublicKeys();
+        final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(devicePublicKeys);
+        final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(SharedSecretAlgorithm.EC_P384, KeyType.ECDSA).orElseThrow(() -> new IllegalStateException("Missing public key"));
+        // TODO - switch to a key derived with KMAC-256 after activation is implemented
+        final SecretKey transportKey = SERVER_KEY_FACTORY.deriveTransportKey(serverPrivateKey, devicePublicKey);
+
+        final byte[] transportKeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(transportKey);
+        return KEY_CONVERTOR.convertBytesToSharedSecretKey(transportKeyBytes);
+    }
+
+    private static String createJwtRequest(EncryptorScope scope, String applicationKey, String activationId, String challenge, String appSecret, SecretKey transportMasterKey, RequestCryptogram requestCryptogram) throws Exception {
+        final Instant now = Instant.now();
+        final JWTClaimsSet.Builder builder = new JWTClaimsSet.Builder()
+                .claim("applicationKey", applicationKey)
+                .claim("activationId", activationId)
+                .claim("challenge", challenge)
+                .issueTime(Date.from(now))
+                .expirationTime(Date.from(now.plus(5, ChronoUnit.MINUTES)));
+        final Object request = requestCryptogram.getSharedSecretRequest();
+        final SharedSecretRequest sharedSecretRequest = new SharedSecretRequest();
+        if (request instanceof SharedSecretRequestEcdhe ecdhe) {
+            sharedSecretRequest.setAlgorithm("EC_P384");
+            sharedSecretRequest.setEcdhe(ecdhe.getEcClientPublicKey());
+        } else if (request instanceof SharedSecretRequestHybrid hybrid) {
+            sharedSecretRequest.setAlgorithm("EC_P384_ML_L3");
+            sharedSecretRequest.setEcdhe(hybrid.getEcClientPublicKey());
+            sharedSecretRequest.setMlkem(hybrid.getPqcEncapsulationKey());
+        } else {
+            throw new IllegalStateException("Invalid cryptogram");
+        }
+        builder.claim("sharedSecretRequest", sharedSecretRequest);
+        final JWTClaimsSet jwtClaims = builder.build();
+        final byte[] secretKey = getSecretKey(scope, appSecret, transportMasterKey);
+        return signJwt(jwtClaims, secretKey);
+    }
+
+    private static byte[] getSecretKey(EncryptorScope scope, String appSecret, SecretKey transportMasterKey) throws Exception {
+        if (scope == EncryptorScope.APPLICATION_SCOPE) {
+            return Base64.getDecoder().decode(appSecret);
+        } else if (scope == EncryptorScope.ACTIVATION_SCOPE) {
+            // TODO - switch to a key derived with KMAC-256 after activation is implemented
+            final byte[] appSecretBytes = Base64.getDecoder().decode(appSecret);
+            final SecretKey secretKeyBytes = KEY_GENERATOR.deriveSecretKeyHmac(transportMasterKey, appSecretBytes);
+            return KEY_CONVERTOR.convertSharedSecretKeyToBytes(secretKeyBytes);
+        }
+        return null;
+    }
+
+    private static String signJwt(JWTClaimsSet jwtClaims, byte[] secretKey) throws Exception {
+        final JWSHeader jwsHeader = new JWSHeader(JWSAlgorithm.HS256);
+        final byte[] payloadBytes = jwtClaims.toPayload().toBytes();
+        final Base64URL encodedHeader = jwsHeader.toBase64URL();
+        final Base64URL encodedPayload = Base64URL.encode(payloadBytes);
+        final String signingInput = encodedHeader + "." + encodedPayload;
+        final byte[] hash = new HMACHashUtilities().hash(secretKey, signingInput.getBytes(StandardCharsets.UTF_8));
+        final Base64URL signature = Base64URL.encode(hash);
+        return encodedHeader + "." + encodedPayload + "." + signature;
+    }
+
+    private static boolean validateJwtSignature(SignedJWT jwt, PublicKey publicKey) throws Exception {
+        final Base64URL[] jwtParts = jwt.getParsedParts();
+        final Base64URL encodedHeader = jwtParts[0];
+        final Base64URL encodedPayload = jwtParts[1];
+        final Base64URL encodedSignature = jwtParts[2];
+        final String signingInput = encodedHeader + "." + encodedPayload;
+        final byte[] signatureBytes = convertRawSignatureToDER(encodedSignature.decode());
+        return SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
+    }
+
+    private static byte[] convertRawSignatureToDER(byte[] rawSignature) throws Exception {
+        if (rawSignature.length % 2 != 0) {
+            throw new IllegalArgumentException("Invalid ECDSA signature format");
+        }
+        int len = rawSignature.length / 2;
+        byte[] rBytes = new byte[len];
+        byte[] sBytes = new byte[len];
+        System.arraycopy(rawSignature, 0, rBytes, 0, len);
+        System.arraycopy(rawSignature, len, sBytes, 0, len);
+        BigInteger r = new BigInteger(1, rBytes);
+        BigInteger s = new BigInteger(1, sBytes);
+        ASN1EncodableVector v = new ASN1EncodableVector();
+        v.add(new ASN1Integer(r));
+        v.add(new ASN1Integer(s));
+        return new DLSequence(v).getEncoded();
+    }
+
+}


### PR DESCRIPTION
Implemenation of E2EE for crypto4.

Out of scope (see TODOs):
- using new keys for request validation and response signing for JWT in temporary key functionality, will be implemented separately
- using new master public keys via SDK configuration in temporary key tests, will be implemented separately
- any activation flow and application changes, will be reviewed separately (some tests fail temporarily because of this)