### PR TITLE
Fix #2025: Unify temporary key expiration with replay attack timestamp checks

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -712,8 +712,17 @@ public class PowerAuthServiceConfiguration {
     }
 
     @PostConstruct
-    void validate() {
+    void validateProximityConfiguration() {
         Assert.state(proximityCheckOtpLength >= MINIMAL_PROXIMITY_CHECK_OTP_LENGTH,
                 "Proximity check OTP length %d is smaller then required minimal %d".formatted(proximityCheckOtpLength, MINIMAL_PROXIMITY_CHECK_OTP_LENGTH));
     }
+
+    @PostConstruct
+    public void validateReplayConfiguration() {
+        Assert.state(temporaryKeyValidity.toMillis() <= requestExpiration.toMillis(),
+                "Temporary key validity %d ms exceeds request expiration %d ms"
+                        .formatted(temporaryKeyValidity.toMillis(), requestExpiration.toMillis())
+        );
+    }
+
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/configuration/PowerAuthServiceConfiguration.java
@@ -718,7 +718,7 @@ public class PowerAuthServiceConfiguration {
     }
 
     @PostConstruct
-    public void validateReplayConfiguration() {
+    void validateReplayConfiguration() {
         Assert.state(temporaryKeyValidity.toMillis() <= requestExpiration.toMillis(),
                 "Temporary key validity %d ms exceeds request expiration %d ms"
                         .formatted(temporaryKeyValidity.toMillis(), requestExpiration.toMillis())


### PR DESCRIPTION
Added state validation for invalid temporary key and replay verification configuration.