### PR TITLE
Fix #2023: Unify parameters request expiration and timestamp threshold

### DIFF
--- a/docs/Configuration-Properties.md
+++ b/docs/Configuration-Properties.md
@@ -33,7 +33,6 @@ The PowerAuth Server uses the following public configuration properties:
 | `powerauth.service.crypto.replayVerificationService`               | `default` | Request replay verification service, options: `default`, `none`                         |
 | `powerauth.service.token.timestamp.validity`                       | `7200000` | PowerAuth MAC token timestamp validity in miliseconds                                   |
 | `powerauth.service.token.timestamp.forward.validity`               | `1800000` | PowerAuth MAC token forward timestamp validity in milliseconds                             |
-| `powerauth.service.replay.timestamp.threshold`                     | `10000`   | Replay attack time threshold in milliseconds to handle potential client time fluctuations. |
 | `powerauth.service.secureVault.enableBiometricAuthentication`      | `false`   | Whether biometric authentication is enabled when accessing Secure Vault                 |
 | `powerauth.server.db.master.encryption.key`                        | `_empty_` | Master DB encryption key for decryption of server private key in database               |
 | `powerauth.service.proximity-check.otp.length`                     | `8`       | Length of OTP generated for proximity check                                             |

--- a/docs/PowerAuth-Server-1.10.0.md
+++ b/docs/PowerAuth-Server-1.10.0.md
@@ -37,8 +37,3 @@ The attribute name is `additionalData` and available in these endpoints:
 We have unified validations in PowerAuth server REST API. The error code returned for failed request validations is always `ERR0024`. As a side effect, the error code `ERR0002` used for the case when no application ID was set in request is no longer returned.
 
 The validation of requests is now stricter and more complete to ensure data integrity. In case you get the `ERR0024` error in your integration with PowerAuth server, please make sure the requests contain all parameters, as seen in REST API documentation available at `http[s]://[hostname]:[port]/powerauth-java-server/swagger-ui/index.html`.
