### PR TITLE
Fix #1895: Update JWT request verification and JWT response signing for temporary keys

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/TemporaryKeyServiceEcies.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/TemporaryKeyServiceEcies.java
@@ -46,7 +46,7 @@ import com.wultra.security.powerauth.app.server.service.crypto.TemporaryKeyServi
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
-import com.wultra.security.powerauth.app.server.service.model.crypto.TemporaryKeyResult;
+import com.wultra.security.powerauth.app.server.service.model.crypto.v3.TemporaryKeyResult;
 import com.wultra.security.powerauth.app.server.service.util.jwt.MACVerifier16B;
 import com.wultra.security.powerauth.client.model.entity.v3.request.TemporaryPublicKeyRequestClaims;
 import com.wultra.security.powerauth.client.model.entity.v3.response.TemporaryPublicKeyResponseClaims;

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -323,7 +323,7 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
         return result;
     }
 
-    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims, final SharedSecretAlgorithm algorithm) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
+    private TemporaryKeyResult obtainTemporaryKeyResult(final TemporaryPublicKeyRequestClaims requestClaims, final SharedSecretAlgorithm algorithm) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
         final String applicationKey = requestClaims.getApplicationKey();
         if (applicationKey != null) {
             final ApplicationVersionEntity applicationVersionEntity = applicationVersionRepository.findByApplicationKey(applicationKey);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -21,9 +21,9 @@ package com.wultra.security.powerauth.app.server.service.crypto.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObjectJSON;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.MACVerifier;
 import com.nimbusds.jose.jwk.Curve;
@@ -47,7 +47,9 @@ import com.wultra.security.powerauth.app.server.service.crypto.TemporaryKeyServi
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
-import com.wultra.security.powerauth.app.server.service.model.crypto.TemporaryKeyResult;
+import com.wultra.security.powerauth.app.server.service.model.crypto.v4.TemporaryKeyResult;
+import com.wultra.security.powerauth.app.server.service.util.jwt.JWSAlgorithmMLDSA;
+import com.wultra.security.powerauth.app.server.service.util.jwt.MLDSASigner;
 import com.wultra.security.powerauth.client.model.entity.v4.request.SharedSecretRequest;
 import com.wultra.security.powerauth.client.model.entity.v4.response.SharedSecretResponse;
 import com.wultra.security.powerauth.client.model.entity.v4.request.TemporaryPublicKeyRequestClaims;
@@ -138,8 +140,10 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
                 throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
             }
 
+            final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(requestClaims.getSharedSecretRequest().getAlgorithm());
+
             // Obtain verifier secret and check JWT signature
-            final TemporaryKeyResult temporaryKeyResult = obtainTemporaryKeyResult(requestClaims);
+            final TemporaryKeyResult temporaryKeyResult = obtainTemporaryKeyResult(requestClaims, algorithm);
             final MACVerifier verifier = new MACVerifier(temporaryKeyResult.getSecretKeyBytes());
             boolean verified = decodedJWT.verify(verifier);
             if (!verified) {
@@ -150,22 +154,13 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
             final Date currentTimestamp = new Date();
 
             // Derive shared secret using SharedSecret algorithm
-            final SharedSecretAlgorithm algorithm = SharedSecretAlgorithm.valueOf(requestClaims.getSharedSecretRequest().getAlgorithm());
             final ResponseCryptogram sharedSecretResponse = deriveSharedSecret(temporaryKeyResult.getSharedSecretRequest(), algorithm);
 
             // Generate new key and store it
             final TemporaryPublicKeyResponseClaims responseClaims = storeTemporaryKey(requestClaims, currentTimestamp, sharedSecretResponse, algorithm);
 
             // Built and return the response claims
-            // TODO - add Dilithium signature using custom signer
-            final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).type(JOSEObjectType.JWT).build();
-            final JWTClaimsSet claimsSet = buildClaims(responseClaims, currentTimestamp);
-
-            final ECDSASigner signer = new ECDSASigner(temporaryKeyResult.getPrivateKey(), Curve.P_384);
-
-            final SignedJWT signedJWT = new SignedJWT(header, claimsSet);
-            signedJWT.sign(signer);
-            return signedJWT.serialize();
+            return buildJwsResponse(temporaryKeyResult, responseClaims, currentTimestamp, algorithm);
         } catch (ParseException | JOSEException e) {
             logger.error("Temporary key request is invalid", e);
             // Rollback is not required, error occurs before writing to database
@@ -328,7 +323,7 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
         return result;
     }
 
-    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
+    private TemporaryKeyResult obtainTemporaryKeyResult(TemporaryPublicKeyRequestClaims requestClaims, final SharedSecretAlgorithm algorithm) throws InvalidKeySpecException, CryptoProviderException, GenericCryptoException, GenericServiceException, InvalidKeyException {
         final String applicationKey = requestClaims.getApplicationKey();
         if (applicationKey != null) {
             final ApplicationVersionEntity applicationVersionEntity = applicationVersionRepository.findByApplicationKey(applicationKey);
@@ -343,7 +338,7 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
                 final EncryptionMode encryptionMode = masterKeyPairEntity.getMasterPrivateKeysEncryption();
                 final PrivateKeys masterPrivateKeys = new PrivateKeys(encryptionMode, masterPrivateKeysBase64);
                 final PrivateKeyRegistry privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(masterPrivateKeys, applicationVersionEntity.getApplication().getId());
-                final PrivateKey privateKey = privateKeyRegistry.getPrivateKey(KeyType.ECDSA_P384)
+                final PrivateKey ecPrivateKey = privateKeyRegistry.getPrivateKey(KeyType.ECDSA_P384)
                         .orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR));
 
                 final byte[] appSecretBytes = Base64.getDecoder().decode(applicationSecret);
