### PR TITLE
Fix #2034: Add multi-signature endpoint with JWS JSON serialization format

### DIFF
--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/v4/JwtSignatureFormat.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/v4/JwtSignatureFormat.java
@@ -27,13 +27,13 @@ package com.wultra.security.powerauth.client.model.enumeration.v4;
 public enum JwtSignatureFormat {
 
     /**
-     * Signature is in a JWT format.
+     * Signature is in a JWS compact serialization format.
      */
-    JWT,
+    JWS_COMPACT,
 
     /**
-     * Signature is in a JWS format.
+     * Signature is in a JWS JSON serialization format.
      */
-    JWS
+    JWS_JSON
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/v4/JwtSignatureFormat.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/enumeration/v4/JwtSignatureFormat.java
@@ -1,0 +1,39 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.client.model.enumeration.v4;
+
+/**
+ * Enum with possible JWT signature formats.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public enum JwtSignatureFormat {
+
+    /**
+     * Signature is in a JWT format.
+     */
+    JWT,
+
+    /**
+     * Signature is in a JWS format.
+     */
+    JWS
+
+}

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/SignJwtRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/SignJwtRequest.java
@@ -1,0 +1,51 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.client.model.request.v4;
+
+import com.wultra.security.powerauth.client.model.enumeration.v4.AsymmetricSignatureType;
+import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Model class representing request for signing data using JWT request (V4).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class SignJwtRequest {
+
+    @Schema(description = "Activation identifier")
+    @NotBlank(message = "Activation ID must not be empty when creating signature")
+    private String activationId;
+
+    @Schema(description = "Data to be signed")
+    @NotNull(message = "Data must not be null when creating signature")
+    private String data;
+
+    @Schema(description = "Signature format")
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+
+    @Schema(description = "Signature type")
+    private AsymmetricSignatureType signatureType;
+
+}

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/SignJwtRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/SignJwtRequest.java
@@ -43,7 +43,7 @@ public class SignJwtRequest {
     private String data;
 
     @Schema(description = "Signature format")
-    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWS_COMPACT;
 
     @Schema(description = "Signature type")
     private AsymmetricSignatureType signatureType;

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/VerifyJwtSignatureRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/VerifyJwtSignatureRequest.java
@@ -42,6 +42,6 @@ public class VerifyJwtSignatureRequest {
     private String signedData;
 
     @Schema(description = "Signature format")
-    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWS_COMPACT;
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/VerifyJwtSignatureRequest.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/request/v4/VerifyJwtSignatureRequest.java
@@ -1,0 +1,47 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.client.model.request.v4;
+
+import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/**
+ * Model class representing request for JWT signature verification (V4).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class VerifyJwtSignatureRequest {
+
+    @Schema(description = "Activation identifier")
+    @NotBlank(message = "Activation ID must not be empty when verifying signature")
+    private String activationId;
+
+    @Schema(description = "Signed data")
+    @NotNull(message = "Signed data must not be null when verifying signature")
+    private String signedData;
+
+    @Schema(description = "Signature format")
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+
+}

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/SignJwtResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/SignJwtResponse.java
@@ -1,0 +1,41 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.client.model.response.v4;
+
+import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.ToString;
+
+/**
+ * Model class representing response for signing JWT data (V4).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Data
+public class SignJwtResponse {
+
+    @ToString.Exclude
+    private String signedData;
+
+    @Schema(description = "Signature format")
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+
+}

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/SignJwtResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/SignJwtResponse.java
@@ -36,6 +36,6 @@ public class SignJwtResponse {
     private String signedData;
 
     @Schema(description = "Signature format")
-    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWT;
+    private JwtSignatureFormat signatureFormat = JwtSignatureFormat.JWS_COMPACT;
 
 }

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/VerifyJwtSignatureResponse.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/model/response/v4/VerifyJwtSignatureResponse.java
@@ -1,0 +1,37 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.client.model.response.v4;
+
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Model class representing response with JWT signature verification results (V4).
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Builder
+@Getter @ToString @EqualsAndHashCode
+@Jacksonized
+public class VerifyJwtSignatureResponse {
+
+    private final boolean signatureValid;
+
+}

--- a/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/v4/PowerAuthClient.java
+++ b/powerauth-client-model/src/main/java/com/wultra/security/powerauth/client/v4/PowerAuthClient.java
@@ -608,6 +608,36 @@ public interface PowerAuthClient {
     VaultUnlockResponse unlockVault(VaultUnlockRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
+     * Call the signAsymmetric method of the PowerAuth Server interface.
+     *
+     * @param request {@link SignAsymmetricRequest} instance.
+     * @return {@link SignAsymmetricResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    SignAsymmetricResponse signAsymmetric(SignAsymmetricRequest request) throws PowerAuthClientException;
+
+    /**
+     * Call the signAsymmetric method of the PowerAuth Server interface.
+     *
+     * @param request {@link SignAsymmetricRequest} instance.
+     * @param queryParams HTTP query parameters.
+     * @param httpHeaders HTTP headers.
+     * @return {@link SignAsymmetricResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    SignAsymmetricResponse signAsymmetric(SignAsymmetricRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
+
+    /**
+     * Call the signAsymmetric method of the PowerAuth Server interface.
+     *
+     * @param activationId Activation ID of activation to be used for authentication.
+     * @param data         Data to be signed by asymmetric signature algorithm.
+     * @return Sign data using asymmetric signature algorithm and return REST response with results
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    SignAsymmetricResponse signAsymmetric(String activationId, String data) throws PowerAuthClientException;
+
+    /**
      * Call the verifyAsymmetricSignature method of the PowerAuth Server interface.
      *
      * @param request {@link VerifyAsymmetricSignatureRequest} instance.
@@ -637,6 +667,46 @@ public interface PowerAuthClient {
      * @throws PowerAuthClientException In case REST API call fails.
      */
     VerifyAsymmetricSignatureResponse verifyAsymmetricSignature(String activationId, String data, String signature) throws PowerAuthClientException;
+
+    /**
+     * Call the signJwt method of the PowerAuth Server interface.
+     *
+     * @param request {@link SignJwtRequest} instance.
+     * @return {@link SignJwtResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    SignJwtResponse signJwt(SignJwtRequest request) throws PowerAuthClientException;
+
+    /**
+     * Call the signJwt method of the PowerAuth Server interface.
+     *
+     * @param request {@link SignJwtRequest} instance.
+     * @param queryParams HTTP query parameters.
+     * @param httpHeaders HTTP headers.
+     * @return {@link SignJwtResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    SignJwtResponse signJwt(SignJwtRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
+
+    /**
+     * Call the verifyJwtSignature method of the PowerAuth Server interface.
+     *
+     * @param request {@link VerifyJwtSignatureRequest} instance.
+     * @return {@link VerifyJwtSignatureResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    VerifyJwtSignatureResponse verifyJwtSignature(VerifyJwtSignatureRequest request) throws PowerAuthClientException;
+
+    /**
+     * Call the verifyJwtSignature method of the PowerAuth Server interface.
+     *
+     * @param request {@link VerifyJwtSignatureRequest} instance.
+     * @param queryParams HTTP query parameters.
+     * @param httpHeaders HTTP headers.
+     * @return {@link VerifyJwtSignatureResponse}
+     * @throws PowerAuthClientException In case REST API call fails.
+     */
+    VerifyJwtSignatureResponse verifyJwtSignature(VerifyJwtSignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException;
 
     /**
      * Call the getSignatureAuditLog method of the PowerAuth Server interface.

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/JwtSignatureController.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/api/v4/JwtSignatureController.java
@@ -1,0 +1,90 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.controller.api.v4;
+
+import com.wultra.core.rest.model.base.request.ObjectRequest;
+import com.wultra.core.rest.model.base.response.ObjectResponse;
+import com.wultra.security.powerauth.app.server.service.behavior.tasks.v4.JwtSignatureServiceBehavior;
+import com.wultra.security.powerauth.client.model.request.v4.SignJwtRequest;
+import com.wultra.security.powerauth.client.model.request.v4.VerifyJwtSignatureRequest;
+import com.wultra.security.powerauth.client.model.response.v4.SignJwtResponse;
+import com.wultra.security.powerauth.client.model.response.v4.VerifyJwtSignatureResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * JWT signature controller.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@RestController("jwtControllerV4")
+@RequestMapping("/rest/v4/jwt")
+@Tag(name = "JWT Signature Controller (V4)")
+@AllArgsConstructor
+@Validated
+@Slf4j
+public class JwtSignatureController {
+
+    private final JwtSignatureServiceBehavior jwtSignatureServiceBehavior;
+
+    /**
+     * Sign a JWT.
+     *
+     * @param request Sign JWT request.
+     * @return Sign JWT response.
+     * @throws Exception In case the service throws exception.
+     */
+    @PostMapping("/sign")
+    public ObjectResponse<SignJwtResponse> signJwt(@Valid @RequestBody ObjectRequest<SignJwtRequest> request) throws Exception {
+        final SignJwtRequest req = request.getRequestObject();
+        logger.info("action: signJwt, state: initiated, activationId: {}", req.getActivationId());
+        logger.debug("action: signJwt, state: initiated, request: {}", request);
+        final ObjectResponse<SignJwtResponse> response = new ObjectResponse<>("OK", jwtSignatureServiceBehavior.signJwt(req));
+        logger.info("action: signJwt, state: succeeded");
+        logger.debug("action: signJwt, state: succeeded, response: {}", response);
+        return response;
+    }
+
+    /**
+     * Verify a JWT signature.
+     *
+     * @param request Verify JWT signature request.
+     * @return Verify JWT signature response.
+     * @throws Exception In case the service throws exception.
+     */
+    @PostMapping("/verify")
+    public ObjectResponse<VerifyJwtSignatureResponse> verifyJwtSignature(@Valid @RequestBody ObjectRequest<VerifyJwtSignatureRequest> request) throws Exception {
+        final VerifyJwtSignatureRequest req = request.getRequestObject();
+        logger.info("action: verifyJwtSignature, state: initiated, activationId: {}", req.getActivationId());
+        logger.debug("action: verifyJwtSignature, state: initiated, request: {}", request);
+        final ObjectResponse<VerifyJwtSignatureResponse> response = new ObjectResponse<>("OK", jwtSignatureServiceBehavior.verifyJwtSignature(req));
+        logger.info("action: verifyJwtSignature, state: succeeded, signatureValid: {}", response.getResponseObject().isSignatureValid());
+        logger.debug("action: verifyJwtSignature, state: succeeded, response: {}", response);
+        return response;
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AsymmetricSignatureServiceBehavior.java
@@ -86,7 +86,7 @@ public class AsymmetricSignatureServiceBehavior {
 
             final byte[] dataRaw = Base64.getDecoder().decode(data);
             final byte[] signatureEcdsa = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.ECDSA_P384, dataRaw, activation);
-            final String signatureEcdsBase64 = Base64.getEncoder().encodeToString(signatureEcdsa);
+            final String signatureEcdsaBase64 = Base64.getEncoder().encodeToString(signatureEcdsa);
             final String signatureMldsaBase64;
             if (activation.getCryptoAlgorithm() == SharedSecretAlgorithm.EC_P384_ML_L3) {
                 final byte[] signatureMldsa = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.MLDSA_65, dataRaw, activation);
@@ -96,7 +96,7 @@ public class AsymmetricSignatureServiceBehavior {
             }
 
             final SignAsymmetricResponse response = new SignAsymmetricResponse();
-            response.setSignatureEcdsa(signatureEcdsBase64);
+            response.setSignatureEcdsa(signatureEcdsaBase64);
             response.setSignatureMldsa(signatureMldsaBase64);
             return response;
         } catch (GenericServiceException ex) {
@@ -115,7 +115,7 @@ public class AsymmetricSignatureServiceBehavior {
      * Validate ECDSA or ML-DSA signature for given data using public key associated with given activation ID.
      *
      * @param request Request with ECDSA verification request.
-     * @return True in case signature validates for given data with provided public key, false otherwise.
+     * @return Result of signature verification.
      * @throws GenericServiceException In case signature verification fails.
      */
     @Transactional

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
@@ -87,15 +87,15 @@ public class JwtSignatureServiceBehavior {
         final byte[] dataBytes = Base64URL.from(data).decode();
         final AsymmetricSignatureType signatureType = request.getSignatureType();
         return switch (request.getSignatureFormat()) {
-            case JWT -> signJwtInternal(dataBytes, signatureType, activation);
-            case JWS -> signJwsInternal(dataBytes, signatureType, activation);
+            case JWS_COMPACT -> signJwtInternal(dataBytes, signatureType, activation);
+            case JWS_JSON -> signJwsInternal(dataBytes, signatureType, activation);
         };
     }
 
     public SignJwtResponse signJwtInternal(byte[] dataBytes, AsymmetricSignatureType signatureType, ActivationRecordEntity activation) throws GenericServiceException {
         final SharedSecretAlgorithm sharedSecretAlgorithm = activation.getCryptoAlgorithm();
         final SignJwtResponse signJwtResponse = new SignJwtResponse();
-        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWT);
+        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWS_COMPACT);
         final JWSSigner signer = new JWSActivationSigner(
                 cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
                 activation
@@ -135,7 +135,7 @@ public class JwtSignatureServiceBehavior {
     private SignJwtResponse signJwsInternal(byte[] dataBytes, AsymmetricSignatureType signatureType, ActivationRecordEntity activation) throws GenericServiceException {
         final SharedSecretAlgorithm sharedSecretAlgorithm = activation.getCryptoAlgorithm();
         final SignJwtResponse signJwtResponse = new SignJwtResponse();
-        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWS);
+        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
         final JWSSigner signer = new JWSActivationSigner(
                 cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
                 activation
@@ -200,7 +200,7 @@ public class JwtSignatureServiceBehavior {
         activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
 
         try {
-            if (request.getSignatureFormat() == JwtSignatureFormat.JWT) {
+            if (request.getSignatureFormat() == JwtSignatureFormat.JWS_COMPACT) {
                 final SignedJWT signedJWT = SignedJWT.parse(signedData);
                 final JWSActivationVerifier verifier = new JWSActivationVerifier(
                         cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
@@ -1,0 +1,239 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
+
+import com.nimbusds.jose.*;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner;
+import com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationVerifier;
+import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
+import com.wultra.security.powerauth.client.model.enumeration.v4.AsymmetricSignatureType;
+import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
+import com.wultra.security.powerauth.client.model.request.v4.SignJwtRequest;
+import com.wultra.security.powerauth.client.model.request.v4.VerifyJwtSignatureRequest;
+import com.wultra.security.powerauth.client.model.response.v4.SignJwtResponse;
+import com.wultra.security.powerauth.client.model.response.v4.VerifyJwtSignatureResponse;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner.JWT_ALGORITHM_NAME_MLDSA_65;
+
+/**
+ * Behavior class implementing the asymmetric JWT signature related processes. The
+ * class separates the logic from the main service class.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@Service("jwtSignatureServiceBehaviorV4")
+@Slf4j
+@AllArgsConstructor
+public class JwtSignatureServiceBehavior {
+
+    private final LocalizationProvider localizationProvider;
+    private final ActivationQueryService activationQueryService;
+    private final ActivationContextValidator activationValidator;
+    private final CryptographyServiceFactory cryptographyServiceFactory;
+
+    /**
+     * Sign a JWT.
+     *
+     * @param request Sign JWT request.
+     * @return Sign JWT response.
+     * @throws GenericServiceException In case of invalid request or signature calculation failure.
+     */
+    public SignJwtResponse signJwt(SignJwtRequest request) throws GenericServiceException {
+        final String activationId = request.getActivationId();
+        final String data = request.getData();
+
+        final ActivationRecordEntity activation = activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
+            logger.warn("Activation used when computing JWT signature does not exist, activation ID: {}", activationId);
+            return localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+        });
+        activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
+
+        final ActivationStatus activationStatus = activation.getActivationStatus();
+        if (activationStatus != ActivationStatus.ACTIVE) {
+            logger.warn("Activation used when computing JWT signature is in incorrect status, activation ID: {}, status: {}", activationId, activationStatus);
+            throw localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE);
+        }
+
+        final byte[] dataBytes = Base64URL.from(data).decode();
+        final AsymmetricSignatureType signatureType = request.getSignatureType();
+        return switch (request.getSignatureFormat()) {
+            case JWT -> signJwtInternal(dataBytes, signatureType, activation);
+            case JWS -> signJwsInternal(dataBytes, signatureType, activation);
+        };
+    }
+
+    public SignJwtResponse signJwtInternal(byte[] dataBytes, AsymmetricSignatureType signatureType, ActivationRecordEntity activation) throws GenericServiceException {
+        final SharedSecretAlgorithm sharedSecretAlgorithm = activation.getCryptoAlgorithm();
+        final SignJwtResponse signJwtResponse = new SignJwtResponse();
+        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWT);
+        final JWSSigner signer = new JWSActivationSigner(
+                cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
+                activation
+        );
+        final JWSHeader header = switch (sharedSecretAlgorithm) {
+            case EC_P256 -> new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+            case EC_P384 -> new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+            case EC_P384_ML_L3 -> {
+                if (signatureType == null) {
+                    yield new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+                } else {
+                    final JWSAlgorithm alg = switch (signatureType) {
+                        case ECDSA -> JWSAlgorithm.ES384;
+                        case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
+                    };
+                    yield new JWSHeader.Builder(alg).build();
+                }
+            }
+            default -> {
+                logger.warn("Unsupported shared secret algorithm in JWT sign request: {}", sharedSecretAlgorithm);
+                throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+            }
+        };
+        try {
+            final Payload payload = new Payload(dataBytes);
+            final JWSObject jwsObject = new JWSObject(header, payload);
+            jwsObject.sign(signer);
+            final String signedData = jwsObject.serialize();
+            signJwtResponse.setSignedData(signedData);
+            return signJwtResponse;
+        } catch (Exception e) {
+            logger.warn("Error occurred while signing JWT: {}", e.getMessage());
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+    }
+
+    private SignJwtResponse signJwsInternal(byte[] dataBytes, AsymmetricSignatureType signatureType, ActivationRecordEntity activation) throws GenericServiceException {
+        final SharedSecretAlgorithm sharedSecretAlgorithm = activation.getCryptoAlgorithm();
+        final SignJwtResponse signJwtResponse = new SignJwtResponse();
+        signJwtResponse.setSignatureFormat(JwtSignatureFormat.JWS);
+        final JWSSigner signer = new JWSActivationSigner(
+                cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
+                activation
+        );
+        try {
+            final Payload payload = new Payload(dataBytes);
+            final JWSObjectJSON jwsObject = new JWSObjectJSON(payload);
+            switch (sharedSecretAlgorithm) {
+                case EC_P256 -> {
+                    final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+                    jwsObject.sign(header, signer);
+                }
+                case EC_P384 -> {
+                    final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+                    jwsObject.sign(header, signer);
+                }
+                case EC_P384_ML_L3 -> {
+                    if (signatureType == null) {
+                        final JWSHeader ecdsaHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+                        final JWSHeader mldsaHeader = new JWSHeader.Builder(new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)).build();
+                        jwsObject.sign(ecdsaHeader, signer);
+                        jwsObject.sign(mldsaHeader, signer);
+                    } else {
+                        final JWSAlgorithm alg = switch (signatureType) {
+                            case ECDSA -> JWSAlgorithm.ES384;
+                            case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
+                        };
+                        final JWSHeader header = new JWSHeader.Builder(alg).build();
+                        jwsObject.sign(header, signer);
+                    }
+                }
+                default -> {
+                    logger.warn("Unsupported shared secret algorithm in JWS sign request: {}", sharedSecretAlgorithm);
+                    throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+                }
+            }
+            final String jwsJson = jwsObject.serializeGeneral();
+            signJwtResponse.setSignedData(jwsJson);
+            return signJwtResponse;
+        } catch (Exception e) {
+            logger.warn("Error occurred while signing JWS: {}", e.getMessage(), e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+    }
+
+    /**
+     * Verify a JWT signature.
+     *
+     * @param request Verify JWT signature request.
+     * @return Verify JWT signature response.
+     * @throws GenericServiceException In case signature verification failure.
+     */
+    @Transactional
+    public VerifyJwtSignatureResponse verifyJwtSignature(VerifyJwtSignatureRequest request) throws GenericServiceException {
+        final String activationId = request.getActivationId();
+        final String signedData = request.getSignedData();
+
+        final ActivationRecordEntity activation = activationQueryService.findActivationWithoutLock(activationId).orElseThrow(() -> {
+            logger.warn("Activation used when verifying JWT signature does not exist, activation ID: {}", activationId);
+            return localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND);
+        });
+        activationValidator.validatePowerAuthProtocol(activation.getProtocol(), localizationProvider);
+
+        try {
+            if (request.getSignatureFormat() == JwtSignatureFormat.JWT) {
+                final SignedJWT signedJWT = SignedJWT.parse(signedData);
+                final JWSActivationVerifier verifier = new JWSActivationVerifier(
+                        cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
+                        activation
+                );
+                final boolean verified = signedJWT.verify(verifier);
+                return VerifyJwtSignatureResponse.builder()
+                        .signatureValid(verified)
+                        .build();
+            } else {
+                final JWSObjectJSON jwsObject = JWSObjectJSON.parse(signedData);
+                final JWSActivationVerifier verifier = new JWSActivationVerifier(
+                        cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()),
+                        activation
+                );
+
+                int verifiedCount = 0;
+                for (JWSObjectJSON.Signature signature : jwsObject.getSignatures()) {
+                    final JWSHeader header = signature.getHeader();
+                    if (verifier.supportedJWSAlgorithms().contains(header.getAlgorithm())) {
+                        if (signature.verify(verifier)) {
+                            verifiedCount++;
+                        }
+                    }
+                }
+                return VerifyJwtSignatureResponse.builder()
+                        .signatureValid(verifiedCount == jwsObject.getSignatures().size())
+                        .build();
+            }
+        } catch (Exception e) {
+            logger.warn("Error occurred while verifying JWT/JWS: {}", e.getMessage(), e);
+            throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
+        }
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
@@ -101,17 +101,17 @@ public class JwtSignatureServiceBehavior {
                 activation
         );
         final JWSHeader header = switch (sharedSecretAlgorithm) {
-            case EC_P256 -> new JWSHeader.Builder(JWSAlgorithm.ES256).build();
-            case EC_P384 -> new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+            case EC_P256 -> new JWSHeader(JWSAlgorithm.ES256);
+            case EC_P384 -> new JWSHeader(JWSAlgorithm.ES384);
             case EC_P384_ML_L3 -> {
                 if (signatureType == null) {
-                    yield new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+                    yield new JWSHeader(JWSAlgorithm.ES384);
                 } else {
                     final JWSAlgorithm alg = switch (signatureType) {
                         case ECDSA -> JWSAlgorithm.ES384;
                         case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
                     };
-                    yield new JWSHeader.Builder(alg).build();
+                    yield new JWSHeader(alg);
                 }
             }
             default -> {
@@ -145,17 +145,17 @@ public class JwtSignatureServiceBehavior {
             final JWSObjectJSON jwsObject = new JWSObjectJSON(payload);
             switch (sharedSecretAlgorithm) {
                 case EC_P256 -> {
-                    final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
+                    final JWSHeader header = new JWSHeader(JWSAlgorithm.ES256);
                     jwsObject.sign(header, signer);
                 }
                 case EC_P384 -> {
-                    final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.ES384).build();
+                    final JWSHeader header = new JWSHeader(JWSAlgorithm.ES384);
                     jwsObject.sign(header, signer);
                 }
                 case EC_P384_ML_L3 -> {
                     if (signatureType == null) {
-                        final JWSHeader ecdsaHeader = new JWSHeader.Builder(JWSAlgorithm.ES384).build();
-                        final JWSHeader mldsaHeader = new JWSHeader.Builder(new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)).build();
+                        final JWSHeader ecdsaHeader = new JWSHeader(JWSAlgorithm.ES384);
+                        final JWSHeader mldsaHeader = new JWSHeader(new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65));
                         jwsObject.sign(ecdsaHeader, signer);
                         jwsObject.sign(mldsaHeader, signer);
                     } else {
@@ -163,7 +163,7 @@ public class JwtSignatureServiceBehavior {
                             case ECDSA -> JWSAlgorithm.ES384;
                             case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
                         };
-                        final JWSHeader header = new JWSHeader.Builder(alg).build();
+                        final JWSHeader header = new JWSHeader(alg);
                         jwsObject.sign(header, signer);
                     }
                 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
@@ -30,6 +30,7 @@ import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner;
 import com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationVerifier;
+import com.wultra.security.powerauth.app.server.service.util.jwt.JWSAlgorithmMLDSA;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
 import com.wultra.security.powerauth.client.model.enumeration.v4.AsymmetricSignatureType;
 import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
@@ -42,8 +43,6 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner.JWT_ALGORITHM_NAME_MLDSA_65;
 
 /**
  * Behavior class implementing the asymmetric JWT signature related processes. The
@@ -109,7 +108,7 @@ public class JwtSignatureServiceBehavior {
                 } else {
                     final JWSAlgorithm alg = switch (signatureType) {
                         case ECDSA -> JWSAlgorithm.ES384;
-                        case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
+                        case MLDSA -> JWSAlgorithmMLDSA.MLDSA65;
                     };
                     yield new JWSHeader(alg);
                 }
@@ -155,13 +154,13 @@ public class JwtSignatureServiceBehavior {
                 case EC_P384_ML_L3 -> {
                     if (signatureType == null) {
                         final JWSHeader ecdsaHeader = new JWSHeader(JWSAlgorithm.ES384);
-                        final JWSHeader mldsaHeader = new JWSHeader(new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65));
+                        final JWSHeader mldsaHeader = new JWSHeader(JWSAlgorithmMLDSA.MLDSA65);
                         jwsObject.sign(ecdsaHeader, signer);
                         jwsObject.sign(mldsaHeader, signer);
                     } else {
                         final JWSAlgorithm alg = switch (signatureType) {
                             case ECDSA -> JWSAlgorithm.ES384;
-                            case MLDSA -> new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65);
+                            case MLDSA -> JWSAlgorithmMLDSA.MLDSA65;
                         };
                         final JWSHeader header = new JWSHeader(alg);
                         jwsObject.sign(header, signer);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehavior.java
@@ -217,21 +217,23 @@ public class JwtSignatureServiceBehavior {
                         activation
                 );
 
-                int verifiedCount = 0;
-                for (JWSObjectJSON.Signature signature : jwsObject.getSignatures()) {
-                    final JWSHeader header = signature.getHeader();
-                    if (verifier.supportedJWSAlgorithms().contains(header.getAlgorithm())) {
-                        if (signature.verify(verifier)) {
-                            verifiedCount++;
-                        }
-                    }
-                }
+                final boolean allSignaturesValid = jwsObject.getSignatures().stream()
+                        .allMatch(sig -> {
+                            try {
+                                return sig.verify(verifier);
+                            } catch (JOSEException e) {
+                                logger.warn("Error occurred while verifying JWT signature: {}", e.getMessage(), e);
+                                return false;
+                            }
+                        });
+
                 return VerifyJwtSignatureResponse.builder()
-                        .signatureValid(verifiedCount == jwsObject.getSignatures().size())
+                        .signatureValid(allSignaturesValid)
                         .build();
+
             }
         } catch (Exception e) {
-            logger.warn("Error occurred while verifying JWT/JWS: {}", e.getMessage(), e);
+            logger.warn("Error occurred while verifying JWT signature: {}", e.getMessage(), e);
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST);
         }
     }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/CryptographyServiceHybrid.java
@@ -228,23 +228,23 @@ public class CryptographyServiceHybrid extends CryptographyService {
         try {
             final PublicKeyRegistry devicePublicKeyRegistry = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
             final ECPublicKey devicePublicKeyEcdsa = (ECPublicKey) devicePublicKeyRegistry.getPublicKey(KeyType.ECDSA_P384).orElseThrow(() -> {
-                logger.error("Missing ECDSA device public key for application ID: {}", activation.getApplication().getId());
+                logger.error("Missing device ECDSA public key for application ID: {}", activation.getApplication().getId());
                 // Rollback is not required, database is not used for writing
                 return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
             });
             final MLDSAPublicKey devicePublicKeyMldsa = (MLDSAPublicKey) devicePublicKeyRegistry.getPublicKey(KeyType.MLDSA_65).orElseThrow(() -> {
-                logger.error("Missing ML-DSA device public key for application ID: {}", activation.getApplication().getId());
+                logger.error("Missing device ML-DSA public key for application ID: {}", activation.getApplication().getId());
                 // Rollback is not required, database is not used for writing
                 return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
             });
             final PublicKeyRegistry serverPublicKeyRegistry = publicKeysConverter.fromDBValue(activation.getServerPublicKeys());
             final ECPublicKey serverPublicKeyEcdsa = (ECPublicKey) serverPublicKeyRegistry.getPublicKey(KeyType.ECDSA_P384).orElseThrow(() -> {
-                logger.error("Missing ECDSA server public key for application ID: {}", activation.getApplication().getId());
+                logger.error("Missing server ECDSA public key for application ID: {}", activation.getApplication().getId());
                 // Rollback is not required, database is not used for writing
                 return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
             });
             final MLDSAPublicKey serverPublicKeyMldsa = (MLDSAPublicKey) serverPublicKeyRegistry.getPublicKey(KeyType.MLDSA_65).orElseThrow(() -> {
-                logger.error("Missing ML-DSA server public key for application ID: {}", activation.getApplication().getId());
+                logger.error("Missing server ML-DSA public key for application ID: {}", activation.getApplication().getId());
                 // Rollback is not required, database is not used for writing
                 return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
             });
@@ -330,7 +330,7 @@ public class CryptographyServiceHybrid extends CryptographyService {
                 try {
                     final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
                     final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(KeyType.ECDSA_P384).orElseThrow(() -> {
-                        logger.error("Missing device public key for ECDSA for activation ID: {}", activation.getActivationId());
+                        logger.error("Missing device ECDSA public key for activation ID: {}", activation.getActivationId());
                         // Rollback is not required, database is not used for writing
                         return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
                     });
@@ -344,7 +344,7 @@ public class CryptographyServiceHybrid extends CryptographyService {
                 try {
                     final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(activation.getDevicePublicKeys());
                     final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(KeyType.MLDSA_65).orElseThrow(() -> {
-                        logger.error("Missing device public key for ML-DSA for activation ID: {}", activation.getActivationId());
+                        logger.error("Missing device ML-DSA public key for activation ID: {}", activation.getActivationId());
                         // Rollback is not required, database is not used for writing
                         return localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR);
                     });

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationSigner.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationSigner.java
@@ -1,0 +1,88 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.util.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+
+import java.util.Set;
+
+/**
+ * Signer for JWT for PowerAuth activations.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class JWSActivationSigner implements JWSSigner {
+
+    public static final String JWT_ALGORITHM_NAME_ES256 = "ES256";
+    public static final String JWT_ALGORITHM_NAME_ES384 = "ES384";
+    public static final String JWT_ALGORITHM_NAME_MLDSA_65 = "MLDSA-65";
+
+    private final CryptographyService cryptoService;
+    private final ActivationRecordEntity activation;
+    private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES256),
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES384),
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)
+    );
+    private final JCAContext jcaContext = new JCAContext();
+
+    public JWSActivationSigner(CryptographyService cryptoService, ActivationRecordEntity activation) {
+        this.cryptoService = cryptoService;
+        this.activation = activation;
+    }
+
+    @Override
+    public Base64URL sign(JWSHeader header, byte[] dataToSign) throws JOSEException {
+        try {
+            final byte[] signatureBytes = cryptoService.generateSignatureForActivation(convertToKeyType(header), dataToSign, activation);
+            return Base64URL.encode(signatureBytes);
+        } catch (Exception e) {
+            throw new JOSEException("Signature generation failed", e);
+        }
+    }
+
+    @Override
+    public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+        return SUPPORTED_ALGORITHMS;
+    }
+
+    @Override
+    public JCAContext getJCAContext() {
+        return jcaContext;
+    }
+
+    private KeyType convertToKeyType(JWSHeader jwsHeader) {
+        return switch (jwsHeader.getAlgorithm().getName()) {
+            case JWT_ALGORITHM_NAME_ES256 -> KeyType.ECDSA_P256;
+            case JWT_ALGORITHM_NAME_ES384 -> KeyType.ECDSA_P384;
+            case JWT_ALGORITHM_NAME_MLDSA_65 -> KeyType.MLDSA_65;
+            default -> throw new IllegalArgumentException("Unsupported JWT algorithm: " + jwsHeader.getAlgorithm().getName());
+        };
+    }
+
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationSigner.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationSigner.java
@@ -38,16 +38,12 @@ import java.util.Set;
  */
 public class JWSActivationSigner implements JWSSigner {
 
-    public static final String JWT_ALGORITHM_NAME_ES256 = "ES256";
-    public static final String JWT_ALGORITHM_NAME_ES384 = "ES384";
-    public static final String JWT_ALGORITHM_NAME_MLDSA_65 = "MLDSA-65";
-
     private final CryptographyService cryptoService;
     private final ActivationRecordEntity activation;
     private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES256),
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES384),
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)
+            JWSAlgorithm.ES256,
+            JWSAlgorithm.ES384,
+            JWSAlgorithmMLDSA.MLDSA65
     );
     private final JCAContext jcaContext = new JCAContext();
 
@@ -78,9 +74,9 @@ public class JWSActivationSigner implements JWSSigner {
 
     private KeyType convertToKeyType(JWSHeader jwsHeader) {
         return switch (jwsHeader.getAlgorithm().getName()) {
-            case JWT_ALGORITHM_NAME_ES256 -> KeyType.ECDSA_P256;
-            case JWT_ALGORITHM_NAME_ES384 -> KeyType.ECDSA_P384;
-            case JWT_ALGORITHM_NAME_MLDSA_65 -> KeyType.MLDSA_65;
+            case "ES256" -> KeyType.ECDSA_P256;
+            case "ES384" -> KeyType.ECDSA_P384;
+            case "ML-DSA-65" -> KeyType.MLDSA_65;
             default -> throw new IllegalArgumentException("Unsupported JWT algorithm: " + jwsHeader.getAlgorithm().getName());
         };
     }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationVerifier.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationVerifier.java
@@ -1,0 +1,87 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.util.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+
+import java.util.Set;
+
+import static com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner.*;
+
+/**
+ * Verifier for JWT for PowerAuth activations.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+public class JWSActivationVerifier implements JWSVerifier {
+
+    private final CryptographyService cryptoService;
+    private final ActivationRecordEntity activation;
+    private final JCAContext jcaContext = new JCAContext();
+
+    private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES256),
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES384),
+            new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)
+    );
+
+    public JWSActivationVerifier(CryptographyService cryptoService, ActivationRecordEntity activation) {
+        this.cryptoService = cryptoService;
+        this.activation = activation;
+    }
+
+    @Override
+    public boolean verify(JWSHeader header, byte[] signedData, Base64URL signature) throws JOSEException {
+        try {
+            final KeyType keyType = convertToKeyType(header);
+            final byte[] signatureBytes = signature.decode();
+            return cryptoService.verifySignatureForActivation(keyType, signedData, signatureBytes, activation);
+        } catch (Exception e) {
+            throw new JOSEException("Verification failed", e);
+        }
+    }
+
+    @Override
+    public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+        return SUPPORTED_ALGORITHMS;
+    }
+
+    @Override
+    public JCAContext getJCAContext() {
+        return jcaContext;
+    }
+
+    private KeyType convertToKeyType(JWSHeader jwsHeader) {
+        return switch (jwsHeader.getAlgorithm().getName()) {
+            case JWT_ALGORITHM_NAME_ES256 -> KeyType.ECDSA_P256;
+            case JWT_ALGORITHM_NAME_ES384 -> KeyType.ECDSA_P384;
+            case JWT_ALGORITHM_NAME_MLDSA_65 -> KeyType.MLDSA_65;
+            default -> throw new IllegalArgumentException("Unsupported JWT algorithm: " + jwsHeader.getAlgorithm().getName());
+        };
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationVerifier.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/jwt/JWSActivationVerifier.java
@@ -31,8 +31,6 @@ import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServi
 
 import java.util.Set;
 
-import static com.wultra.security.powerauth.app.server.service.util.jwt.JWSActivationSigner.*;
-
 /**
  * Verifier for JWT for PowerAuth activations.
  *
@@ -45,9 +43,9 @@ public class JWSActivationVerifier implements JWSVerifier {
     private final JCAContext jcaContext = new JCAContext();
 
     private static final Set<JWSAlgorithm> SUPPORTED_ALGORITHMS = Set.of(
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES256),
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_ES384),
-            new JWSAlgorithm(JWT_ALGORITHM_NAME_MLDSA_65)
+            JWSAlgorithm.ES256,
+            JWSAlgorithm.ES384,
+            JWSAlgorithmMLDSA.MLDSA65
     );
 
     public JWSActivationVerifier(CryptographyService cryptoService, ActivationRecordEntity activation) {
@@ -78,9 +76,9 @@ public class JWSActivationVerifier implements JWSVerifier {
 
     private KeyType convertToKeyType(JWSHeader jwsHeader) {
         return switch (jwsHeader.getAlgorithm().getName()) {
-            case JWT_ALGORITHM_NAME_ES256 -> KeyType.ECDSA_P256;
-            case JWT_ALGORITHM_NAME_ES384 -> KeyType.ECDSA_P384;
-            case JWT_ALGORITHM_NAME_MLDSA_65 -> KeyType.MLDSA_65;
+            case "ES256" -> KeyType.ECDSA_P256;
+            case "ES384" -> KeyType.ECDSA_P384;
+            case "ML-DSA-65" -> KeyType.MLDSA_65;
             default -> throw new IllegalArgumentException("Unsupported JWT algorithm: " + jwsHeader.getAlgorithm().getName());
         };
     }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
@@ -1,0 +1,396 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationProtocol;
+import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyService;
+import com.wultra.security.powerauth.app.server.service.crypto.CryptographyServiceFactory;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvider;
+import com.wultra.security.powerauth.app.server.service.model.ServiceError;
+import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
+import com.wultra.security.powerauth.client.model.enumeration.v4.AsymmetricSignatureType;
+import com.wultra.security.powerauth.client.model.enumeration.v4.JwtSignatureFormat;
+import com.wultra.security.powerauth.client.model.request.v4.SignJwtRequest;
+import com.wultra.security.powerauth.client.model.request.v4.VerifyJwtSignatureRequest;
+import com.wultra.security.powerauth.client.model.response.v4.SignJwtResponse;
+import com.wultra.security.powerauth.client.model.response.v4.VerifyJwtSignatureResponse;
+import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link JwtSignatureServiceBehavior}.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@ExtendWith(MockitoExtension.class)
+class JwtSignatureServiceBehaviorTest {
+
+    @Mock
+    private LocalizationProvider localizationProvider;
+
+    @Mock
+    private ActivationQueryService activationQueryService;
+
+    @Mock
+    private ActivationContextValidator activationValidator;
+
+    @Mock
+    private CryptographyServiceFactory cryptographyServiceFactory;
+
+    @Mock
+    private CryptographyService cryptographyService;
+
+    @InjectMocks
+    private JwtSignatureServiceBehavior tested;
+
+    private ActivationRecordEntity activation;
+    private final Base64URL dataToSign = Base64URL.encode("DataToSign");
+    private final String activationId = "78f184f2-c434-474f-971e-9c2d255faf8c";
+
+    @BeforeEach
+    void setUp() {
+        activation = new ActivationRecordEntity();
+        activation.setActivationStatus(ActivationStatus.ACTIVE);
+        activation.setProtocol(ActivationProtocol.POWERAUTH);
+        activation.setCryptoAlgorithm(SharedSecretAlgorithm.EC_P384_ML_L3);
+    }
+
+    @Test
+    void signJwt_validEcdsa() throws Exception {
+        String signatureEcdsa = "MGUCMHSj_atLUNwJrM0q8-PTtvNPpftHSGX3ErcyCwqfqZ0Ia627POEla-gaAcALqdLGjAIxAMa19AkR63k4HItcvqDcOuhgKv-E5PFcWXF1dkpgNq7jjvBMM3G1jYt7dG-DsVF71Q";
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.generateSignatureForActivation(eq(KeyType.ECDSA_P384), any(), eq(activation)))
+                .thenReturn(Base64URL.from(signatureEcdsa).decode());
+
+        SignJwtRequest request = new SignJwtRequest();
+        request.setActivationId(activationId);
+        request.setData(dataToSign.toString());
+        request.setSignatureFormat(JwtSignatureFormat.JWT);
+        request.setSignatureType(AsymmetricSignatureType.ECDSA);
+
+        SignJwtResponse response = tested.signJwt(request);
+
+        assertNotNull(response.getSignedData());
+        assertEquals(JwtSignatureFormat.JWT, response.getSignatureFormat());
+        SignedJWT jwt = SignedJWT.parse(response.getSignedData());
+        assertEquals("ES384", jwt.getHeader().getAlgorithm().getName());
+        assertEquals(signatureEcdsa, jwt.getSignature().toString());
+    }
+
+    @Test
+    void signJwt_invalidState() {
+        activation.setActivationStatus(ActivationStatus.REMOVED);
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_INCORRECT_STATE))
+                .thenReturn(new GenericServiceException(ServiceError.ACTIVATION_INCORRECT_STATE, "Activation is in removed state"));
+
+        SignJwtRequest request = new SignJwtRequest();
+        request.setActivationId(activationId);
+        request.setData(dataToSign.toString());
+
+        assertThrows(GenericServiceException.class, () -> tested.signJwt(request));
+    }
+
+    @Test
+    void signJwt_activationNotFound() {
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.empty());
+        when(localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND))
+                .thenReturn(new GenericServiceException(ServiceError.ACTIVATION_NOT_FOUND, "Activation not found"));
+
+        SignJwtRequest request = new SignJwtRequest();
+        request.setActivationId(activationId);
+        request.setData(dataToSign.toString());
+
+        assertThrows(GenericServiceException.class, () -> tested.signJwt(request));
+    }
+
+    @Test
+    void signJws_validHybrid() throws Exception {
+        // given
+        String signatureEcdsa = "MGUCMHSj_atLUNwJrM0q8-PTtvNPpftHSGX3ErcyCwqfqZ0Ia627POEla-gaAcALqdLGjAIxAMa19AkR63k4HItcvqDcOuhgKv-E5PFcWXF1dkpgNq7jjvBMM3G1jYt7dG-DsVF71Q";
+        String signatureMldsa = "UgQ_UPqHFY9foxoDM1AuJO9hEnSKoNtRtYNZWUntaPDbKct-rkyxTatncPcXWp7qUyfsmkyySPqulmaeqzlKFO58SQzILl0i8DGFX8_c4wgXR-quGn5N2DTA4of0pjUBWWMX24eG9L1Uz11qZlq08dqdAqfNZ-McM6MHQdqKa17AyepUbuGGWcZ-PI0EYCuHAi_EjutA9jMf3t3zqK8GCn5AAjBVMyDfWS6s6yHixIniEdejIT-vuCSq-zSDG8TZVn49qQvXnc_0OYuw-9yssu-ZnOOmWhfG4h_NqzzE0t3-pefCpXEdxE2NgoLzMVIcARsEmioSNQ9nofRJD7XKS-Nwmljfa-WlyPN1FMelPTzcthxE4cltdXsG5TSh8WqZqIU6zR9GEWEM5_b7WV8RRHYspJdq60WoOzPsxRHrGhHdCrbxCGE4yMWtAQrGjV0-vJQHJ2ywovVqR6rwdje2PaTzrw-lReaU6rFCa2_7XcFongj37ooN7Euhj9S3UvrEIm1_Ooi7Z2o-xxRC6Q7OvJaCatB6OsakdFq17vgK611kw8kmiJeC-QEHdoVo2MesRvWtakFXnJS0yc6LUW_cwzxTNxWejv8E9Nyq5YfADHAUZFXfgfLPzRtDVn6L5Um5JW2n7G6aYfxg0_jEpsNuHgorDWtBGvnO90Lg31JKjGuKDeb_aZsf5JjZOipJG_lgJTJQ7BIGZz2rkM1MQlSAgr1H2FZj6de_HZngNrsw26BbRf5F_yHrP6ztVHTimkhc_77AhFsOLRkvQ7Zz1aaj0M8I5r4m8RAZ3l4p-_-i_G75VV_CR1_huAPhPA8SYc4ZmNptH97SOeEbmh9G3XyFog5h8BtyinN9aqyFKOtRPMuZyoTPibTXZ9dPbmfnPTw9CuU5KoyjBKAUzd-ujP4VoOSF9DuZ5T309XYh2SDVU8BHhDuM3nIcJNSSAv2yVLYR_RWHC26Ry7wEjhNshYj_bnvR1mm8K7aaU2oIrr14dZ49Z4h--KW97mEju3Lu0W71rTkZGyn6O0D_NHlAPQuXfMhi8ZcJWOmgIUmhSwTIJMkrVlCCkDDPybqOJXsjtmmsZJF4whYUSu-hqb_EWMr-cLOTJVOhccLAyLpR2y7rvgkvhSbGKjmPkDzlSr5oTrCKfOTo4qbFKTntRsNNg_6_xO09y__4UoVNdpW3OzCMVVPrBEdqwB8NgQ-34ZhbwwwLW7dyF9kR_m4CjdV511iooILW2NDjTbzPNX-CYhc24Yh6QexDLvhEY_U0RW_4FNxa15E4aDvmICAHriqF5A6iYvIN2CvVwJ45XMyJ8aICoqHgu-SXSpddJKKAqPbWxo_WQ_8EffOImK5XicrmsOb4m44NYBqMsV3aJwapHjRNqBCTM04obLcBK5ffrU61keO5mjNuAM69C_JqpAjRuFep241m8YwS48vn-qKjLfcjU4fN8yHOCBrM_MSMGytGg4NZ9DhuBld5BAwU4acAjhbBNhcwLvpqufAKh459HdFNe9A3QalHMQvDvA6GUpj-9y9WPmkkXcAI_momwJu9En-GeXC_besoAUlIoEy-QII9HQ0qHy_wOJ7ljVDkFqPYET361BWt6elDJepJ7zhVtwpqc9JrR5Y9fcdQToItX4zZL74gnzX3hxmnhWf9EupBYBznNvaN0h5LeCYrKuvUfZe47HBGA8PgrkGYZSSJlF0kczDpm9syOElIqt2uab3tRFcWcujlWfssy0GqRLp4u65iR11x6cVg3wxUV_--VJldNWpCY8hMUD5a7HHq_dQUTivFfk7OKJDHvpV7LMm_fsqGS7xpVi83V9CF17VdAAbsrC0_IqN_wDX_4WtcdqpxjAmaqbFDY68m3x8y3pqFKVCNqkS2nqO_BkOV5Iv14AbJzbF7qCLSep_i_KXliimGMUG3LNtCgz8Ku3kIyfxbrE9tQybIhpYvFM1xdLLNvGgyRjnIpyn-Z-EyloWS84S52kpi90udRgmwxLpDTRbnrlBiiakEM2I_kHo5KoyvTNb-dEX0XLrFpq_kQ2-9DS0A9AprjlW5v_kYdchlWPZfbhozbh0jicp9wcX-XoNTAqBlE_RMiLwImQVx1ZtWZXB0XfCljtVvZfSoBRjKwcQ2w6p2MlMfOtpNsmv06uCjVCVqUimIvdtWqOgkLSSi6f7BFDTzC2Cex4AI0141atosYmardR5hWSLtLFyItdrYJGOR2V-1XNK01KcpD7Zh5JdOwj9QupwUfbl3ZcIC8NL9yldkuBRBYQB9WAIOXXK27AP2Uue-q-Pq_uK1Iq8WQS0EVOFKcDczJRcJ2XlL9AyJqi86nZP-7kVFZny0ZTxl4etlRqDxWtzRd-vItuMm8mUa0BApE1XvMYikk_nPk3i9ulzSx0xHO2JTMS_XKCxHbcdonh-sWOLmtElF225ZTRn2j-LiOu3eAHwftohcZLlJuVB_Np2ZMDTknZchCPOX8OVyOtGESLEZhjl0-1aoHtyQ8aQ-hUGXpRnqYoovebwIeWH4R9fHTuAqezlC-LOKfaNl0gR-rMZta-_fLrJLsrqlEbWIJKWLUgqHi8zVMTgWZbB_owDHpMb_yUTjZ8cqagFNiVG-08RTyrG6NrTPwWnLZupdoMxI4vGDwEWWVnDN8JGrvXzz2KmRf8z7KrtxSedYe1TNpkRUMjIJPDe-CnEW59FOW0VuOmXJ_joW_Dq5bPFBUkaqCuBgW6qBp1B3U2utMAnvRFPMEi_vr9z4pfo3lVrSD2bNlLWsQWbRibJkH7NKo5BW5AKqyPHx9NghrCOW3ADjnWol2_6lKfhFnpcPiF1pGS7JPL4Ghb5hB2eQuOXYJwgH_KkUXG6O862huGfxuL2prUbhs1fChTG1lgYqvtNUPxg16XbFZYD3LR0Z0jMZ1YzV07LCtMucCNFS83yQB-DgjEimpznhMCuAj8-Xp4b4ibecL8RwpseH4MFDum389b-4-TL__amzwsM_TMmtO_i1Uru0l4i4iqKKfuP-G231RELMI5RL_XiFBDaIvDhugdI0qFrCUmr216301_fl2tVYa3LmRh3onj_imUeuL0JRjUeBX7wsaJJo0I5hCpyht7nuoK0JrucdgAqBhBQYwHp_Eco7ZR9H9OjhEDAzVf2Qe3zohgdZzq-As-_SPHOA8xtJz-ZHcbMQjTDllFamQfb4KAElu70XDRWw4w6nwwBWVhg2jarb1ew15xq3Vf3A_FIZtl76tFYAqeTVL3PtxECdqxlu8cUz4QtHzK1VfpiSk2ZtztYK60e-xkyhIZIjAx6cKozVGrdPM7F_KIxicmZk_TdAA9HkI-6UDdAJI9G1nAddp9db8DRwfiV_c1dYI6bJZBf5tWIUQ5ZVZx9IQYdXQV1SLte3yTUQ_vPc7q-ibp3NyEy9ABZAKSW4tEs1EMjqUJXvjZUkoQm94QW2OefPrZCP0TSBHr0Tc60YEw8-KvOTbl4_7we1Kox-DXRVsCIP9IF4MPcc7E9BJVdsbbVdMIDboiiJ8VLiwMF_GJZk_fRd2FRlrQZ8m6UBa7ZOFAgFkzOew3mJJX7FhIsoGw3ueJTuvMv7qi00pWto05APCiD3btGekIadBULzQE84Sjacd7tejW_pEimkH3mOl4k9dTfxJFwwULHGQ-4mAHt1-R7HXclzLLXih8E_Uxy1UAcEpkEklBKlv8h4qUkN-Cocsf8AASYg4Aixd9IiPn9lUTrARGkAoq1iyZcPR18dD_poq_r03bn4pd-yM23sDxJrt-DVTpzE-cLGWrbz4pME3EG3_mtkHDApqlzJlWqZLNOgUE9iZsgo0dqvR_vWWdaJ6-6ZawZCyhP5OhSke4sFr_Lgc0x2jS2DXcA3ZCMyeYlPH3vwigZRBGrsUiiil6NrONvnwGKZgK8imdTUC3n43NzV8driC3CU_QUV3WYGbYyOYayOIVy53MmLJK5WM10FS4M_qplWaX-R6MYdVR3IVYDNi8bGn-izGgSYjcWynKuOwjs1kTo8wSHZi-dgoatVjoEonv0frOY9qWkRs9co_s-vjaryLt99hg9TV0tZI-Lt4UmUgySjTccJroX0Xtbw4nr3Md5Q0JS42Y2RAkDhAChwDpjr5esF9p--70F8ae7rY8C49p4RR6uxue_JYeOrkritTV3RqAlgZMHDttRtKb9lhvW4PvX5P0TcXFC2NhFum0mV91_I38Nq8vNS53B-yutgqQmKfmuBjzzsE3zpJm0Lq1hw2QrNVrjOxgJjxlWg5GQ5V6u5E3B5wzt-KcYSas-sP0Otd0d7jTXx1thOwuqCgB4vNMH80wV5W2fSUufrHLOq04EDRAIZwSePdkdRVsMhMlaZxQpyqdP7K6C5BBQWOjxhZHWKk73g-ClXbIWpub_O5wAAAAAAAAAAAAAAAAAAAAAAAwgNEB0m";
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.generateSignatureForActivation(eq(KeyType.ECDSA_P384), any(), eq(activation)))
+                .thenReturn(Base64URL.from(signatureEcdsa).decode());
+        when(cryptographyService.generateSignatureForActivation(eq(KeyType.MLDSA_65), any(), eq(activation)))
+                .thenReturn(Base64URL.from(signatureMldsa).decode());
+
+        SignJwtRequest request = new SignJwtRequest();
+        request.setActivationId(activationId);
+        request.setData(dataToSign.toString());
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        SignJwtResponse response = tested.signJwt(request);
+        assertNotNull(response.getSignedData());
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jwsJson = mapper.readTree(response.getSignedData());
+        assertTrue(jwsJson.has("payload"));
+        assertTrue(jwsJson.has("signatures"));
+        JsonNode signatures = jwsJson.get("signatures");
+        assertEquals(2, signatures.size());
+        JsonNode es384Sig = signatures.get(0);
+        assertEquals("eyJhbGciOiJFUzM4NCJ9", es384Sig.get("protected").asText());
+        assertEquals(signatureEcdsa, es384Sig.get("signature").asText());
+        JsonNode mlDsaSig = signatures.get(1);
+        assertEquals("eyJhbGciOiJNTERTQS02NSJ9", mlDsaSig.get("protected").asText());
+        assertEquals(signatureMldsa, mlDsaSig.get("signature").asText());
+    }
+
+    @Test
+    void verifyJwsSignature_valid() throws Exception {
+        String jwsJson = """
+        {"payload":"UGF5bG9hZA","signatures":[
+           {"protected":"eyJhbGciOiJFUzM4NCJ9","signature":"c2ln"}
+        ]}
+        """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.verifySignatureForActivation(any(), any(), any(), eq(activation)))
+                .thenReturn(true);
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
+        assertTrue(response.isSignatureValid());
+    }
+
+    @Test
+    void verifyJwtSignature_invalidJwt() {
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
+                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Invalid JWT"));
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData("not-a-jwt");
+        request.setSignatureFormat(JwtSignatureFormat.JWT);
+
+        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+    }
+
+    @Test
+    void verifyJwtSignature_activationNotFound() {
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.empty());
+        when(localizationProvider.buildExceptionForCode(ServiceError.ACTIVATION_NOT_FOUND))
+                .thenReturn(new GenericServiceException(ServiceError.ACTIVATION_NOT_FOUND, "Missing activation"));
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData("fake");
+        request.setSignatureFormat(JwtSignatureFormat.JWT);
+
+        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+    }
+
+    @Test
+    void verifyJwsSignature_hybridDualSignatures_valid() throws Exception {
+        String jwsJson = """
+    {
+      "payload": "UGF5bG9hZA",
+      "signatures": [
+        {
+          "protected": "eyJhbGciOiJFUzM4NCJ9",
+          "signature": "c2lnMQ"
+        },
+        {
+          "protected": "eyJhbGciOiJNTERTQS02NSJ9",
+          "signature": "c2lnMg"
+        }
+      ]
+    }
+    """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.verifySignatureForActivation(any(), any(), any(), eq(activation)))
+                .thenReturn(true);
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
+        assertTrue(response.isSignatureValid());
+    }
+
+    @Test
+    void verifyJwsSignature_hybridDualSignatures_oneInvalid() throws Exception {
+        String jwsJson = """
+    {
+      "payload": "UGF5bG9hZA",
+      "signatures": [
+        {
+          "protected": "eyJhbGciOiJFUzM4NCJ9",
+          "signature": "c2lnMQ"
+        },
+        {
+          "protected": "eyJhbGciOiJNTERTQS02NSJ9",
+          "signature": "c2lnMg"
+        }
+      ]
+    }
+    """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.verifySignatureForActivation(eq(KeyType.ECDSA_P384), any(), any(), eq(activation)))
+                .thenReturn(false);
+        when(cryptographyService.verifySignatureForActivation(eq(KeyType.MLDSA_65), any(), any(), eq(activation)))
+                .thenReturn(true);
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
+        assertFalse(response.isSignatureValid());
+    }
+
+    @Test
+    void verifyJwsSignature_hybridDualSignatures_bothInvalid() throws Exception {
+        String jwsJson = """
+    {
+      "payload": "UGF5bG9hZA",
+      "signatures": [
+        {
+          "protected": "eyJhbGciOiJFUzM4NCJ9",
+          "signature": "c2lnMQ"
+        },
+        {
+          "protected": "eyJhbGciOiJNTERTQS02NSJ9",
+          "signature": "c2lnMg"
+        }
+      ]
+    }
+    """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
+        when(cryptographyService.verifySignatureForActivation(any(), any(), any(), eq(activation)))
+                .thenReturn(false);
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
+        assertFalse(response.isSignatureValid());
+    }
+
+    @Test
+    void verifyJwsSignature_malformedJson() {
+        String malformedJson = """
+        {"payload":"UGF5bG9hZA","signatures":[{"protected":"eyJhbGciOiJFUzM4NCJ9","signature":c2ln]}
+        """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId))
+                .thenReturn(Optional.of(activation));
+        when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
+                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Malformed JWS JSON"));
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(malformedJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+    }
+
+    @Test
+    void verifyJwsSignature_invalidBase64Payload() {
+        String jwsJson = """
+        {
+          "payload": "UGF5bG9h#ZA",
+          "signatures": [
+            {
+              "protected": "eyJhbGciOiJFUzM4NCJ9",
+              "signature": "c2ln"
+            }
+          ]
+        }
+        """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId))
+                .thenReturn(Optional.of(activation));
+        when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
+                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Invalid Base64 payload"));
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+    }
+
+    @Test
+    void verifyJwsSignature_missingSignatures() {
+        String jwsJson = """
+        {
+          "payload": "UGF5bG9hZA"
+        }
+        """;
+
+        when(activationQueryService.findActivationWithoutLock(activationId))
+                .thenReturn(Optional.of(activation));
+        when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
+                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Missing signatures array"));
+
+        VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
+        request.setActivationId(activationId);
+        request.setSignedData(jwsJson);
+        request.setSignatureFormat(JwtSignatureFormat.JWS);
+
+        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+    }
+
+}

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
@@ -281,9 +281,9 @@ class JwtSignatureServiceBehaviorTest {
         when(activationQueryService.findActivationWithoutLock(activationId)).thenReturn(Optional.of(activation));
         when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
         when(cryptographyService.verifySignatureForActivation(eq(KeyType.ECDSA_P384), any(), any(), eq(activation)))
-                .thenReturn(false);
-        when(cryptographyService.verifySignatureForActivation(eq(KeyType.MLDSA_65), any(), any(), eq(activation)))
                 .thenReturn(true);
+        when(cryptographyService.verifySignatureForActivation(eq(KeyType.MLDSA_65), any(), any(), eq(activation)))
+                .thenReturn(false);
 
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
@@ -346,7 +346,7 @@ class JwtSignatureServiceBehaviorTest {
     }
 
     @Test
-    void verifyJwsSignature_invalidBase64Payload() {
+    void verifyJwsSignature_invalidBase64Payload() throws GenericServiceException {
         String jwsJson = """
         {
           "payload": "UGF5bG9h#ZA",
@@ -361,15 +361,15 @@ class JwtSignatureServiceBehaviorTest {
 
         when(activationQueryService.findActivationWithoutLock(activationId))
                 .thenReturn(Optional.of(activation));
-        when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
-                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Invalid Base64 payload"));
+        when(cryptographyServiceFactory.getService(any())).thenReturn(cryptographyService);
 
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
         request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
-        assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
+        VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
+        assertFalse(response.isSignatureValid());
     }
 
     @Test
@@ -383,7 +383,7 @@ class JwtSignatureServiceBehaviorTest {
         when(activationQueryService.findActivationWithoutLock(activationId))
                 .thenReturn(Optional.of(activation));
         when(localizationProvider.buildExceptionForCode(ServiceError.INVALID_REQUEST))
-                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Missing signatures array"));
+                .thenReturn(new GenericServiceException(ServiceError.INVALID_REQUEST, "Missing signatures"));
 
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
@@ -105,13 +105,13 @@ class JwtSignatureServiceBehaviorTest {
         SignJwtRequest request = new SignJwtRequest();
         request.setActivationId(activationId);
         request.setData(dataToSign.toString());
-        request.setSignatureFormat(JwtSignatureFormat.JWT);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_COMPACT);
         request.setSignatureType(AsymmetricSignatureType.ECDSA);
 
         SignJwtResponse response = tested.signJwt(request);
 
         assertNotNull(response.getSignedData());
-        assertEquals(JwtSignatureFormat.JWT, response.getSignatureFormat());
+        assertEquals(JwtSignatureFormat.JWS_COMPACT, response.getSignatureFormat());
         SignedJWT jwt = SignedJWT.parse(response.getSignedData());
         assertEquals("ES384", jwt.getHeader().getAlgorithm().getName());
         assertEquals(signatureEcdsa, jwt.getSignature().toString());
@@ -160,7 +160,7 @@ class JwtSignatureServiceBehaviorTest {
         SignJwtRequest request = new SignJwtRequest();
         request.setActivationId(activationId);
         request.setData(dataToSign.toString());
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         SignJwtResponse response = tested.signJwt(request);
         assertNotNull(response.getSignedData());
@@ -194,7 +194,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
         assertTrue(response.isSignatureValid());
@@ -209,7 +209,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData("not-a-jwt");
-        request.setSignatureFormat(JwtSignatureFormat.JWT);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_COMPACT);
 
         assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
     }
@@ -223,7 +223,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData("fake");
-        request.setSignatureFormat(JwtSignatureFormat.JWT);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_COMPACT);
 
         assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
     }
@@ -254,7 +254,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
         assertTrue(response.isSignatureValid());
@@ -288,7 +288,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
         assertFalse(response.isSignatureValid());
@@ -320,7 +320,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         VerifyJwtSignatureResponse response = tested.verifyJwtSignature(request);
         assertFalse(response.isSignatureValid());
@@ -340,7 +340,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(malformedJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
     }
@@ -367,7 +367,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
     }
@@ -388,7 +388,7 @@ class JwtSignatureServiceBehaviorTest {
         VerifyJwtSignatureRequest request = new VerifyJwtSignatureRequest();
         request.setActivationId(activationId);
         request.setSignedData(jwsJson);
-        request.setSignatureFormat(JwtSignatureFormat.JWS);
+        request.setSignatureFormat(JwtSignatureFormat.JWS_JSON);
 
         assertThrows(GenericServiceException.class, () -> tested.verifyJwtSignature(request));
     }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/JwtSignatureServiceBehaviorTest.java
@@ -174,7 +174,7 @@ class JwtSignatureServiceBehaviorTest {
         assertEquals("eyJhbGciOiJFUzM4NCJ9", es384Sig.get("protected").asText());
         assertEquals(signatureEcdsa, es384Sig.get("signature").asText());
         JsonNode mlDsaSig = signatures.get(1);
-        assertEquals("eyJhbGciOiJNTERTQS02NSJ9", mlDsaSig.get("protected").asText());
+        assertEquals("eyJhbGciOiJNTC1EU0EtNjUifQ", mlDsaSig.get("protected").asText());
         assertEquals(signatureMldsa, mlDsaSig.get("signature").asText());
     }
 
@@ -239,7 +239,7 @@ class JwtSignatureServiceBehaviorTest {
           "signature": "c2lnMQ"
         },
         {
-          "protected": "eyJhbGciOiJNTERTQS02NSJ9",
+          "protected": "eyJhbGciOiJNTC1EU0EtNjUifQ",
           "signature": "c2lnMg"
         }
       ]
@@ -271,7 +271,7 @@ class JwtSignatureServiceBehaviorTest {
           "signature": "c2lnMQ"
         },
         {
-          "protected": "eyJhbGciOiJNTERTQS02NSJ9",
+          "protected": "eyJhbGciOiJNTC1EU0EtNjUifQ",
           "signature": "c2lnMg"
         }
       ]

--- a/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/v4/PowerAuthRestClient.java
+++ b/powerauth-rest-client-spring/src/main/java/com/wultra/security/powerauth/rest/client/v4/PowerAuthRestClient.java
@@ -518,6 +518,24 @@ public class PowerAuthRestClient implements PowerAuthClient {
     }
 
     @Override
+    public SignAsymmetricResponse signAsymmetric(SignAsymmetricRequest request) throws PowerAuthClientException {
+        return signAsymmetric(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
+    }
+
+    @Override
+    public SignAsymmetricResponse signAsymmetric(SignAsymmetricRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV4RestApi("/dsa/sign", request, queryParams, httpHeaders, SignAsymmetricResponse.class);
+    }
+
+    @Override
+    public SignAsymmetricResponse signAsymmetric(String activationId, String data) throws PowerAuthClientException {
+        final SignAsymmetricRequest request = new SignAsymmetricRequest();
+        request.setActivationId(activationId);
+        request.setData(data);
+        return signAsymmetric(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
+    }
+
+    @Override
     public VerifyAsymmetricSignatureResponse verifyAsymmetricSignature(VerifyAsymmetricSignatureRequest request) throws PowerAuthClientException {
         return verifyAsymmetricSignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
     }
@@ -534,6 +552,26 @@ public class PowerAuthRestClient implements PowerAuthClient {
         request.setData(data);
         request.setSignature(signature);
         return verifyAsymmetricSignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
+    }
+
+    @Override
+    public SignJwtResponse signJwt(SignJwtRequest request) throws PowerAuthClientException {
+        return signJwt(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
+    }
+
+    @Override
+    public SignJwtResponse signJwt(SignJwtRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV4RestApi("/jwt/sign", request, queryParams, httpHeaders, SignJwtResponse.class);
+    }
+
+    @Override
+    public VerifyJwtSignatureResponse verifyJwtSignature(VerifyJwtSignatureRequest request) throws PowerAuthClientException {
+        return verifyJwtSignature(request, EMPTY_MULTI_MAP, EMPTY_MULTI_MAP);
+    }
+
+    @Override
+    public VerifyJwtSignatureResponse verifyJwtSignature(VerifyJwtSignatureRequest request, MultiValueMap<String, String> queryParams, MultiValueMap<String, String> httpHeaders) throws PowerAuthClientException {
+        return callV4RestApi("/jwt/verify", request, queryParams, httpHeaders, VerifyJwtSignatureResponse.class);
     }
 
     @Override


### PR DESCRIPTION
Support for singing and verifying of JWT and JWS signatures.

Note that this pull requests only adds signatures in activation scope. For application scope, let's discuss the REST API design first, we can implement it separately.