### PR TITLE
Fix #1945: Allow additional activation statuses for temporary keys

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/ExtractEncryptorRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/ExtractEncryptorRequest.java
@@ -19,12 +19,16 @@
 
 package com.wultra.security.powerauth.client.model.request.v4;
 
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
 import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Model class representing request for AEAD encryptor initialization (V4).
@@ -58,5 +62,8 @@ public class ExtractEncryptorRequest {
     @NotNull(message = "Timestamp must not be null when requesting encryptor")
     @Positive(message = "Timestamp must be positive when requesting encryptor")
     private Long timestamp;
+
+    @Schema(description = "Activation states which are allowed when obtaining encryptor in activation scope")
+    private List<@NotNull ActivationStatus> allowedStates = new ArrayList<>();
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -27,7 +27,6 @@ import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
-import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
@@ -114,8 +113,7 @@ public class EncryptionBehaviorAead {
         final String activationId = request.getActivationId();
         final Long timestamp = request.getTimestamp();
         final String nonce = request.getNonce();
-        final List<ActivationStatus> allowedStates = request.getAllowedStates();
-        final List<com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus> convertedStates = allowedStates.stream()
+        final List<com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus> convertedStates = request.getAllowedStates().stream()
                         .map(activationStatusConverter::convert)
                         .toList();
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -18,6 +18,7 @@
  */
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
+import com.wultra.security.powerauth.app.server.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.service.crypto.v4.EncryptionServiceAead;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
@@ -26,6 +27,7 @@ import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.request.EncryptionContext;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
+import com.wultra.security.powerauth.client.model.enumeration.ActivationStatus;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
@@ -39,6 +41,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Base64;
+import java.util.List;
 
 /**
  * Behavior class implementing the AEAD encryption service logic.
@@ -59,6 +62,8 @@ public class EncryptionBehaviorAead {
     private final ActivationQueryService activationQueryService;
     private final ActivationContextValidator activationValidator;
     private final EncryptionServiceAead encryptionService;
+
+    private final ActivationStatusConverter activationStatusConverter = new ActivationStatusConverter();
 
     /**
      * Extract AEAD encryptor parameters to allow decryption of AEAD-encrypted messages on intermediate server.
@@ -109,6 +114,10 @@ public class EncryptionBehaviorAead {
         final String activationId = request.getActivationId();
         final Long timestamp = request.getTimestamp();
         final String nonce = request.getNonce();
+        final List<ActivationStatus> allowedStates = request.getAllowedStates();
+        final List<com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus> convertedStates = allowedStates.stream()
+                        .map(activationStatusConverter::convert)
+                        .toList();
 
         // Lookup the activation
         final ActivationRecordEntity activation = activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
@@ -119,7 +128,7 @@ public class EncryptionBehaviorAead {
 
         activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
 
-        activationValidator.validateActiveStatusForEncryptor(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
+        activationValidator.validateActiveStatusForEncryptor(activation.getActivationStatus(), convertedStates, activation.getActivationId(), localizationProvider);
 
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
         final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/EncryptionBehaviorAead.java
@@ -27,12 +27,10 @@ import com.wultra.security.powerauth.app.server.service.model.request.Encryption
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
 import com.wultra.security.powerauth.client.model.request.v4.ExtractEncryptorRequest;
-import com.wultra.security.powerauth.client.model.response.v3.GetEciesDecryptorResponse;
 import com.wultra.security.powerauth.client.model.response.v4.ExtractEncryptorResponse;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorId;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptorSecrets;
-import com.wultra.security.powerauth.crypto.lib.encryptor.model.v3.ServerEciesSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.context.AeadSecrets;
 import com.wultra.security.powerauth.crypto.lib.v4.encryptor.model.request.AeadEncryptedRequest;
 import lombok.AllArgsConstructor;
@@ -121,7 +119,7 @@ public class EncryptionBehaviorAead {
 
         activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
 
-        activationValidator.validateActiveStatus(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
+        activationValidator.validateActiveStatusForEncryptor(activation.getActivationStatus(), activation.getActivationId(), localizationProvider);
 
         final EncryptionContext context = new EncryptionContext(request.getProtocolVersion(), request.getApplicationKey(), activationId, EncryptorId.ACTIVATION_SCOPE_GENERIC);
         final EncryptorSecrets encryptorSecrets = encryptionService.deriveSecrets(

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/TemporaryKeyServiceAead.java
@@ -365,7 +365,7 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
                     throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
                 }
                 final ActivationRecordEntity activation = activationWithoutLock.get();
-                if ((activation.getActivationStatus() != ActivationStatus.ACTIVE && activation.getActivationStatus() != ActivationStatus.BLOCKED)
+                if ((activation.getActivationStatus() != ActivationStatus.ACTIVE && activation.getActivationStatus() != ActivationStatus.BLOCKED && activation.getActivationStatus() != ActivationStatus.PENDING_COMMIT)
                         || activation.getProtocol() == ActivationProtocol.FIDO2 // FIDO2 does not support temporary keys anywhere
                         || !Objects.equals(appId, activation.getApplication().getRid())) {
                     throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
@@ -401,7 +401,6 @@ public class TemporaryKeyServiceAead extends TemporaryKeyService {
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_APPLICATION);
         }
     }
-
 
     private ResponseCryptogram deriveSharedSecret(SharedSecretRequest request, SharedSecretAlgorithm algorithm) throws GenericCryptoException {
         switch (algorithm) {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/validator/ActivationContextValidator.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/validator/ActivationContextValidator.java
@@ -27,6 +27,8 @@ import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * Validation of activation context.
  *
@@ -71,9 +73,13 @@ public class ActivationContextValidator {
      * @param localizationProvider Localization provider.
      * @throws GenericServiceException Thrown when activation status is invalid.
      */
-    public void validateActiveStatusForEncryptor(final ActivationStatus activationStatus, final String activationId, final LocalizationProvider localizationProvider) throws GenericServiceException {
+    public void validateActiveStatusForEncryptor(final ActivationStatus activationStatus, final List<ActivationStatus> allowedStates, final String activationId, final LocalizationProvider localizationProvider) throws GenericServiceException {
+        if (allowedStates.contains(ActivationStatus.CREATED) || allowedStates.contains(ActivationStatus.REMOVED)) {
+            logger.info("Requested allow states are invalid, activation ID: {}", activationId);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         // Check if the activation is in correct state for extracting encryptor
-        if (activationStatus != ActivationStatus.ACTIVE && activationStatus != ActivationStatus.BLOCKED && activationStatus != ActivationStatus.PENDING_COMMIT) {
+        if (!allowedStates.contains(activationStatus)) {
             logger.info("Activation state is invalid, activation ID: {}", activationId);
             throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
         }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/validator/ActivationContextValidator.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/validator/ActivationContextValidator.java
@@ -65,6 +65,21 @@ public class ActivationContextValidator {
     }
 
     /**
+     * Validate that activation status is in correct state for extracting encryptor.
+     * @param activationStatus Actual validation status.
+     * @param activationId Activation identifier.
+     * @param localizationProvider Localization provider.
+     * @throws GenericServiceException Thrown when activation status is invalid.
+     */
+    public void validateActiveStatusForEncryptor(final ActivationStatus activationStatus, final String activationId, final LocalizationProvider localizationProvider) throws GenericServiceException {
+        // Check if the activation is in correct state for extracting encryptor
+        if (activationStatus != ActivationStatus.ACTIVE && activationStatus != ActivationStatus.BLOCKED && activationStatus != ActivationStatus.PENDING_COMMIT) {
+            logger.info("Activation state is invalid, activation ID: {}", activationId);
+            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
+        }
+    }
+
+    /**
      * Validate activation version.
      * @param actualVersion Actual version.
      * @param expectedVersion Expected version.


### PR DESCRIPTION
Opening of additional statuses for end-to-end encryption, triggered by switching activation status encryption to standard encryption.