### PR TITLE
Fix #2062: Update cryptography service initialization

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureServiceBehavior.java
@@ -85,10 +85,15 @@ public class AsymmetricSignatureServiceBehavior {
             }
 
             final byte[] dataRaw = Base64.getDecoder().decode(data);
-            final byte[] signatureEcdsa = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384_ML_L3).generateSignatureForActivation(KeyType.ECDSA_P384, dataRaw, activation);
+            final byte[] signatureEcdsa = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.ECDSA_P384, dataRaw, activation);
             final String signatureEcdsBase64 = Base64.getEncoder().encodeToString(signatureEcdsa);
-            final byte[] signatureMldsa = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384_ML_L3).generateSignatureForActivation(KeyType.MLDSA_65, dataRaw, activation);
-            final String signatureMldsaBase64 = Base64.getEncoder().encodeToString(signatureMldsa);
+            final String signatureMldsaBase64;
+            if (activation.getCryptoAlgorithm() == SharedSecretAlgorithm.EC_P384_ML_L3) {
+                final byte[] signatureMldsa = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.MLDSA_65, dataRaw, activation);
+                signatureMldsaBase64 = Base64.getEncoder().encodeToString(signatureMldsa);
+            } else {
+                signatureMldsaBase64 = null;
+            }
 
             final SignAsymmetricResponse response = new SignAsymmetricResponse();
             response.setSignatureEcdsa(signatureEcdsBase64);
@@ -142,8 +147,8 @@ public class AsymmetricSignatureServiceBehavior {
             final byte[] signatureBytesDER = signatureDER(signatureFormat, signatureBytes);
 
             final boolean matches = switch (signatureType) {
-                case ECDSA -> cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384_ML_L3).verifySignatureForActivation(KeyType.ECDSA_P384, dataBytes, signatureBytesDER, activation);
-                case MLDSA -> cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384_ML_L3).verifySignatureForActivation(KeyType.MLDSA_65, dataBytes, signatureBytesDER, activation);
+                case ECDSA -> cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).verifySignatureForActivation(KeyType.ECDSA_P384, dataBytes, signatureBytesDER, activation);
+                case MLDSA -> cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).verifySignatureForActivation(KeyType.MLDSA_65, dataBytes, signatureBytesDER, activation);
             };
 
             return VerifyAsymmetricSignatureResponse.builder()

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuthenticationSharedServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuthenticationSharedServiceBehavior.java
@@ -42,7 +42,6 @@ import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderEx
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.v4.authentication.AuthenticationKeyFactory;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import com.wultra.security.powerauth.crypto.server.v4.authentication.PowerAuthServerAuthentication;
 import lombok.Builder;
 import lombok.Getter;
@@ -217,7 +216,7 @@ public class AuthenticationSharedServiceBehavior {
      */
     private AuthenticationResponse verifyAuthenticationImpl(ActivationRecordEntity activation, AuthenticationData authenticationData, List<AuthenticationCodeType> authenticationCodeTypes) throws GenericServiceException, CryptoProviderException, GenericCryptoException {
         activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
-        final SecretKey keyActivationSecret = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).deriveSharedSecretKey(activation);
+        final SecretKey keyActivationSecret = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).deriveSharedSecretKey(activation);
         final Integer authenticationVersion = resolveAuthenticationVersion(activation, authenticationData.getForcedAuthenticationVersion());
 
         final long ctr = activation.getCounter();

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
@@ -163,7 +163,7 @@ public class OfflineAuthenticationServiceBehavior {
             final String dataPlusNonce = fetchDataAndTotp(offlineAuthenticationParameter, powerAuthServiceConfiguration.getProximityCheckOtpLength()) + "\n" + nonce;
             final byte[] signatureBase = (dataPlusNonce + "\n" + KEY_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
             // TODO - v4 support using KMAC
-            final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).generateSignatureForActivation(KeyType.ECDSA_P384, signatureBase, activation);
+            final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.ECDSA_P384, signatureBase, activation);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 
             // Construct complete offline data as '{DATA}\n{NONCE}\n{KEY_SERVER_PRIVATE_INDICATOR}{ECDSA_SIGNATURE}'

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureBehaviorTest.java
@@ -35,6 +35,7 @@ import com.wultra.security.powerauth.client.model.request.v4.SignAsymmetricReque
 import com.wultra.security.powerauth.client.model.request.v4.VerifyAsymmetricSignatureRequest;
 import com.wultra.security.powerauth.client.model.response.v4.SignAsymmetricResponse;
 import com.wultra.security.powerauth.client.model.response.v4.VerifyAsymmetricSignatureResponse;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,6 +86,7 @@ class AsymmetricSignatureBehaviorTest {
         activation = new ActivationRecordEntity();
         activation.setActivationStatus(ActivationStatus.ACTIVE);
         activation.setProtocol(ActivationProtocol.POWERAUTH);
+        activation.setCryptoAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
     }
 
     @Test


### PR DESCRIPTION
Algorithm used by the service should be taken from activation.