@@ -353,8 +348,13 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
 
                 final TemporaryKeyResult result = new TemporaryKeyResult();
                 result.setSecretKeyBytes(secretKeyBytes);
-                result.setPrivateKey(privateKey);
+                result.setEcPrivateKey(ecPrivateKey);
                 result.setSharedSecretRequest(requestClaims.getSharedSecretRequest());
+                if (algorithm == SharedSecretAlgorithm.EC_P384_ML_L3) {
+                    final PrivateKey pqcPrivateKey = privateKeyRegistry.getPrivateKey(KeyType.MLDSA_65)
+                            .orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.NO_MASTER_SERVER_KEYPAIR));
+                    result.setPqcPrivateKey(pqcPrivateKey);
+                }
                 return result;
             } else {
 
@@ -375,7 +375,8 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
                 final EncryptionMode encryptionMode = activation.getServerPrivateKeysEncryption();
                 final PrivateKeys privateKeys = new PrivateKeys(encryptionMode, serverPrivateKeys);
                 final PrivateKeyRegistry privateKeyRegistry = serverPrivateKeysConverter.fromDBValue(privateKeys, activation.getUserId(), activation.getActivationId());
-                final PrivateKey serverPrivateKey = privateKeyRegistry.getPrivateKey(KeyType.ECDSA_P384).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+                final PrivateKey serverEcPrivateKey = privateKeyRegistry.getPrivateKey(KeyType.ECDSA_P384)
+                        .orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
 
                 final String sharedSecretEncrypted = activation.getSharedSecret();
                 final EncryptionMode sharedSecretEncryptionMode = activation.getSharedSecretEncryption();
@@ -387,8 +388,13 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
 
                 final TemporaryKeyResult result = new TemporaryKeyResult();
                 result.setSecretKeyBytes(secretKeyBytes);
-                result.setPrivateKey(serverPrivateKey);
+                result.setEcPrivateKey(serverEcPrivateKey);
                 result.setSharedSecretRequest(requestClaims.getSharedSecretRequest());
+                if (algorithm == SharedSecretAlgorithm.EC_P384_ML_L3) {
+                    final PrivateKey serverPqcPrivateKey = privateKeyRegistry.getPrivateKey(KeyType.MLDSA_65)
+                            .orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
+                    result.setPqcPrivateKey(serverPqcPrivateKey);
+                }
                 return result;
             }
         } else {
@@ -430,6 +436,21 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
             }
             default -> throw new IllegalArgumentException("Unsupported shared secret algorithm: " + algorithm);
         }