-
-## Configuration Update
-
-A new parameter `powerauth.service.replay.timestamp.threshold` was introduced so that the replay attack detection time threshold can be configured due to potential system time fluctuations on moble clients. Under normal circumstances, it is not necessary to configure this parameter. However, in case of dropped requests, the threshold duration can be increased.
-

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -232,13 +232,6 @@ public class PowerAuthServiceConfiguration {
     private Duration tokenTimestampForwardValidity;
 
     /**
-     * Token timestamp validity to future, checked before validating the token.
-     */
-    @Value("${powerauth.service.replay.timestamp.threshold}")
-    @DurationMin(millis = 0)
-    private Duration replayTimestampThreshold;
-
-    /**
      * Master DB encryption key.
      */
     @Value("${powerauth.server.db.master.encryption.key}")

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/replay/DefaultReplayVerificationService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/replay/DefaultReplayVerificationService.java
@@ -20,6 +20,7 @@
 package com.wultra.security.powerauth.app.server.service.replay;
 
 import com.wultra.security.powerauth.app.server.configuration.PowerAuthServiceConfiguration;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.UniqueValueType;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -54,7 +55,7 @@ class DefaultReplayVerificationService implements ReplayVerificationService {
     public void checkAndPersistUniqueValue(String protocolVersion, Date requestTimestamp, UniqueValueParam param) throws GenericServiceException {
         logger.debug("Checking and persisting unique value, request type: {}, request timestamp: {}, identifier: {}", param.getUniqueValueType(), requestTimestamp, param.getIdentifier());
 
-        checkTimestamp(protocolVersion, requestTimestamp);
+        checkTimestamp(protocolVersion, requestTimestamp, param.getUniqueValueType());
 
         final byte uniqueValueType = (byte) param.getUniqueValueType().ordinal();
         final byte[] ephemeralPublicKeyBytes = param.getEphemeralPublicKey() != null ? Base64.getDecoder().decode(param.getEphemeralPublicKey()) : new byte[0];
@@ -86,32 +87,44 @@ class DefaultReplayVerificationService implements ReplayVerificationService {
      *
      * <p>Version 3.0 and 3.1:
      * <ul>
-     * <li>If TIMESTAMP < CURRENT_TIMESTAMP - EXPIRATION, then reject request</li>
-     * <li>If TIMESTAMP > CURRENT_TIMESTAMP + TIMESTAMP_THRESHOLD, then reject request</li>
+     * <li>If TIMESTAMP < CURRENT_TIMESTAMP - EXTENDED_EXPIRATION, then reject request</li>
+     * <li>If TIMESTAMP > CURRENT_TIMESTAMP + EXTENDED_EXPIRATION, then reject request</li>
      * </ul>
      *
      * <p>Version 3.2+:
      * <ul>
-     * <li>If TIMESTAMP < CURRENT_TIMESTAMP - TIMESTAMP_THRESHOLD, then reject request</li>
-     * <li>If TIMESTAMP > CURRENT_TIMESTAMP + TIMESTAMP_THRESHOLD, then reject request</li>
+     * <li>If TIMESTAMP < CURRENT_TIMESTAMP - EXPIRATION, then reject request</li>
+     * <li>If TIMESTAMP > CURRENT_TIMESTAMP + EXPIRATION, then reject request</li>
      * </ul>
      *
      * @param protocolVersion Protocol version.
      * @param requestTimestamp Request timestamp.
      * @throws GenericServiceException Thrown in case request is rejected due to its timestamp.
      */
-    private void checkTimestamp(String protocolVersion, Date requestTimestamp) throws GenericServiceException {
+    private void checkTimestamp(String protocolVersion, Date requestTimestamp, UniqueValueType uniqueValueType) throws GenericServiceException {
+        if (requestTimestamp == null) {
+            // Rollback is not required, error occurs before writing to database
+            logger.warn("Rejected request due to missing timestamp, protocol version: {}", protocolVersion);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
         final Instant now = Instant.now();
         final Instant requestTime = requestTimestamp.toInstant();
         final Instant limitOldest;
         final Instant limitNewest;
         if ("3.0".equals(protocolVersion) || "3.1".equals(protocolVersion)) {
-            // MAC TOKEN only has extended expiration, ECIES is checked only in protocol versions 3.2+
+            // Only MAC_TOKEN uses extended expiration, ECIES timestamps are checked only in protocol versions 3.2+
+            // The presence or absence of ECIES timestamps is checked before decryption in PowerAuth crypto library:
+            // https://github.com/wultra/powerauth-crypto/blob/develop/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/encryptor/ecies/EciesRequestResponseValidator.java
+            if (uniqueValueType != UniqueValueType.MAC_TOKEN) {
+                // Rollback is not required, error occurs before writing to database
+                logger.warn("Rejected request due to invalid unique value type: {}, protocol version: {}", uniqueValueType, protocolVersion);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
             limitOldest = now.minus(powerAuthServiceConfiguration.getRequestExpirationExtended());
             limitNewest = now.plus(powerAuthServiceConfiguration.getRequestExpirationExtended());
         } else {
-            limitOldest = now.minus(powerAuthServiceConfiguration.getReplayTimestampThreshold());
-            limitNewest = now.plus(powerAuthServiceConfiguration.getReplayTimestampThreshold());
+            limitOldest = now.minus(powerAuthServiceConfiguration.getRequestExpiration());
+            limitNewest = now.plus(powerAuthServiceConfiguration.getRequestExpiration());
         }
         if (requestTime.isBefore(limitOldest) || requestTime.isAfter(limitNewest)) {
             // Rollback is not required, error occurs before writing to database

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/replay/DefaultReplayVerificationService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/replay/DefaultReplayVerificationService.java
@@ -113,8 +113,6 @@ class DefaultReplayVerificationService implements ReplayVerificationService {
         final Instant limitNewest;
         if ("3.0".equals(protocolVersion) || "3.1".equals(protocolVersion)) {
             // Only MAC_TOKEN uses extended expiration, ECIES timestamps are checked only in protocol versions 3.2+
-            // The presence or absence of ECIES timestamps is checked before decryption in PowerAuth crypto library:
-            // https://github.com/wultra/powerauth-crypto/blob/develop/powerauth-java-crypto/src/main/java/com/wultra/security/powerauth/crypto/lib/encryptor/ecies/EciesRequestResponseValidator.java
             if (uniqueValueType != UniqueValueType.MAC_TOKEN) {
                 // Rollback is not required, error occurs before writing to database
                 logger.warn("Rejected request due to invalid unique value type: {}, protocol version: {}", uniqueValueType, protocolVersion);

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -72,9 +72,6 @@ powerauth.service.http.connection.max-idle-time=200s
 powerauth.service.token.timestamp.validity=7200000
 powerauth.service.token.timestamp.forward.validity=1800000
 
-# Replay Attach Check Time Synchronization Threshold
-powerauth.service.replay.timestamp.threshold=120000
-
 # Vault Unlock behavior
 powerauth.service.secureVault.enableBiometricAuthentication=false
 

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/replay/ReplayVerificationServiceTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/replay/ReplayVerificationServiceTest.java
@@ -60,7 +60,6 @@ class ReplayVerificationServiceTest {
 
         when(configuration.getRequestExpiration()).thenReturn(Duration.ofSeconds(300));
         when(configuration.getRequestExpirationExtended()).thenReturn(Duration.ofMinutes(120));
-        when(configuration.getReplayTimestampThreshold()).thenReturn(Duration.ofSeconds(120));
         when(localizationProvider.buildExceptionForCode(any())).thenThrow(new RuntimeException());
 
         inMemoryPersistence = new ReplayPersistenceService(uniqueValueRepository, configuration) {
@@ -104,8 +103,8 @@ class ReplayVerificationServiceTest {
 
     static Stream<TestCase> provideTestCases() {
         Instant now = Instant.now();
-        long withinReplayTresholdSeconds = 119;
-        long exceededReplayTresholdSeconds = 121;
+        long withinExpirationSeconds = 299;
+        long exceededExpirationSeconds = 301;
         long withinExtendedExpirationSeconds = 7199;
         long exceededExtendedExpirationSeconds = 7201;
         return Stream.of(
@@ -125,7 +124,7 @@ class ReplayVerificationServiceTest {
 
                 // --- 3.2 ---
                 new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-5", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtNQ=="),
-                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-6", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-6", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-7", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtNw=="),
                 new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-7", null, "bm9uY2U=", Date.from(now), false, null),
                 new TestCase("3.2", UniqueValueType.ECIES_APPLICATION_SCOPE, "YXBwLWtleS0z", null, "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now), true, "AWVwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2U="),
@@ -136,22 +135,22 @@ class ReplayVerificationServiceTest {
 
                 // --- 3.3 ---
                 new TestCase("3.3", UniqueValueType.MAC_TOKEN, null, "token-id-8", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtOA=="),
-                new TestCase("3.3", UniqueValueType.MAC_TOKEN, null, "token-id-8", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.3", UniqueValueType.MAC_TOKEN, null, "token-id-8", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("3.3", UniqueValueType.MAC_TOKEN, null, "token-id-9", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtOQ=="),
                 new TestCase("3.3", UniqueValueType.MAC_TOKEN, null, "token-id-9", null, "bm9uY2U=", Date.from(now), false, null),
                 new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-1", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0x"),
                 new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-1", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now), false, null),
-                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-2", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-2", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-2", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0y"),
 
                 // --- 4.0 ---
                 new TestCase("4.0", UniqueValueType.MAC_TOKEN, null, "token-id-10", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtMTA="),
-                new TestCase("4.0", UniqueValueType.MAC_TOKEN, null, "token-id-10", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("4.0", UniqueValueType.MAC_TOKEN, null, "token-id-10", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("4.0", UniqueValueType.MAC_TOKEN, null, "token-id-11", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtMTE="),
                 new TestCase("4.0", UniqueValueType.MAC_TOKEN, null, "token-id-11", null, "bm9uY2U=", Date.from(now), false, null),
                 new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-3", null, "bm9uY2U=", Date.from(now), true, "BG5vbmNldGVtcC1rZXktaWQtMw=="),
                 new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-3", null, "bm9uY2U=", Date.from(now), false, null),
-                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4", null, "bm9uY2U=", Date.from(now), true, "BG5vbmNldGVtcC1rZXktaWQtNA=="),
 
                 // Timestamp range test cases
@@ -170,25 +169,25 @@ class ReplayVerificationServiceTest {
                 new TestCase("3.1", UniqueValueType.MAC_TOKEN, null, "token-id-3105", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExtendedExpirationSeconds)), false, null),
 
                 // --- 3.2 Expiration ---
-                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3201", null, "bm9uY2U=", Date.from(now.minusSeconds(withinReplayTresholdSeconds)), true, "AG5vbmNldG9rZW4taWQtMzIwMQ=="),
-                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3202", null, "bm9uY2U=", Date.from(now.minusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3201", null, "bm9uY2U=", Date.from(now.minusSeconds(withinExpirationSeconds)), true, "AG5vbmNldG9rZW4taWQtMzIwMQ=="),
+                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3202", null, "bm9uY2U=", Date.from(now.minusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3203", null, "bm9uY2U=", Date.from(now), true, "AG5vbmNldG9rZW4taWQtMzIwMw=="),
-                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3204", null, "bm9uY2U=", Date.from(now.plusSeconds(withinReplayTresholdSeconds)), true, "AG5vbmNldG9rZW4taWQtMzIwNA=="),
-                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3205", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3204", null, "bm9uY2U=", Date.from(now.plusSeconds(withinExpirationSeconds)), true, "AG5vbmNldG9rZW4taWQtMzIwNA=="),
+                new TestCase("3.2", UniqueValueType.MAC_TOKEN, null, "token-id-3205", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
 
                 // --- 3.3 Expiration ---
-                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3301", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.minusSeconds(withinReplayTresholdSeconds)), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0zMzAx"),
-                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3302", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.minusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3301", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.minusSeconds(withinExpirationSeconds)), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0zMzAx"),
+                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3302", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.minusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3303", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0zMzAz"),
-                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3304", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(withinReplayTresholdSeconds)), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0zMzA0"),
-                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3305", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3304", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(withinExpirationSeconds)), true, "A2VwaGVtZXJhbC1wdWJsaWMta2V5bm9uY2V0ZW1wLWtleS1pZC0zMzA0"),
+                new TestCase("3.3", UniqueValueType.ECIES_WITH_TEMPORARY_KEY, null, "temp-key-id-3305", "ZXBoZW1lcmFsLXB1YmxpYy1rZXk=", "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null),
 
                 // --- 4.0 Expiration ---
-                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4001", null, "bm9uY2U=", Date.from(now.minusSeconds(withinReplayTresholdSeconds)), true, "BG5vbmNldGVtcC1rZXktaWQtNDAwMQ=="),
-                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4002", null, "bm9uY2U=", Date.from(now.minusSeconds(exceededReplayTresholdSeconds)), false, null),
+                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4001", null, "bm9uY2U=", Date.from(now.minusSeconds(withinExpirationSeconds)), true, "BG5vbmNldGVtcC1rZXktaWQtNDAwMQ=="),
+                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4002", null, "bm9uY2U=", Date.from(now.minusSeconds(exceededExpirationSeconds)), false, null),
                 new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4003", null, "bm9uY2U=", Date.from(now), true, "BG5vbmNldGVtcC1rZXktaWQtNDAwMw=="),
-                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4004", null, "bm9uY2U=", Date.from(now.plusSeconds(withinReplayTresholdSeconds)), true, "BG5vbmNldGVtcC1rZXktaWQtNDAwNA=="),
-                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4005", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededReplayTresholdSeconds)), false, null)
+                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4004", null, "bm9uY2U=", Date.from(now.plusSeconds(withinExpirationSeconds)), true, "BG5vbmNldGVtcC1rZXktaWQtNDAwNA=="),
+                new TestCase("4.0", UniqueValueType.AEAD_V4, null, "temp-key-id-4005", null, "bm9uY2U=", Date.from(now.plusSeconds(exceededExpirationSeconds)), false, null)
         );
     }
 


### PR DESCRIPTION
Replacement of `TIMESTAMP_THRESHOLD` with `EXPIRATION` and code cleanup, test updates.