### PR TITLE
Fix #2094: Missing private and public key registries for v3 application

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ApplicationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ApplicationServiceBehavior.java
@@ -21,7 +21,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.Applicatio
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationRepository;
 import com.wultra.security.powerauth.app.server.database.repository.ApplicationVersionRepository;
-import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.crypto.MasterKeyGenerationService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -30,7 +30,6 @@ import com.wultra.security.powerauth.client.model.request.*;
 import com.wultra.security.powerauth.client.model.response.*;
 import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
-import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -50,10 +49,10 @@ import java.util.Optional;
 @AllArgsConstructor
 public class ApplicationServiceBehavior {
 
+    private final MasterKeyGenerationService masterKeyGenerationService;
     private final LocalizationProvider localizationProvider;
     private final ApplicationRepository applicationRepository;
     private final ApplicationVersionRepository applicationVersionRepository;
-    private final CryptographyServiceFactory cryptographyServiceFactory;
 
     private final KeyGenerator KEY_GENERATOR = new KeyGenerator();
 
@@ -140,11 +139,8 @@ public class ApplicationServiceBehavior {
             application.setId(applicationId);
             application = applicationRepository.save(application);
 
-            for (SharedSecretAlgorithm algorithm: SharedSecretAlgorithm.values()) {
-                if (algorithm == SharedSecretAlgorithm.ML_L3) continue;
-                // Generate key pairs for all supported algorithms
-                cryptographyServiceFactory.getService(algorithm).generateMasterKeyPair(application);
-            }
+            // Generate master server key pairs
+            masterKeyGenerationService.generateMasterKeyPairs(application);
 
             // Use cryptography methods before writing to database to avoid rollbacks
             final byte[] applicationKeyBytes = KEY_GENERATOR.generateRandomBytes(16);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/MasterKeyGenerationService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/MasterKeyGenerationService.java
@@ -1,0 +1,160 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.crypto;
+
+import com.wultra.security.powerauth.app.server.converter.MasterPrivateKeysConverter;
+import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationEntity;
+import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyPairEntity;
+import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.crypto.lib.enums.EcCurve;
+import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * Service for generating master server keys for applications.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service
+@Slf4j
+@AllArgsConstructor
+public class MasterKeyGenerationService {
+
+    private final MasterKeyPairRepository masterKeyPairRepository;
+    private final LocalizationProvider localizationProvider;
+    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
+    private final PublicKeysConverter publicKeysConverter;
+
+    private final KeyConvertor KEY_CONVERTOR_EC = new KeyConvertor();
+
+    private final com.wultra.security.powerauth.crypto.server.activation.PowerAuthServerActivation SERVER_ACTIVATION_V3 = new com.wultra.security.powerauth.crypto.server.activation.PowerAuthServerActivation();
+    private final com.wultra.security.powerauth.crypto.server.v4.activation.PowerAuthServerActivation SERVER_ACTIVATION_V4 = new com.wultra.security.powerauth.crypto.server.v4.activation.PowerAuthServerActivation();
+
+    /**
+     * Generate master server key pairs for application.
+     * @param application Application.
+     * @throws GenericServiceException Thrown in case of a cryptography error.
+     */
+    public void generateMasterKeyPairs(ApplicationEntity application) throws GenericServiceException {
+        try {
+            MasterKeyPairEntity keyPair = findMasterKeyPair(application);
+
+            final PrivateKeyRegistry privateKeyRegistry;
+            final PublicKeyRegistry publicKeyRegistry;
+
+            if (keyPair == null) {
+                // Initialize keypair
+                keyPair = createInitialV3Entity(application);
+                privateKeyRegistry = new PrivateKeyRegistry();
+                publicKeyRegistry = new PublicKeyRegistry();
+                writeRegistriesToEntity(keyPair, privateKeyRegistry, publicKeyRegistry, application);
+            } else if (keyPair.getMasterPrivateKeys() == null) {
+                // Migration to V4 registries
+                privateKeyRegistry = new PrivateKeyRegistry();
+                publicKeyRegistry = new PublicKeyRegistry();
+            } else {
+                // Update existing V4 keypairs
+                privateKeyRegistry = loadPrivateRegistryFromEntity(keyPair, application);
+                publicKeyRegistry = loadPublicRegistryFromEntity(keyPair);
+            }
+
+            generateAndStoreV4KeyPairs(privateKeyRegistry, publicKeyRegistry);
+            writeRegistriesToEntity(keyPair, privateKeyRegistry, publicKeyRegistry, application);
+            masterKeyPairRepository.save(keyPair);
+
+        } catch (CryptoProviderException e) {
+            logger.error("Could not generate keypair", e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
+        }
+    }
+
+    private MasterKeyPairEntity findMasterKeyPair(ApplicationEntity application) {
+        return masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
+    }
+
+    private MasterKeyPairEntity createInitialV3Entity(ApplicationEntity app) throws CryptoProviderException, GenericServiceException {
+        final KeyPair kp = SERVER_ACTIVATION_V3.generateServerKeyPair();
+        final PrivateKey privateKey = kp.getPrivate();
+        final PublicKey publicKey = kp.getPublic();
+
+        MasterKeyPairEntity entity = new MasterKeyPairEntity();
+        entity.setTimestampCreated(new Date());
+        entity.setName(app.getId() + " Default Keypair");
+        entity.setApplication(app);
+
+        // Initialize empty V4 registries into DB fields
+        PrivateKeyRegistry privateKeyRegistry = new PrivateKeyRegistry();
+        PublicKeyRegistry publicKeyRegistry = new PublicKeyRegistry();
+        PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, app.getId());
+        entity.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
+        entity.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
+        entity.setMasterPublicKeys(publicKeysConverter.toDBValue(publicKeyRegistry));
+
+        entity.setMasterKeyPrivateBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPrivateKeyToBytes(privateKey)));
+        entity.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR_EC.convertPublicKeyToBytes(EcCurve.P256, publicKey)));
+
+        return entity;
+    }
+
+    private PrivateKeyRegistry loadPrivateRegistryFromEntity(MasterKeyPairEntity entity, ApplicationEntity app) throws GenericServiceException {
+        PrivateKeys privateKeys = new PrivateKeys(entity.getMasterPrivateKeysEncryption(), entity.getMasterPrivateKeys());
+        return masterPrivateKeysConverter.fromDBValue(privateKeys, app.getId());
+    }
+
+    private PublicKeyRegistry loadPublicRegistryFromEntity(MasterKeyPairEntity entity) throws GenericServiceException {
+        return publicKeysConverter.fromDBValue(entity.getMasterPublicKeys());
+    }
+
+    private void generateAndStoreV4KeyPairs(PrivateKeyRegistry privateKeyRegistry, PublicKeyRegistry publicKeyRegistry) throws CryptoProviderException {
+        KeyPair ec = SERVER_ACTIVATION_V4.generateEcServerKeyPair();
+        privateKeyRegistry.storePrivateKey(KeyType.ECDSA_P384, ec.getPrivate());
+        publicKeyRegistry.storePublicKey(KeyType.ECDSA_P384, ec.getPublic());
+
+        KeyPair pqcDsa = SERVER_ACTIVATION_V4.generatePqcServerKeyPair();
+        privateKeyRegistry.storePrivateKey(KeyType.MLDSA_65, pqcDsa.getPrivate());
+        publicKeyRegistry.storePublicKey(KeyType.MLDSA_65, pqcDsa.getPublic());
+    }
+
+    private void writeRegistriesToEntity(MasterKeyPairEntity entity, PrivateKeyRegistry privateKeyRegistry,
+                                         PublicKeyRegistry publicKeyRegistry, ApplicationEntity app) throws GenericServiceException {
+        PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, app.getId());
+        entity.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
+        entity.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
+        entity.setMasterPublicKeys(publicKeysConverter.toDBValue(publicKeyRegistry));
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v3/CryptographyServiceEc256.java
@@ -19,8 +19,6 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto.v3;
 