+    }
+
+    private String buildJwsResponse(final TemporaryKeyResult temporaryKeyResult, final TemporaryPublicKeyResponseClaims responseClaims, final Date timestamp, final SharedSecretAlgorithm algorithm) throws JOSEException {
+        final JWTClaimsSet claimsSet = buildClaims(responseClaims, timestamp);
+        final JWSObjectJSON jws = new JWSObjectJSON(claimsSet.toPayload());
+
+        final ECDSASigner ecdsaSigner = new ECDSASigner(temporaryKeyResult.getEcPrivateKey(), Curve.P_384);
+        jws.sign(new JWSHeader(JWSAlgorithm.ES384), ecdsaSigner);
+
+        if (algorithm == SharedSecretAlgorithm.EC_P384_ML_L3) {
+            final MLDSASigner mldsaSigner = new MLDSASigner(temporaryKeyResult.getPqcPrivateKey());
+            jws.sign(new JWSHeader(JWSAlgorithmMLDSA.MLDSA65), mldsaSigner);
+        }
+
+        return jws.serializeGeneral();
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/v3/TemporaryKeyResult.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/v3/TemporaryKeyResult.java
@@ -1,0 +1,44 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.model.crypto.v3;
+
+import com.wultra.security.powerauth.client.model.entity.v4.request.SharedSecretRequest;
+import lombok.Data;
+import lombok.ToString;
+
+import java.security.PrivateKey;
+
+/**
+ * Temporary key result (V3).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class TemporaryKeyResult {
+
+    @ToString.Exclude
+    private byte[] secretKeyBytes;
+
+    @ToString.Exclude
+    private PrivateKey privateKey;
+
+    private SharedSecretRequest sharedSecretRequest;
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/v4/TemporaryKeyResult.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/crypto/v4/TemporaryKeyResult.java
@@ -1,0 +1,47 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.model.crypto.v4;
+
+import com.wultra.security.powerauth.client.model.entity.v4.request.SharedSecretRequest;
+import lombok.Data;
+import lombok.ToString;
+
+import java.security.PrivateKey;
+
+/**
+ * Temporary key result (V4).
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@Data
+public class TemporaryKeyResult {
+
+    @ToString.Exclude
+    private byte[] secretKeyBytes;
+
+    @ToString.Exclude
+    private PrivateKey ecPrivateKey;
+
+    @ToString.Exclude
+    private PrivateKey pqcPrivateKey;
+
+    private SharedSecretRequest sharedSecretRequest;
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSAlgorithmMLDSA.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSAlgorithmMLDSA.java
@@ -14,31 +14,23 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
-package com.wultra.security.powerauth.app.server.service.model.crypto;
+package com.wultra.security.powerauth.app.server.service.util.jwt;
 
-import com.wultra.security.powerauth.client.model.entity.v4.request.SharedSecretRequest;
-import lombok.Data;
-import lombok.ToString;
-
-import java.security.PrivateKey;
+import com.nimbusds.jose.JWSAlgorithm;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 /**
- * Temporary key result.
+ * JWS algorithm name used in the {@code alg} header when the ML-DSA algorithm is used for signing.
+ * This class exists due to missing support of the algorithm name in the {@link JWSAlgorithm} list.
  *
- * @author Roman Strobl, roman.strobl@wultra.com
+ * @author Jan Pesek, jan.pesek@wultra.com
  */
-@Data
-public class TemporaryKeyResult {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class JWSAlgorithmMLDSA {
 
-    @ToString.Exclude
-    private byte[] secretKeyBytes;
-
-    @ToString.Exclude
-    private PrivateKey privateKey;
-
-    private SharedSecretRequest sharedSecretRequest;
+    public static final JWSAlgorithm MLDSA65 = new JWSAlgorithm("ML-DSA-65");
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/MLDSASigner.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/MLDSASigner.java
@@ -57,7 +57,7 @@ public class MLDSASigner implements JWSSigner {
             final byte[] signature = PQC_DSA.sign(privateKey, signingInput);
             return Base64URL.encode(signature);
         } catch (GenericCryptoException e) {
-            throw new JOSEException(e);
+            throw new JOSEException(e.getMessage(), e);
         }
     }
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/MLDSASigner.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/MLDSASigner.java
@@ -1,0 +1,74 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.app.server.service.util.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.impl.AlgorithmSupportMessage;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
+import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
+import com.wultra.security.powerauth.crypto.lib.v4.PqcDsa;
+import lombok.AllArgsConstructor;
+
+import java.security.PrivateKey;
+import java.util.Set;
+
+/**
+ * Implementation of the {@link JWSSigner} to support {@link PqcDsa}.
+ *
+ * @author Jan Pesek, jan.pesek@wultra.com
+ */
+@AllArgsConstructor
+public class MLDSASigner implements JWSSigner {
+    private static final PqcDsa PQC_DSA = new PqcDsa();
+    private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(JWSAlgorithmMLDSA.MLDSA65);
+    private final JCAContext jcaContext = new JCAContext();
+
+    private final PrivateKey privateKey;
+
+    @Override
+    public Base64URL sign(final JWSHeader header, final byte[] signingInput) throws JOSEException {
+        final JWSAlgorithm alg = header.getAlgorithm();
+
+        if (!supportedJWSAlgorithms().contains(alg)) {
+            throw new JOSEException(AlgorithmSupportMessage.unsupportedJWSAlgorithm(alg, this.supportedJWSAlgorithms()));
+        }
+
+        try {
+            final byte[] signature = PQC_DSA.sign(privateKey, signingInput);
+            return Base64URL.encode(signature);
+        } catch (GenericCryptoException e) {
+            throw new JOSEException(e);
+        }
+    }
+
+    @Override
+    public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+        return SUPPORTED_ALGORITHMS;
+    }
+
+    @Override
+    public JCAContext getJCAContext() {
+        return jcaContext;
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationServiceBehaviorTest.java
@@ -145,8 +145,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -215,8 +214,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key in hybrid mode
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramHybrid();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -274,8 +272,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -326,8 +323,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -389,8 +385,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key in hybrid mode
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramHybrid();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -441,8 +436,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, detailResponse);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -686,8 +680,7 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, applicationDetail.getVersions().get(0));
-        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        final JWTClaimsSet claims = requestTemporaryKeyJwt(requestCryptogramTemporary, applicationDetail);
 
         final String temporaryKeyId = claims.getSubject();
         final Object claim = claims.getClaim("sharedSecretResponse");
@@ -734,6 +727,11 @@ class ActivationServiceBehaviorTest {
         statusRequest.setActivationId(activationId);
         final GetActivationStatusResponse statusResponse = activationStatusServiceBehavior.getActivationStatus(statusRequest);
         return statusResponse.getActivationStatus();
+    }
+
+    private JWTClaimsSet requestTemporaryKeyJwt(final RequestCryptogram requestCryptogram, final GetApplicationDetailResponse detailResponse) throws Exception {
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, detailResponse.getVersions().get(0));
+        return JWTClaimsSet.parse(jws.getPayload().toJSONObject());
     }
 
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationServiceBehaviorTest.java
@@ -19,7 +19,8 @@
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jose.JWSObjectJSON;
+import com.nimbusds.jwt.JWTClaimsSet;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.ActivationServiceBehavior;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.ActivationInitServiceBehavior;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.ApplicationServiceBehavior;
@@ -144,9 +145,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
         sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -212,9 +215,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key in hybrid mode
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramHybrid();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseHybrid sharedSecretResponseHybrid = new SharedSecretResponseHybrid();
         sharedSecretResponseHybrid.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -269,9 +274,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
         sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -319,9 +326,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
         sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -380,9 +389,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key in hybrid mode
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramHybrid();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseHybrid sharedSecretResponseHybrid = new SharedSecretResponseHybrid();
         sharedSecretResponseHybrid.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -430,9 +441,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, detailResponse.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
         sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());
@@ -673,9 +686,11 @@ class ActivationServiceBehaviorTest {
 
         // Request temporary key
         final RequestCryptogram requestCryptogramTemporary = generateRequestCryptogramEcdhe();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, applicationDetail.getVersions().get(0));
-        final String temporaryKeyId = decodedJWT.getJWTClaimsSet().getStringClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogramTemporary, applicationDetail.getVersions().get(0));
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         final SharedSecretResponseEcdhe sharedSecretResponseEcdhe = new SharedSecretResponseEcdhe();
         sharedSecretResponseEcdhe.setEcServerPublicKey(serverResponse.getEcdhe());

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
@@ -170,7 +170,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON jws = JWSObjectJSON.parse(response.getJwt());
         assertEquals(1, jws.getSignatures().size());
-        assertValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion));
+        assertTrue(hasValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion)));
 
         final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claims.getStringClaim("applicationKey"));
