### PR TITLE
Fix format of additionalData in audit (backport)

### DIFF
--- a/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehavior.java
@@ -17,6 +17,8 @@
  */
 package io.getlime.security.powerauth.app.server.service.behavior.tasks;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wultra.core.audit.base.model.AuditDetail;
 import com.wultra.core.audit.base.model.AuditLevel;
 import io.getlime.security.powerauth.app.server.converter.ActivationStatusConverter;
@@ -31,8 +33,8 @@ import io.getlime.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.client.model.entity.ActivationHistoryItem;
 import com.wultra.security.powerauth.client.model.request.ActivationHistoryRequest;
 import com.wultra.security.powerauth.client.model.response.ActivationHistoryResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,22 +48,17 @@ import java.util.List;
  */
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class ActivationHistoryServiceBehavior {
 
     private final ActivationHistoryRepository activationHistoryRepository;
 
     private final ActivationRepository activationRepository;
     private final AuditingServiceBehavior audit;
+    private final ObjectMapper objectMapper;
 
     // Prepare converters
     private final ActivationStatusConverter activationStatusConverter = new ActivationStatusConverter();
-
-    @Autowired
-    public ActivationHistoryServiceBehavior(ActivationHistoryRepository activationHistoryRepository, ActivationRepository activationRepository, AuditingServiceBehavior audit) {
-        this.activationHistoryRepository = activationHistoryRepository;
-        this.activationRepository = activationRepository;
-        this.audit = audit;
-    }
 
     /**
      * Log activation status change into activation history.
@@ -158,9 +155,7 @@ public class ActivationHistoryServiceBehavior {
         }
     }
 
-    // Private methods
-
-    private void logAuditItem(ActivationRecordEntity activation, String externalUserId, String historyEventReason) {
+    protected void logAuditItem(ActivationRecordEntity activation, String externalUserId, String historyEventReason) {
         // Prepare shared parameters
         final AuditDetail.Builder auditDetailBuilder = AuditDetail.builder()
                 .type(AuditType.ACTIVATION.getCode())
@@ -188,8 +183,12 @@ public class ActivationHistoryServiceBehavior {
         }
 
         if (activation.getAdditionalData() != null) {
-            auditDetailBuilder
-                    .param("additionalData", activation.getAdditionalData());
+            try {
+                final Object additionalData = objectMapper.readValue(activation.getAdditionalData(), Object.class);
+                auditDetailBuilder.param("additionalData", additionalData);
+            } catch (JsonProcessingException e) {
+                logger.error("Unable to deserialize additionalData: {}, activationId: {}", activation.getAdditionalData(), activation.getActivationId(), e);
+            }
         }
 
         // Build audit log message

--- a/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/io/getlime/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehaviorTest.java
@@ -1,0 +1,97 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package io.getlime.security.powerauth.app.server.service.behavior.tasks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wultra.core.audit.base.model.AuditDetail;
+import com.wultra.core.audit.base.model.AuditLevel;
+import io.getlime.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import io.getlime.security.powerauth.app.server.database.model.entity.ApplicationEntity;
+import io.getlime.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for {@link ActivationHistoryServiceBehavior}.
+ *
+ * @author Lubos Racansky, lubos.racansky@wultra.com
+ */
+@ExtendWith(MockitoExtension.class)
+class ActivationHistoryServiceBehaviorTest {
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private AuditingServiceBehavior audit;
+
+    @InjectMocks
+    private ActivationHistoryServiceBehavior tested;
+
+    @Test
+    void testLogAuditItem_additionalData() {
+        final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setApplication(new ApplicationEntity());
+        activation.setActivationStatus(ActivationStatus.ACTIVE);
+        activation.setAdditionalData("""
+                {"foo":"bar"}
+                """);
+
+        tested.logAuditItem(activation, "user1", "test");
+
+        final ArgumentCaptor<AuditDetail> auditDetailCaptor = ArgumentCaptor.forClass(AuditDetail.class);
+
+        verify(audit).log(eq(AuditLevel.INFO), any(), auditDetailCaptor.capture(), any(), any());
+
+        final AuditDetail capturedAuditDetail = auditDetailCaptor.getValue();
+
+        assertThat(capturedAuditDetail.getType()).isEqualTo("activation");
+        assertThat(capturedAuditDetail.getParam().get("additionalData")).isEqualTo(Map.of("foo", "bar"));
+    }
+
+    @Test
+    void testLogAuditItem_additionalData_invalidJson() {
+        final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setApplication(new ApplicationEntity());
+        activation.setActivationStatus(ActivationStatus.ACTIVE);
+        activation.setAdditionalData("invalid json");
+
+        tested.logAuditItem(activation, "user1", "test");
+
+        final ArgumentCaptor<AuditDetail> auditDetailCaptor = ArgumentCaptor.forClass(AuditDetail.class);
+
+        verify(audit).log(eq(AuditLevel.INFO), any(), auditDetailCaptor.capture(), any(), any());
+
+        final AuditDetail capturedAuditDetail = auditDetailCaptor.getValue();
+
+        assertThat(capturedAuditDetail.getType()).isEqualTo("activation");
+        assertThat(capturedAuditDetail.getParam().get("additionalData")).isNull();
+    }
+}


### PR DESCRIPTION
* Fix format of additionalData in audit

A follow-up to #1962

(cherry picked from commit 8c3b32a399f7c355d037d644161d61671917294a)