-import com.wultra.security.powerauth.app.server.converter.MasterPrivateKeysConverter;
-import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
 import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeyConverter;
 import com.wultra.security.powerauth.app.server.database.model.*;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
@@ -29,6 +27,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyP
 import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
 import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+import com.wultra.security.powerauth.app.server.service.crypto.MasterKeyGenerationService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -43,8 +42,8 @@ import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.crypto.server.keyfactory.PowerAuthServerKeyFactory;
 import com.wultra.security.powerauth.crypto.server.activation.PowerAuthServerActivation;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -55,7 +54,6 @@ import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
-import java.util.Date;
 
 /**
  * Cryptography Service V3 implementation based on EC curve P-256.
@@ -64,26 +62,15 @@ import java.util.Date;
  */
 @Service
 @Slf4j
+@AllArgsConstructor
 public class CryptographyServiceEc256 extends CryptographyService {
 
+    private final MasterKeyGenerationService masterKeyGenerationService;
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final LocalizationProvider localizationProvider;
     private final ServerPrivateKeyConverter serverPrivateKeyConverter;
-    private final MasterPrivateKeysConverter masterPrivateKeysConverter;
-    private final PublicKeysConverter publicKeysConverter;
 
     private final PowerAuthServerActivation SERVER_ACTIVATION = new PowerAuthServerActivation();
-
-    @Autowired
-    public CryptographyServiceEc256(MasterKeyPairRepository masterKeyPairRepository,
-                                    LocalizationProvider localizationProvider1,
-                                    ServerPrivateKeyConverter serverPrivateKeyConverter, MasterPrivateKeysConverter masterPrivateKeysConverter, PublicKeysConverter publicKeysConverter) {
-        this.masterKeyPairRepository = masterKeyPairRepository;
-        this.localizationProvider = localizationProvider1;
-        this.serverPrivateKeyConverter = serverPrivateKeyConverter;
-        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
-        this.publicKeysConverter = publicKeysConverter;
-    }
 
     private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private final SignatureUtils SIGNATURE_UTILS = new SignatureUtils();
@@ -91,39 +78,7 @@ public class CryptographyServiceEc256 extends CryptographyService {
 
     @Override
     public void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException {
-        try {
-            final KeyPair kp = SERVER_ACTIVATION.generateServerKeyPair();
-            final PrivateKey privateKey = kp.getPrivate();
-            final PublicKey publicKey = kp.getPublic();
-
-            // Key pairs for multiple algorithms are stored for the same entity in order:
-            // 1. EC_P256 (ECDSA keypair)
-            // 2. EC_P384 (ECDSA keypair)
-            // 3. EC_P384_ML_L3 (ECDSA keypair and MLDSA keypair, ECDSA keypair is reused from algorithm EC_P384)
-            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
-            if (keyPair != null) {
-                logger.error("Key pair generation called in invalid order");
-                throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-            }
-            keyPair = new MasterKeyPairEntity();
-            final PrivateKeyRegistry privateKeyRegistry = new PrivateKeyRegistry();
-            final PublicKeyRegistry publicKeyRegistry = new PublicKeyRegistry();
-            keyPair.setTimestampCreated(new Date());
-            keyPair.setName(application.getId() + " Default Keypair");
-            // Store empty registries for V4
-            final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
-            keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
-            keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
-            final String masterPublicKeys = publicKeysConverter.toDBValue(publicKeyRegistry);
-            keyPair.setMasterPublicKeys(masterPublicKeys);
-            keyPair.setApplication(application);
-            keyPair.setMasterKeyPrivateBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPrivateKeyToBytes(privateKey)));
-            keyPair.setMasterKeyPublicBase64(Base64.getEncoder().encodeToString(KEY_CONVERTOR.convertPublicKeyToBytes(EcCurve.P256, publicKey)));
-            masterKeyPairRepository.save(keyPair);
-        } catch (CryptoProviderException e) {
-            logger.error("Could not generate keypair", e);
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-        }
+         masterKeyGenerationService.generateMasterKeyPairs(application);
     }
 
     @Override

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceEc384.java
@@ -30,6 +30,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyP
 import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
 import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+import com.wultra.security.powerauth.app.server.service.crypto.MasterKeyGenerationService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -43,8 +44,8 @@ import com.wultra.security.powerauth.crypto.lib.util.HybridPublicKeyFingerprint;
 import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.util.SignatureUtils;
 import com.wultra.security.powerauth.crypto.server.v4.activation.PowerAuthServerActivation;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -63,8 +64,10 @@ import java.util.Base64;
  */
 @Service
 @Slf4j