@@ -186,8 +186,8 @@ class TemporaryKeyBehaviorTest {
         final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
 
         assertEquals(2, jws.getSignatures().size());
-        assertValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion));
-        assertValidSignature(jws, JWSAlgorithmMLDSA.MLDSA65, getMasterPublicPqcKey(defaultVersion));
+        assertTrue(hasValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion)));
+        assertTrue(hasValidSignature(jws, JWSAlgorithmMLDSA.MLDSA65, getMasterPublicPqcKey(defaultVersion)));
 
         final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claims.getClaim("applicationKey"));
@@ -197,6 +197,26 @@ class TemporaryKeyBehaviorTest {
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         assertNotNull(serverResponse.getEcdhe());
         assertNotNull(serverResponse.getMlkem());
+    }
+
+    @Test
+    void testJwtRequestApplicationScope_wrongApplicationKey() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        defaultVersion.setApplicationKey("wrongApplicationKey");
+
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion));
+        assertEquals(ServiceError.INVALID_APPLICATION, exception.getCode());
+    }
+
+    @Test
+    void testJwtRequestHybridApplicationScope_wrongMlDsaPublicKey() throws Exception {
+        final ApplicationVersion defaultVersion = createApplication();
+        final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
+
+        assertEquals(2, jws.getSignatures().size());
+        assertFalse(hasValidSignature(jws, JWSAlgorithmMLDSA.MLDSA65, PQC_DSA.generateKeyPair().getPublic()));
     }
 
     @Test
@@ -240,7 +260,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(1, decodedJWSActivation.getSignatures().size());
-        assertValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId));
+        assertTrue(hasValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId)));
 
         final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
@@ -280,8 +300,8 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(2, decodedJWSActivation.getSignatures().size());
-        assertValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId));
-        assertValidSignature(decodedJWSActivation, JWSAlgorithmMLDSA.MLDSA65, getServerPublicPqcKey(activationId));
+        assertTrue(hasValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId)));
+        assertTrue(hasValidSignature(decodedJWSActivation, JWSAlgorithmMLDSA.MLDSA65, getServerPublicPqcKey(activationId)));
 
         final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
@@ -442,13 +462,13 @@ class TemporaryKeyBehaviorTest {
         }
     }
 
-    private void assertValidSignature(JWSObjectJSON jws, JWSAlgorithm algorithm, PublicKey publicKey) throws GenericCryptoException, IOException, InvalidKeyException, CryptoProviderException {
+    private boolean hasValidSignature(JWSObjectJSON jws, JWSAlgorithm algorithm, PublicKey publicKey) throws GenericCryptoException, IOException, InvalidKeyException, CryptoProviderException {
         final JWSObjectJSON.Signature jwsSignature = jws.getSignatures().stream()
                 .filter(signature -> Objects.equals(signature.getHeader().getAlgorithm(), algorithm))
                 .findFirst()
                 .orElseThrow(() -> new AssertionError("No signature found for algorithm: " + algorithm));
 
-        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jwsSignature, publicKey));
+        return temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jwsSignature, publicKey);
     }
 
     @Data

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
@@ -19,6 +19,7 @@
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSObjectJSON;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
@@ -33,6 +34,7 @@ import com.wultra.security.powerauth.app.server.service.model.SdkConfiguration;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.response.v4.ActivationLayer2Response;
 import com.wultra.security.powerauth.app.server.service.util.SdkConfigurationSerializer;
+import com.wultra.security.powerauth.app.server.service.util.jwt.JWSAlgorithmMLDSA;
 import com.wultra.security.powerauth.app.server.util.TemporaryKeyTestService;
 import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
 import com.wultra.security.powerauth.client.model.entity.v4.request.DevicePublicKeys;
@@ -166,7 +168,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON jws = JWSObjectJSON.parse(response.getJwt());
         assertEquals(1, jws.getSignatures().size());
-        assertEquals("ES384", jws.getSignatures().get(0).getHeader().getAlgorithm().getName());
+        assertEquals(JWSAlgorithm.ES384, jws.getSignatures().get(0).getHeader().getAlgorithm());
 
         final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
 
@@ -186,8 +188,8 @@ class TemporaryKeyBehaviorTest {
         final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
 
         assertEquals(2, jws.getSignatures().size());
-        assertEquals("ES384", jws.getSignatures().get(0).getHeader().getAlgorithm().getName());
-        assertEquals("ML-DSA-65", jws.getSignatures().get(1).getHeader().getAlgorithm().getName());
+        assertEquals(JWSAlgorithm.ES384, jws.getSignatures().get(0).getHeader().getAlgorithm());
+        assertEquals(JWSAlgorithmMLDSA.MLDSA65, jws.getSignatures().get(1).getHeader().getAlgorithm());
 
         final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
         final PublicKey masterPublicKeyMlDsa65 = getMasterPublicPqcKey(defaultVersion);
@@ -245,7 +247,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(1, decodedJWSActivation.getSignatures().size());
-        assertEquals("ES384", decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm().getName());
+        assertEquals(JWSAlgorithm.ES384, decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm());
         assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
 
         final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
@@ -286,8 +288,8 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(2, decodedJWSActivation.getSignatures().size());
-        assertEquals("ES384", decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm().getName());
-        assertEquals("ML-DSA-65", decodedJWSActivation.getSignatures().get(1).getHeader().getAlgorithm().getName());
+        assertEquals(JWSAlgorithm.ES384, decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm());
+        assertEquals(JWSAlgorithmMLDSA.MLDSA65, decodedJWSActivation.getSignatures().get(1).getHeader().getAlgorithm());
         assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
         assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(1), getServerPublicPqcKey(activationId)));
 

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
@@ -19,8 +19,8 @@
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JWSObjectJSON;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
 import com.wultra.security.powerauth.app.server.database.model.KeyType;
 import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
