### PR TITLE
Fix #2024: Unify token validity checks with replay attack time limit checks

### DIFF
--- a/docs/Configuration-Properties.md
+++ b/docs/Configuration-Properties.md
@@ -31,8 +31,6 @@ The PowerAuth Server uses the following public configuration properties:
 | `powerauth.service.crypto.requestExpirationInMilliseconds`         | `60000`   | Expiration for ECIES and MAC token requests.                                            |
 | `powerauth.service.crypto.requestExpirationInMillisecondsExtended` | `7200000` | Expiration for ECIES and MAC token requests for protocol versions 3.1 and older.        |
 | `powerauth.service.crypto.replayVerificationService`               | `default` | Request replay verification service, options: `default`, `none`                         |
-| `powerauth.service.token.timestamp.validity`                       | `7200000` | PowerAuth MAC token timestamp validity in miliseconds                                   |
-| `powerauth.service.token.timestamp.forward.validity`               | `1800000` | PowerAuth MAC token forward timestamp validity in milliseconds                             |
 | `powerauth.service.replay.timestamp.threshold`                     | `10000`   | Replay attack time threshold in milliseconds to handle potential client time fluctuations. |
 | `powerauth.service.secureVault.enableBiometricAuthentication`      | `false`   | Whether biometric authentication is enabled when accessing Secure Vault                 |
 | `powerauth.server.db.master.encryption.key`                        | `_empty_` | Master DB encryption key for decryption of server private key in database               |

--- a/docs/PowerAuth-Server-2.0.0.md
+++ b/docs/PowerAuth-Server-2.0.0.md
@@ -81,3 +81,7 @@ Following property names were changed:
 - `powerauth.service.crypto.offlineSignatureComponentLength` is now `powerauth.service.crypto.offlineAuthenticationCodeComponentLength`
 
 Usually there is no reason to change these configuration properties, default values are used in most of the deployments. Please double-check if this change affects existing deployments.
+
+### Updated MAC Token Request Timestamp Validations
+
+We have unified validations in PowerAuth server REST API. The error code returned for failed MAC token request timestamp validation is always `ERR0024`. As a side effect, error codes `ERR0030` and `ERR0044` used for the case when MAC token request timestamp validation fails are no longer returned.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -218,20 +218,6 @@ public class PowerAuthServiceConfiguration {
     private Duration httpMaxIdleTime;
 
     /**
-     * Token timestamp validity, checked before validating the token.
-     */
-    @Value("${powerauth.service.token.timestamp.validity}")
-    @DurationMin(millis = 1)
-    private Duration tokenTimestampValidity;
-
-    /**
-     * Token timestamp validity to future, checked before validating the token.
-     */
-    @Value("${powerauth.service.token.timestamp.forward.validity}")
-    @DurationMin(millis = 0)
-    private Duration tokenTimestampForwardValidity;
-
-    /**
      * Token timestamp validity to future, checked before validating the token.
      */
     @Value("${powerauth.service.replay.timestamp.threshold}")
@@ -626,38 +612,6 @@ public class PowerAuthServiceConfiguration {
      */
     public void setHttpProxyPassword(String httpProxyPassword) {
         this.httpProxyPassword = httpProxyPassword;
-    }
-
-    /**
-     * Get the token timestamp validity.
-     * @return Token timestamp validity.
-     */
-    public Duration getTokenTimestampValidity() {
-        return tokenTimestampValidity;
-    }
-
-    /**
-     * Set the token timestamp validity.
-     * @param tokenTimestampValidity Token timestamp validity.
-     */
-    public void setTokenTimestampValidity(Duration tokenTimestampValidity) {
-        this.tokenTimestampValidity = tokenTimestampValidity;
-    }
-
-    /**
-     * Get the token timestamp validity into future.
-     * @return Token timestamp validity into future.
-     */
-    public Duration getTokenTimestampForwardValidity() {
-        return tokenTimestampForwardValidity;
-    }
-
-    /**
-     * Set the token timestamp validity into future in milliseconds.
-     * @param tokenTimestampForwardValidity Token timestamp validity into future in milliseconds
-     */
-    public void setTokenTimestampForwardValidity(Duration tokenTimestampForwardValidity) {
-        this.tokenTimestampForwardValidity = tokenTimestampForwardValidity;
     }
 
     /**

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/TokenBehavior.java
@@ -154,20 +154,6 @@ public class TokenBehavior {
     @Transactional
     public ValidateTokenResponse validateToken(ValidateTokenRequest request) throws GenericServiceException {
         try {
-            // Verify the token timestamp validity
-            final long currentTimeMillis = System.currentTimeMillis();
-            final long requestTimestamp = request.getTimestamp();
-            if (requestTimestamp < currentTimeMillis - powerAuthServiceConfiguration.getTokenTimestampValidity().toMillis()) {
-                logger.warn("Invalid request - token timestamp is too old for token ID: {}, request timestamp: {}", request.getTokenId(), requestTimestamp);
-                // Rollback is not required, database is not used for writing
-                throw localizationProvider.buildExceptionForCode(ServiceError.TOKEN_TIMESTAMP_TOO_OLD);
-            }
-            if (requestTimestamp > currentTimeMillis + powerAuthServiceConfiguration.getTokenTimestampForwardValidity().toMillis()) {
-                logger.warn("Invalid request - token timestamp is set too much in the future for token ID: {}, request timestamp: {}", request.getTokenId(), requestTimestamp);
-                // Rollback is not required, database is not used for writing
-                throw localizationProvider.buildExceptionForCode(ServiceError.TOKEN_TIMESTAMP_TOO_IN_FUTURE);
-            }
-
             final String tokenId = request.getTokenId();
             final byte[] nonce = Base64.getDecoder().decode(request.getNonce());
             final byte[] timestamp = tokenVerifier.convertTokenTimestamp(request.getTimestamp());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/ServiceError.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/model/ServiceError.java
@@ -162,7 +162,10 @@ public final class ServiceError {
 
     /**
      * Token timestamp is too old.
+     *
+     * @deprecated replaced by {@link #INVALID_REQUEST}
      */
+    @Deprecated
     public static final String TOKEN_TIMESTAMP_TOO_OLD = "ERR0030";
 
     /**
@@ -232,7 +235,10 @@ public final class ServiceError {
 
     /**
      * Token timestamp is too much in the future.
+     *
+     * @deprecated replaced by {@link #INVALID_REQUEST}
      */
+    @Deprecated
     public static final String TOKEN_TIMESTAMP_TOO_IN_FUTURE = "ERR0044";
 
     /**

--- a/powerauth-java-server/src/main/resources/application.properties
+++ b/powerauth-java-server/src/main/resources/application.properties
@@ -68,10 +68,6 @@ powerauth.service.http.connection.timeout=5000
 powerauth.service.http.response.timeout=60s
 powerauth.service.http.connection.max-idle-time=200s
 
-# Token Timestamp Validity in Milliseconds
-powerauth.service.token.timestamp.validity=7200000
-powerauth.service.token.timestamp.forward.validity=1800000
-
 # Replay Attach Check Time Synchronization Threshold
 powerauth.service.replay.timestamp.threshold=120000
 


### PR DESCRIPTION
Removed duplicate token timestamp checks. The request timestamps are now only checked in replay verification service.