+@AllArgsConstructor
 public class CryptographyServiceEc384 extends CryptographyService {
 
+    private final MasterKeyGenerationService masterKeyGenerationService;
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final LocalizationProvider localizationProvider;
     private final MasterPrivateKeysConverter masterPrivateKeysConverter;
@@ -77,52 +80,9 @@ public class CryptographyServiceEc384 extends CryptographyService {
 
     private final PowerAuthServerActivation SERVER_ACTIVATION = new PowerAuthServerActivation();
 
-    @Autowired
-    public CryptographyServiceEc384(MasterKeyPairRepository masterKeyPairRepository, LocalizationProvider localizationProvider, MasterPrivateKeysConverter masterPrivateKeysConverter, ServerPrivateKeysConverter serverPrivateKeysConverter, ActivationSharedSecretConverter sharedSecretConverter, PublicKeysConverter publicKeysConverter) {
-        this.masterKeyPairRepository = masterKeyPairRepository;
-        this.localizationProvider = localizationProvider;
-        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
-        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
-        this.sharedSecretConverter = sharedSecretConverter;
-        this.publicKeysConverter = publicKeysConverter;
-    }
-
     @Override
     public void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException {
-        try {
-            // Generate P-384 key pair
-            final KeyPair kp = SERVER_ACTIVATION.generateEcServerKeyPair();
-            final PrivateKey privateKey = kp.getPrivate();
-            final PublicKey publicKey = kp.getPublic();
-
-            // Key pairs for multiple algorithms are stored for the same entity in order:
-            // 1. EC_P256 (ECDSA keypair)
-            // 2. EC_P384 (ECDSA keypair)
-            // 3. EC_P384_ML_L3 (ECDSA keypair and MLDSA keypair, ECDSA keypair is reused from algorithm EC_P384)
-            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
-            if (keyPair == null) {
-                logger.error("Key pair generation called in invalid order");
-                throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-            }
-            final PrivateKeys privateKeys = new PrivateKeys(keyPair.getMasterPrivateKeysEncryption(), keyPair.getMasterPrivateKeys());
-            final PrivateKeyRegistry privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(privateKeys, application.getId());
-            final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(keyPair.getMasterPublicKeys());
-
-            // Store ECDSA keypair in JSON format
-            privateKeyRegistry.storePrivateKey(KeyType.ECDSA_P384, privateKey);
-            final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
-            keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
-            keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
-
-            publicKeyRegistry.storePublicKey(KeyType.ECDSA_P384, publicKey);
-            final String publicKeys384Json = publicKeysConverter.toDBValue(publicKeyRegistry);
-            keyPair.setMasterPublicKeys(publicKeys384Json);
-
-            masterKeyPairRepository.save(keyPair);
-        } catch (CryptoProviderException e) {
-            logger.error("Could not generate keypair", e);
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-        }
+        masterKeyGenerationService.generateMasterKeyPairs(application);
     }
 
     @Override

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
@@ -30,6 +30,7 @@ import com.wultra.security.powerauth.app.server.database.model.entity.MasterKeyP
 import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
 import com.wultra.security.powerauth.app.server.database.repository.MasterKeyPairRepository;
 import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+import com.wultra.security.powerauth.app.server.service.crypto.MasterKeyGenerationService;
 import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
 import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
@@ -46,9 +47,9 @@ import com.wultra.security.powerauth.crypto.lib.v4.api.PqcDsaKeyConvertor;
 import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsa;
 import com.wultra.security.powerauth.crypto.lib.v4.ml.MlDsaKeyConvertor;
 import com.wultra.security.powerauth.crypto.server.v4.activation.PowerAuthServerActivation;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jcajce.interfaces.MLDSAPublicKey;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
@@ -67,8 +68,10 @@ import java.util.Base64;
  */
 @Service
 @Slf4j
+@AllArgsConstructor
 public class CryptographyServiceHybrid extends CryptographyService {
 
+    private final MasterKeyGenerationService masterKeyGenerationService;
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final LocalizationProvider localizationProvider;
     private final MasterPrivateKeysConverter masterPrivateKeysConverter;
@@ -83,50 +86,9 @@ public class CryptographyServiceHybrid extends CryptographyService {
 
     private final PowerAuthServerActivation SERVER_ACTIVATION = new PowerAuthServerActivation();
 
-    @Autowired
-    public CryptographyServiceHybrid(MasterKeyPairRepository masterKeyPairRepository, LocalizationProvider localizationProvider, MasterPrivateKeysConverter masterPrivateKeysConverter, ServerPrivateKeysConverter serverPrivateKeysConverter, ActivationSharedSecretConverter sharedSecretConverter, PublicKeysConverter publicKeysConverter) {
-        this.masterKeyPairRepository = masterKeyPairRepository;
-        this.localizationProvider = localizationProvider;
-        this.masterPrivateKeysConverter = masterPrivateKeysConverter;
-        this.serverPrivateKeysConverter = serverPrivateKeysConverter;
-        this.sharedSecretConverter = sharedSecretConverter;
-        this.publicKeysConverter = publicKeysConverter;
-    }
-
     @Override
     public void generateMasterKeyPair(ApplicationEntity application) throws GenericServiceException {
-        try {
-            // Generate PQC key pair
-            final KeyPair kpPqcDsa = SERVER_ACTIVATION.generatePqcServerKeyPair();
-            final PrivateKey privateKeyPqcDsa = kpPqcDsa.getPrivate();
-            final PublicKey publicKeyPqcDsa = kpPqcDsa.getPublic();
-
-            // Key pairs for multiple algorithms are stored for the same entity in order:
-            // 1. EC_P256 (ECDSA keypair)
-            // 2. EC_P384 (ECDSA keypair)
-            // 3. EC_P384_ML_L3 (ECDSA keypair and MLDSA keypair, ECDSA keypair is reused from algorithm EC_P384)
-            MasterKeyPairEntity keyPair = masterKeyPairRepository.findFirstByApplicationIdOrderByTimestampCreatedDesc(application.getId());
-            if (keyPair == null) {
-                logger.error("Key pair generation called in invalid order");
-                throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-            }
-            final PrivateKeys privateKeys = new PrivateKeys(keyPair.getMasterPrivateKeysEncryption(), keyPair.getMasterPrivateKeys());
-            final PrivateKeyRegistry privateKeyRegistry = masterPrivateKeysConverter.fromDBValue(privateKeys, application.getId());
-            final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(keyPair.getMasterPublicKeys());
-
-            // Store private and public keys for ML-DSA in JSON format
-            privateKeyRegistry.storePrivateKey(KeyType.MLDSA_65, privateKeyPqcDsa);
-            final PrivateKeys masterPrivateKeys = masterPrivateKeysConverter.toDBValue(privateKeyRegistry, application.getId());
-            keyPair.setMasterPrivateKeys(masterPrivateKeys.privateKeysBase64());
-            keyPair.setMasterPrivateKeysEncryption(masterPrivateKeys.encryptionMode());
-            publicKeyRegistry.storePublicKey(KeyType.MLDSA_65, publicKeyPqcDsa);
-            final String publicKeys384Json = publicKeysConverter.toDBValue(publicKeyRegistry);
-            keyPair.setMasterPublicKeys(publicKeys384Json);
-            masterKeyPairRepository.save(keyPair);
-        } catch (CryptoProviderException e) {
-            logger.error("Could not generate keypair", e);
-            throw localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
-        }
+        masterKeyGenerationService.generateMasterKeyPairs(application);
     }
 
     @Override


### PR DESCRIPTION
This pull request centralizes the master server public key generation into one service. It will be further extended by https://github.com/wultra/powerauth-server/issues/1907 but for now this is to mainly make application migration from V3 to V4 possible.