@@ -30,6 +30,7 @@ import com.wultra.security.powerauth.app.server.service.behavior.tasks.Activatio
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.ApplicationServiceBehavior;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.model.SdkConfiguration;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.response.v4.ActivationLayer2Response;
 import com.wultra.security.powerauth.app.server.service.util.SdkConfigurationSerializer;
 import com.wultra.security.powerauth.app.server.util.TemporaryKeyTestService;
@@ -133,7 +134,8 @@ class TemporaryKeyBehaviorTest {
     void testJwtRequestEmpty() {
         final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
         request.setJwt("");
-        assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
     }
 
     @Test
@@ -144,7 +146,8 @@ class TemporaryKeyBehaviorTest {
         final String jwtRequest = temporaryKeyTestService.signJwt(jwtClaims, signingKey);
         final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest();
         request.setJwt(jwtRequest);
-        assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+        final GenericServiceException exception = assertThrows(GenericServiceException.class, () -> temporaryKeyBehavior.requestTemporaryKey(request));
+        assertEquals(ServiceError.INVALID_REQUEST, exception.getCode());
     }
 
     @Test
@@ -160,30 +163,42 @@ class TemporaryKeyBehaviorTest {
         request.setJwt(jwtRequest);
         final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
         assertNotNull(response.getJwt());
-        final SignedJWT decodedJWT = SignedJWT.parse(response.getJwt());
-        final PublicKey masterPublicKeyEc384 = getMasterPublicKey(defaultVersion);
 
-        assertTrue(temporaryKeyTestService.validateJwtSignature(decodedJWT, masterPublicKeyEc384));
-        assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
-        assertEquals(challenge, decodedJWT.getJWTClaimsSet().getClaim("challenge"));
-        assertNull(decodedJWT.getJWTClaimsSet().getClaim("activationId"));
-        assertNotNull(decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse"));
+        final JWSObjectJSON jws = JWSObjectJSON.parse(response.getJwt());
+        assertEquals(1, jws.getSignatures().size());
+        assertEquals("ES384", jws.getSignatures().get(0).getHeader().getAlgorithm().getName());
+
+        final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
+
+        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(0), masterPublicKeyEc384));
+
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        assertEquals(defaultVersion.getApplicationKey(), claims.getStringClaim("applicationKey"));
+        assertEquals(challenge, claims.getStringClaim("challenge"));
+        assertNull(claims.getClaim("activationId"));
+        assertNotNull(claims.getClaim("sharedSecretResponse"));
     }
 
     @Test
     void testJwtRequestHybridValidApplicationScope() throws Exception {
         final ApplicationVersion defaultVersion = createApplication();
         final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
-        final PublicKey masterPublicKeyEc384 = getMasterPublicKey(defaultVersion);
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
 
-        // TODO - validate Dilithium signature after it is available
-        assertTrue(temporaryKeyTestService.validateJwtSignature(decodedJWT, masterPublicKeyEc384));
+        assertEquals(2, jws.getSignatures().size());
+        assertEquals("ES384", jws.getSignatures().get(0).getHeader().getAlgorithm().getName());
+        assertEquals("ML-DSA-65", jws.getSignatures().get(1).getHeader().getAlgorithm().getName());
 
-        assertEquals(defaultVersion.getApplicationKey(), decodedJWT.getJWTClaimsSet().getClaim("applicationKey"));
-        assertNull(decodedJWT.getJWTClaimsSet().getClaim("activationId"));
-        assertNotNull(decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse"));
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
+        final PublicKey masterPublicKeyMlDsa65 = getMasterPublicPqcKey(defaultVersion);
+        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(0), masterPublicKeyEc384));
+        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(1), masterPublicKeyMlDsa65));
+
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+        assertEquals(defaultVersion.getApplicationKey(), claims.getClaim("applicationKey"));
+        assertNull(claims.getClaim("activationId"));
+        assertNotNull(claims.getClaim("sharedSecretResponse"));
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         assertNotNull(serverResponse.getEcdhe());
         assertNotNull(serverResponse.getMlkem());
@@ -193,8 +208,10 @@ class TemporaryKeyBehaviorTest {
     void testJwtRequestValidApplicationScopeWithRemove() throws Exception {
         final ApplicationVersion defaultVersion = createApplication();
         final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
-        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
         final RemoveTemporaryPublicKeyRequest removeRequest = new RemoveTemporaryPublicKeyRequest();
         removeRequest.setId(temporaryKeyId);
         final RemoveTemporaryPublicKeyResponse removeResponse = temporaryKeyBehavior.removeTemporaryKey(removeRequest);
@@ -206,10 +223,11 @@ class TemporaryKeyBehaviorTest {
     void testJwtRequestEcdheValidActivationScope() throws Exception {
         final ApplicationVersion defaultVersion = createApplication();
         final RequestCryptogram requestCryptogram = SHARED_SECRET_ECDHE.generateRequestCryptogram();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
 
-        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         assertNotNull(serverResponse.getEcdhe());
         // extract temporary key and use it during an activation
@@ -224,13 +242,18 @@ class TemporaryKeyBehaviorTest {
         requestTempKeyActivation.setJwt(jwtRequestActivation);
         final TemporaryPublicKeyResponse responseTempKeyActivation = temporaryKeyBehavior.requestTemporaryKey(requestTempKeyActivation);
         assertNotNull(responseTempKeyActivation.getJwt());
-        final SignedJWT decodedJWTActivation = SignedJWT.parse(responseTempKeyActivation.getJwt());
-        assertTrue(temporaryKeyTestService.validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId)));
-        assertEquals(defaultVersion.getApplicationKey(), decodedJWTActivation.getJWTClaimsSet().getClaim("applicationKey"));
-        assertEquals(challengeActivation, decodedJWTActivation.getJWTClaimsSet().getClaim("challenge"));
-        assertEquals(activationId, decodedJWTActivation.getJWTClaimsSet().getClaim("activationId"));
-        assertNotNull(decodedJWTActivation.getJWTClaimsSet().getClaim("sharedSecretResponse"));
-        final Object claimActivation = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+
+        final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
+        assertEquals(1, decodedJWSActivation.getSignatures().size());
+        assertEquals("ES384", decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm().getName());
+        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
+
+        final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
+        assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
+        assertEquals(challengeActivation, claimsActivation.getClaim("challenge"));
+        assertEquals(activationId, claimsActivation.getClaim("activationId"));
+        assertNotNull(claimsActivation.getClaim("sharedSecretResponse"));
+        final Object claimActivation = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponseActivation = OBJECT_MAPPER.convertValue(claimActivation, SharedSecretResponse.class);
         assertNotNull(serverResponseActivation.getEcdhe());
     }
@@ -239,12 +262,15 @@ class TemporaryKeyBehaviorTest {
     void testJwtRequestHybridValidActivationScope() throws Exception {
         final ApplicationVersion defaultVersion = createApplication();
         final RequestCryptogram requestCryptogram = SHARED_SECRET_HYBRID.generateRequestCryptogram();
-        final SignedJWT decodedJWT = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
-        final String temporaryKeyId = (String) decodedJWT.getJWTClaimsSet().getClaim("sub");
-        final Object claim = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+        final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
+        final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
+
+        final String temporaryKeyId = claims.getSubject();
+        final Object claim = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponse = OBJECT_MAPPER.convertValue(claim, SharedSecretResponse.class);
         assertNotNull(serverResponse.getEcdhe());
         assertNotNull(serverResponse.getMlkem());
+
         // extract temporary key and use it during an activation
         final ActivationContext activationContext = createActivation(defaultVersion, temporaryKeyId, requestCryptogram.getSharedSecretClientContext(), serverResponse);
         final String activationId = activationContext.activationLayer2Response.getActivationId();
@@ -257,13 +283,20 @@ class TemporaryKeyBehaviorTest {
         requestTempKeyActivation.setJwt(jwtRequestActivation);
         final TemporaryPublicKeyResponse responseTempKeyActivation = temporaryKeyBehavior.requestTemporaryKey(requestTempKeyActivation);
         assertNotNull(responseTempKeyActivation.getJwt());
-        final SignedJWT decodedJWTActivation = SignedJWT.parse(responseTempKeyActivation.getJwt());
-        assertTrue(temporaryKeyTestService.validateJwtSignature(decodedJWTActivation, getServerPublicKey(activationId)));
-        assertEquals(defaultVersion.getApplicationKey(), decodedJWTActivation.getJWTClaimsSet().getClaim("applicationKey"));
-        assertEquals(challengeActivation, decodedJWTActivation.getJWTClaimsSet().getClaim("challenge"));
-        assertEquals(activationId, decodedJWTActivation.getJWTClaimsSet().getClaim("activationId"));
-        assertNotNull(decodedJWTActivation.getJWTClaimsSet().getClaim("sharedSecretResponse"));
-        final Object claimActivation = decodedJWT.getJWTClaimsSet().getClaim("sharedSecretResponse");
+
+        final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
+        assertEquals(2, decodedJWSActivation.getSignatures().size());
+        assertEquals("ES384", decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm().getName());
+        assertEquals("ML-DSA-65", decodedJWSActivation.getSignatures().get(1).getHeader().getAlgorithm().getName());
+        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
+        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(1), getServerPublicPqcKey(activationId)));
+
+        final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
+        assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
+        assertEquals(challengeActivation, claimsActivation.getClaim("challenge"));
+        assertEquals(activationId, claimsActivation.getClaim("activationId"));
+        assertNotNull(claimsActivation.getClaim("sharedSecretResponse"));
+        final Object claimActivation = claims.getClaim("sharedSecretResponse");
         final SharedSecretResponse serverResponseActivation = OBJECT_MAPPER.convertValue(claimActivation, SharedSecretResponse.class);
         assertNotNull(serverResponseActivation.getEcdhe());
         assertNotNull(serverResponseActivation.getMlkem());
@@ -372,19 +405,34 @@ class TemporaryKeyBehaviorTest {
         return PQC_DSA.generateKeyPair();
     }
 
-    private PublicKey getServerPublicKey(String activationId) throws Exception {
+    private PublicKey getServerPublicEcKey(String activationId) throws Exception {
         final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
         final String serverPublicKeys = activation.getServerPublicKeys();
         final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(serverPublicKeys);
         return publicKeyRegistry.getPublicKey(KeyType.ECDSA_P384).orElseThrow(() -> new IllegalStateException("Missing public key"));
     }
 
-    private PublicKey getMasterPublicKey(ApplicationVersion applicationVersion) throws GenericCryptoException, InvalidKeySpecException, CryptoProviderException {
+    private PublicKey getServerPublicPqcKey(String activationId) throws Exception {
+        final ActivationRecordEntity activation = activationRepository.findActivationWithoutLock(activationId).orElseThrow(() -> new IllegalStateException("Missing activation"));
+        final String serverPublicKeys = activation.getServerPublicKeys();
+        final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(serverPublicKeys);
+        return publicKeyRegistry.getPublicKey(KeyType.MLDSA_65).orElseThrow(() -> new IllegalStateException("Missing public key"));
+    }
+
+    private PublicKey getMasterPublicEcKey(ApplicationVersion applicationVersion) throws GenericCryptoException, InvalidKeySpecException, CryptoProviderException {
         final String mobileSdkConfig = applicationVersion.getMobileSdkConfig();
         final SdkConfiguration sdkConfiguration = SdkConfigurationSerializer.deserialize(mobileSdkConfig);
         final String masterPublicKeyBase64 = Objects.requireNonNull(sdkConfiguration).masterPublicKeyP384();
         final byte[] masterPublicKeyBytes = Base64.getDecoder().decode(masterPublicKeyBase64);
         return KEY_CONVERTOR_EC.convertBytesToPublicKey(EcCurve.P384, masterPublicKeyBytes);
+    }
+
+    private PublicKey getMasterPublicPqcKey(ApplicationVersion applicationVersion) throws GenericCryptoException {
+        final String mobileSdkConfig = applicationVersion.getMobileSdkConfig();
+        final SdkConfiguration sdkConfiguration = SdkConfigurationSerializer.deserialize(mobileSdkConfig);
+        final String masterPublicKeyBase64 = Objects.requireNonNull(sdkConfiguration).masterPublicKeyMlDsa65();
+        final byte[] masterPublicKeyBytes = Base64.getDecoder().decode(masterPublicKeyBase64);
+        return KEY_CONVERTOR_PQC_DSA.convertBytesToPublicKey(masterPublicKeyBytes);
     }
 
     private SecretKey deriveSharedSecret(SharedSecretClientContext clientContext, SharedSecretResponse serverResponse) throws Exception {

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/TemporaryKeyBehaviorTest.java
@@ -82,7 +82,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.crypto.SecretKey;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
 import java.security.KeyPair;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -168,11 +170,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON jws = JWSObjectJSON.parse(response.getJwt());
         assertEquals(1, jws.getSignatures().size());
-        assertEquals(JWSAlgorithm.ES384, jws.getSignatures().get(0).getHeader().getAlgorithm());
-
-        final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
-
-        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(0), masterPublicKeyEc384));
+        assertValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion));
 
         final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claims.getStringClaim("applicationKey"));
@@ -188,13 +186,8 @@ class TemporaryKeyBehaviorTest {
         final JWSObjectJSON jws = temporaryKeyTestService.fetchTemporaryKey(requestCryptogram, defaultVersion);
 
         assertEquals(2, jws.getSignatures().size());
-        assertEquals(JWSAlgorithm.ES384, jws.getSignatures().get(0).getHeader().getAlgorithm());
-        assertEquals(JWSAlgorithmMLDSA.MLDSA65, jws.getSignatures().get(1).getHeader().getAlgorithm());
-
-        final PublicKey masterPublicKeyEc384 = getMasterPublicEcKey(defaultVersion);
-        final PublicKey masterPublicKeyMlDsa65 = getMasterPublicPqcKey(defaultVersion);
-        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(0), masterPublicKeyEc384));
-        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jws.getSignatures().get(1), masterPublicKeyMlDsa65));
+        assertValidSignature(jws, JWSAlgorithm.ES384, getMasterPublicEcKey(defaultVersion));
+        assertValidSignature(jws, JWSAlgorithmMLDSA.MLDSA65, getMasterPublicPqcKey(defaultVersion));
 
         final JWTClaimsSet claims = JWTClaimsSet.parse(jws.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claims.getClaim("applicationKey"));
@@ -247,8 +240,7 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(1, decodedJWSActivation.getSignatures().size());
-        assertEquals(JWSAlgorithm.ES384, decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm());
-        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
+        assertValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId));
 
         final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
@@ -288,10 +280,8 @@ class TemporaryKeyBehaviorTest {
 
         final JWSObjectJSON decodedJWSActivation = JWSObjectJSON.parse(responseTempKeyActivation.getJwt());
         assertEquals(2, decodedJWSActivation.getSignatures().size());
-        assertEquals(JWSAlgorithm.ES384, decodedJWSActivation.getSignatures().get(0).getHeader().getAlgorithm());
-        assertEquals(JWSAlgorithmMLDSA.MLDSA65, decodedJWSActivation.getSignatures().get(1).getHeader().getAlgorithm());
-        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(0), getServerPublicEcKey(activationId)));
-        assertTrue(temporaryKeyTestService.validateJwsSignature(decodedJWSActivation.getPayload(), decodedJWSActivation.getSignatures().get(1), getServerPublicPqcKey(activationId)));
+        assertValidSignature(decodedJWSActivation, JWSAlgorithm.ES384, getServerPublicEcKey(activationId));
+        assertValidSignature(decodedJWSActivation, JWSAlgorithmMLDSA.MLDSA65, getServerPublicPqcKey(activationId));
 
         final JWTClaimsSet claimsActivation = JWTClaimsSet.parse(decodedJWSActivation.getPayload().toJSONObject());
         assertEquals(defaultVersion.getApplicationKey(), claimsActivation.getClaim("applicationKey"));
@@ -450,6 +440,15 @@ class TemporaryKeyBehaviorTest {
         } else {
             throw new IllegalStateException("Invalid client context");
         }
+    }
+
+    private void assertValidSignature(JWSObjectJSON jws, JWSAlgorithm algorithm, PublicKey publicKey) throws GenericCryptoException, IOException, InvalidKeyException, CryptoProviderException {
+        final JWSObjectJSON.Signature jwsSignature = jws.getSignatures().stream()
+                .filter(signature -> Objects.equals(signature.getHeader().getAlgorithm(), algorithm))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("No signature found for algorithm: " + algorithm));
+
+        assertTrue(temporaryKeyTestService.validateJwsSignature(jws.getPayload(), jwsSignature, publicKey));
     }
 
     @Data

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/util/TemporaryKeyTestService.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/util/TemporaryKeyTestService.java
@@ -181,7 +181,9 @@ public class TemporaryKeyTestService {
     }
 
     /**
-     * Validate a JWS signature.
+     * Validates a JWS signature of the given payload.
+     * This method supports validation of signatures generated using
+     * the {@code ES384} or {@code ML-DSA-65} algorithms.
      *
      * @param payload JWS payload.
      * @param signature Item from the JWS signatures array.

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/util/TemporaryKeyTestService.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/util/TemporaryKeyTestService.java
@@ -21,9 +21,10 @@ package com.wultra.security.powerauth.app.server.util;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObjectJSON;
+import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.wultra.security.powerauth.app.server.service.behavior.tasks.v4.TemporaryKeyBehaviorAead;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.client.model.entity.ApplicationVersion;
@@ -38,6 +39,7 @@ import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoExc
 import com.wultra.security.powerauth.crypto.lib.util.HMACHashUtilities;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
+import com.wultra.security.powerauth.crypto.lib.v4.PqcDsa;
 import com.wultra.security.powerauth.crypto.lib.v4.kdf.KeyFactory;
 import com.wultra.security.powerauth.crypto.lib.v4.model.request.RequestCryptogram;
 import com.wultra.security.powerauth.crypto.lib.v4.model.request.SharedSecretRequestEcdhe;
@@ -74,19 +76,20 @@ public class TemporaryKeyTestService {
     private static final KeyGenerator KEY_GENERATOR = new KeyGenerator();
     private static final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
     private static final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
+    private static final PqcDsa PQC_DSA = new PqcDsa();
 
     /**
      * Fetch a temporary key.
      *
      * @param requestCryptogram Request cryptogram for AEAD client request.
      * @param applicationVersion Application version.
-     * @return SignedJWT object containing information about temporary key.
+     * @return JWSObjectJSON object containing information about temporary key.
      * @throws GenericServiceException Thrown in case of a business logic error.
      * @throws CryptoProviderException Thrown in case crypto provider is not initialized properly.
      * @throws GenericCryptoException Thrown in case of a cryptography error.
      * @throws ParseException Thrown in case of invalid response from server.
      */
-    public SignedJWT fetchTemporaryKey(RequestCryptogram requestCryptogram, ApplicationVersion applicationVersion) throws GenericServiceException, CryptoProviderException, GenericCryptoException, ParseException {
+    public JWSObjectJSON fetchTemporaryKey(RequestCryptogram requestCryptogram, ApplicationVersion applicationVersion) throws GenericServiceException, CryptoProviderException, GenericCryptoException, ParseException {
         final byte[] challengeBytes = KEY_GENERATOR.generateRandomBytes(18);
         final String challenge = Base64.getEncoder().encodeToString(challengeBytes);
         final byte[] secretKeyBytes = Base64.getDecoder().decode(applicationVersion.getApplicationSecret());
@@ -94,7 +97,7 @@ public class TemporaryKeyTestService {
         final String jwtRequest = createJwtRequest(EncryptorScope.APPLICATION_SCOPE, applicationVersion.getApplicationKey(), null, challenge, secretKey, requestCryptogram);
         final TemporaryPublicKeyRequest request = new TemporaryPublicKeyRequest(jwtRequest);
         final TemporaryPublicKeyResponse response = temporaryKeyBehavior.requestTemporaryKey(request);
-        return SignedJWT.parse(response.getJwt());
+        return JWSObjectJSON.parse(response.getJwt());
     }
 
     /**
@@ -178,9 +181,10 @@ public class TemporaryKeyTestService {
     }
 
     /**
-     * Validate a JWT signature.
+     * Validate a JWS signature.
      *
-     * @param jwt Signed JWT.
+     * @param payload JWS payload.
+     * @param signature Item from the JWS signatures array.
      * @param publicKey Public key to use for signature verification.
      * @return Whether signature is valid.
      * @throws IOException Thrown in case of a conversion error.
@@ -188,14 +192,14 @@ public class TemporaryKeyTestService {
      * @throws InvalidKeyException Thrown in case the public key is invalid.
      * @throws CryptoProviderException Thrown in case crypto provider is not initialized properly.
      */
-    public boolean validateJwtSignature(SignedJWT jwt, PublicKey publicKey) throws IOException, GenericCryptoException, InvalidKeyException, CryptoProviderException {
-        final Base64URL[] jwtParts = jwt.getParsedParts();
-        final Base64URL encodedHeader = jwtParts[0];
-        final Base64URL encodedPayload = jwtParts[1];
-        final Base64URL encodedSignature = jwtParts[2];
-        final String signingInput = encodedHeader + "." + encodedPayload;
-        final byte[] signatureBytes = convertRawSignatureToDER(encodedSignature.decode());
-        return SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, signingInput.getBytes(StandardCharsets.UTF_8), signatureBytes, publicKey);
+    public boolean validateJwsSignature(Payload payload, JWSObjectJSON.Signature signature, PublicKey publicKey) throws IOException, GenericCryptoException, InvalidKeyException, CryptoProviderException {
+        final String signingInput = signature.getHeader().getParsedBase64URL() + "." + payload.toBase64URL();
+
+        return switch (signature.getHeader().getAlgorithm().getName()) {
+            case "ES384" -> SIGNATURE_UTILS.validateECDSASignature(EcCurve.P384, signingInput.getBytes(StandardCharsets.UTF_8), convertRawSignatureToDER(signature.getSignature().decode()), publicKey);
+            case "ML-DSA-65" -> PQC_DSA.verify(publicKey, signingInput.getBytes(StandardCharsets.UTF_8), signature.getSignature().decode());
+            default -> throw new IllegalStateException("Unexpected value: " + signature.getHeader().getAlgorithm().getName());
+        };
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/wultra/powerauth-server/issues/1895 by adding support for singing using both `EC_P384` and `EC_P384_ML_L3`.
- The resulting JWS is now serialized into the general JSON structure, instead of the compact one used in v3.
- The verification procedure remains unchanged as it was already updated for v4 support.