### PR TITLE
Fix #2076: Update offline authentication for crypto4

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/OfflineSignatureServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/OfflineSignatureServiceBehavior.java
@@ -165,7 +165,6 @@ public class OfflineSignatureServiceBehavior {
             // {DATA} consist of data from request plus optional generated proximity TOTP value
             final String dataPlusNonce = fetchDataAndTotp(offlineSignatureParameter, powerAuthServiceConfiguration.getProximityCheckOtpLength()) + "\n" + nonce;
             final byte[] signatureBase = (dataPlusNonce + "\n" + KEY_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            // TODO - v4 support
             final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).generateSignatureForActivation(KeyType.ECDSA_P256, signatureBase, activation);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 
@@ -245,7 +244,6 @@ public class OfflineSignatureServiceBehavior {
 
             // Compute ECDSA signature of '{DATA}\n{NONCE}\n{KEY_MASTER_SERVER_PRIVATE_INDICATOR}'
             final byte[] signatureBase = (data + "\n" + nonce + "\n" + KEY_MASTER_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            // TODO - v4 support
             final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P256).generateSignatureForApplication(KeyType.ECDSA_P256, signatureBase, application);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
@@ -18,6 +18,10 @@
  */
 package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import com.wultra.security.powerauth.app.server.configuration.PowerAuthServiceConfiguration;
 import com.wultra.security.powerauth.app.server.converter.ActivationStatusConverter;
 import com.wultra.security.powerauth.app.server.database.model.KeyType;
@@ -33,6 +37,7 @@ import com.wultra.security.powerauth.app.server.service.i18n.LocalizationProvide
 import com.wultra.security.powerauth.app.server.service.model.ServiceError;
 import com.wultra.security.powerauth.app.server.service.model.authentication.v4.*;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.util.SharedSecretExtractor;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
 import com.wultra.security.powerauth.client.model.enumeration.v4.AuthenticationCodeType;
 import com.wultra.security.powerauth.client.model.request.v4.CreateNonPersonalizedOfflineAuthPayloadRequest;
@@ -46,6 +51,8 @@ import com.wultra.security.powerauth.crypto.lib.generator.KeyGenerator;
 import com.wultra.security.powerauth.crypto.lib.model.exception.CryptoProviderException;
 import com.wultra.security.powerauth.crypto.lib.model.exception.GenericCryptoException;
 import com.wultra.security.powerauth.crypto.lib.totp.Totp;
+import com.wultra.security.powerauth.crypto.lib.v4.kdf.KeyFactory;
+import com.wultra.security.powerauth.crypto.lib.v4.kdf.Kmac;
 import com.wultra.security.powerauth.crypto.lib.v4.model.context.SharedSecretAlgorithm;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,6 +60,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.crypto.SecretKey;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
@@ -73,7 +81,7 @@ public class OfflineAuthenticationServiceBehavior {
 
     private static final String APPLICATION_SECRET_OFFLINE_MODE = "offline";
     private static final String KEY_MASTER_SERVER_PRIVATE_INDICATOR = "0";
-    private static final String KEY_SERVER_PRIVATE_INDICATOR = "1";
+    private static final byte[] KMAC_JOSE_SIGNATURE_CUSTOM_BYTES = "JOSE".getBytes(StandardCharsets.UTF_8);
 
     private final AuthenticationSharedServiceBehavior authenticationSharedServiceBehavior;
     private final ActivationQueryService activationQueryService;
@@ -82,6 +90,7 @@ public class OfflineAuthenticationServiceBehavior {
     private final ActivationContextValidator activationValidator;
     private final MasterKeyPairRepository masterKeyPairRepository;
     private final ApplicationRepository applicationRepository;
+    private final SharedSecretExtractor sharedSecretExtractor;
 
     // Prepare converters
     private final ActivationStatusConverter activationStatusConverter = new ActivationStatusConverter();
@@ -158,16 +167,20 @@ public class OfflineAuthenticationServiceBehavior {
 
             final String nonce = fetchNonce(offlineAuthenticationParameter);
 
-            // Compute ECDSA signature of '{DATA}\n{NONCE}\n{KEY_SERVER_PRIVATE_INDICATOR}'
+            // Compute KMAC-256 of '{DATA}\n{NONCE}
             // {DATA} consist of data from request plus optional generated proximity TOTP value
             final String dataPlusNonce = fetchDataAndTotp(offlineAuthenticationParameter, powerAuthServiceConfiguration.getProximityCheckOtpLength()) + "\n" + nonce;
-            final byte[] signatureBase = (dataPlusNonce + "\n" + KEY_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            // TODO - v4 support using KMAC
-            final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(activation.getCryptoAlgorithm()).generateSignatureForActivation(KeyType.ECDSA_P384, signatureBase, activation);
-            final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
+            final byte[] kmacData = (dataPlusNonce).getBytes(StandardCharsets.UTF_8);
 
-            // Construct complete offline data as '{DATA}\n{NONCE}\n{KEY_SERVER_PRIVATE_INDICATOR}{ECDSA_SIGNATURE}'
-            final String offlineData = (dataPlusNonce + "\n" + KEY_SERVER_PRIVATE_INDICATOR + ecdsaSignature);
+            final SecretKey activationSecretKey = sharedSecretExtractor.extractActivationSecretKey(activation);
+            final SecretKey keyMacPersonalisedData = KeyFactory.deriveKeyMacPersonalizedData(activationSecretKey);
+
+            // Construct KMAC-256 tag
+            final byte[] tagKmac = Kmac.kmac256(keyMacPersonalisedData, kmacData, KMAC_JOSE_SIGNATURE_CUSTOM_BYTES, 64);
+            final String signature = createJwsJson(Base64URL.encode(tagKmac));
+
+            // Construct complete offline data as '{DATA}\n{NONCE}\n{SIGNATURE}'
+            final String offlineData = (dataPlusNonce + "\n" + signature);
 
             // Return the result
             final CreatePersonalizedOfflineAuthPayloadResponse response = new CreatePersonalizedOfflineAuthPayloadResponse();
@@ -188,6 +201,20 @@ public class OfflineAuthenticationServiceBehavior {
             logger.error("Unknown error occurred", ex);
             throw new GenericServiceException(ServiceError.UNKNOWN_ERROR, ex.getMessage());
         }
+    }
+
+    /**
+     * Create a JSON with JWS signatures from a KMAC-256 tag.
+     * @param kmacTag KMAC-256 tag.
+     * @return JSON with JWS signatures array.
+     */
+    private String createJwsJson(Base64URL kmacTag) {
+        final JWSHeader header = new JWSHeader.Builder(new JWSAlgorithm("KMAC256")).build();
+        final Base64URL protectedHeader = header.toBase64URL();
+        final Map<String, Object> signatureMap = new LinkedHashMap<>();
+        signatureMap.put("protected", protectedHeader.toString());
+        signatureMap.put("signature", kmacTag.toString());
+        return "[" + JSONObjectUtils.toJSONString(signatureMap) + "]";
     }
 
     private static String fetchDataAndTotp(OfflineAuthenticationParameter request, int digitsNumber) throws CryptoProviderException {

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OfflineAuthenticationServiceBehavior.java
@@ -269,7 +269,6 @@ public class OfflineAuthenticationServiceBehavior {
 
             // Compute ECDSA signature of '{DATA}\n{NONCE}\n{KEY_MASTER_SERVER_PRIVATE_INDICATOR}'
             final byte[] signatureBase = (data + "\n" + nonce + "\n" + KEY_MASTER_SERVER_PRIVATE_INDICATOR).getBytes(StandardCharsets.UTF_8);
-            // TODO - v4 support using KMAC
             final byte[] ecdsaSignatureBytes = cryptographyServiceFactory.getService(SharedSecretAlgorithm.EC_P384).generateSignatureForApplication(KeyType.ECDSA_P384, signatureBase, application);
             final String ecdsaSignature = Base64.getEncoder().encodeToString(ecdsaSignatureBytes);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/VaultUnlockServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/VaultUnlockServiceBehavior.java
@@ -20,9 +20,7 @@ package com.wultra.security.powerauth.app.server.service.behavior.tasks.v4;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.wultra.security.powerauth.app.server.converter.ActivationSharedSecretConverter;
 import com.wultra.security.powerauth.app.server.database.model.AdditionalInformation;
-import com.wultra.security.powerauth.app.server.database.model.SharedSecret;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
 import com.wultra.security.powerauth.app.server.database.model.enumeration.ActivationStatus;
@@ -37,6 +35,7 @@ import com.wultra.security.powerauth.app.server.service.model.request.v4.VaultUn
 import com.wultra.security.powerauth.app.server.service.model.response.DecryptionResultVaultUnlock;
 import com.wultra.security.powerauth.app.server.service.model.response.v4.VaultUnlockResponsePayload;
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
+import com.wultra.security.powerauth.app.server.service.util.SharedSecretExtractor;
 import com.wultra.security.powerauth.app.server.service.validator.ActivationContextValidator;
 import com.wultra.security.powerauth.client.model.entity.ApplicationConfigurationItem;
 import com.wultra.security.powerauth.client.model.entity.KeyValue;
@@ -90,8 +89,8 @@ public class VaultUnlockServiceBehavior {
     private final EncryptionServiceAead encryptionService;
     private final ObjectMapper objectMapper;
     private final OnlineAuthenticationServiceBehavior onlineAuthenticationServiceBehavior;
-    private final ActivationSharedSecretConverter activationSharedSecretConverter;
     private final ApplicationConfigServiceBehavior applicationConfigServiceBehavior;
+    private final SharedSecretExtractor sharedSecretExtractor;
 
     private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
 
@@ -252,7 +251,7 @@ public class VaultUnlockServiceBehavior {
      * @throws GenericCryptoException  Thrown in case key derivation fails.
      */
     private String deriveVaultEncryptionKey(String keyIdentifier, ActivationRecordEntity activation) throws GenericServiceException, GenericCryptoException {
-        final SecretKey activationSecretKey = extractActivationSecretKey(activation);
+        final SecretKey activationSecretKey = sharedSecretExtractor.extractActivationSecretKey(activation);
         final SecretKey vaultEncryptionKey = deriveVaultEncryptionKey(keyIdentifier, activationSecretKey);
         final byte[] keyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(vaultEncryptionKey);
         return Base64.getEncoder().encodeToString(keyBytes);
@@ -367,20 +366,6 @@ public class VaultUnlockServiceBehavior {
             logger.warn("Invalid vault unlock reason: {}", reason);
             throw localizationProvider.buildExceptionForCode(ServiceError.INVALID_INPUT_FORMAT);
         }
-    }
-
-    /**
-     * Extract the activation secret key from activation entity.
-     *
-     * @param activation Activation entity.
-     * @return Activation shared secret key.
-     * @throws GenericServiceException Thrown in case key conversion fails.
-     */
-    private SecretKey extractActivationSecretKey(ActivationRecordEntity activation) throws GenericServiceException {
-        final SharedSecret activationSharedSecret = new SharedSecret(activation.getSharedSecretEncryption(), activation.getSharedSecret());
-        final String activationSecretBase64 = activationSharedSecretConverter.fromDBValue(activationSharedSecret, activation.getUserId(), activation.getActivationId());
-        final byte[] activationSecretBytes = Base64.getDecoder().decode(activationSecretBase64);
-        return KEY_CONVERTOR.convertBytesToSharedSecretKey(activationSecretBytes);
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/v4/EncryptionServiceAead.java
@@ -19,10 +19,12 @@
 
 package com.wultra.security.powerauth.app.server.service.crypto.v4;
 
-import com.wultra.security.powerauth.app.server.converter.ActivationSharedSecretConverter;
 import com.wultra.security.powerauth.app.server.converter.PublicKeysConverter;
 import com.wultra.security.powerauth.app.server.converter.ServerPrivateKeysConverter;
-import com.wultra.security.powerauth.app.server.database.model.*;
+import com.wultra.security.powerauth.app.server.database.model.KeyType;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeyRegistry;
+import com.wultra.security.powerauth.app.server.database.model.PrivateKeys;
+import com.wultra.security.powerauth.app.server.database.model.PublicKeyRegistry;
 import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
 import com.wultra.security.powerauth.app.server.database.model.entity.ApplicationVersionEntity;
 import com.wultra.security.powerauth.app.server.database.model.enumeration.EncryptionMode;
@@ -37,6 +39,7 @@ import com.wultra.security.powerauth.app.server.service.model.response.Decryptio
 import com.wultra.security.powerauth.app.server.service.persistence.ActivationQueryService;
 import com.wultra.security.powerauth.app.server.service.replay.ReplayVerificationService;
 import com.wultra.security.powerauth.app.server.service.util.ReplayAttackUtils;
+import com.wultra.security.powerauth.app.server.service.util.SharedSecretExtractor;
 import com.wultra.security.powerauth.crypto.lib.encryptor.EncryptorFactory;
 import com.wultra.security.powerauth.crypto.lib.encryptor.exception.EncryptorException;
 import com.wultra.security.powerauth.crypto.lib.encryptor.model.EncryptedRequest;
@@ -57,7 +60,6 @@ import java.security.InvalidKeyException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Base64;
 import java.util.Date;
 
 /**
@@ -74,21 +76,21 @@ public class EncryptionServiceAead extends EncryptionService {
     private final ReplayVerificationService replayVerificationService;
     private final ServerPrivateKeysConverter serverPrivateKeysConverter;
     private final PublicKeysConverter publicKeysConverter;
-    private final ActivationSharedSecretConverter activationSharedSecretConverter;
+    private final SharedSecretExtractor sharedSecretExtractor;
 
     private final EncryptorFactory ENCRYPTOR_FACTORY = new EncryptorFactory();
     private final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
     private static final PowerAuthServerKeyFactory SERVER_KEY_FACTORY = new PowerAuthServerKeyFactory();
 
     @Autowired
-    public EncryptionServiceAead(ApplicationVersionRepository applicationVersionRepository, LocalizationProvider localizationProvider, TemporaryKeyServiceAead temporaryKeyService, ActivationQueryService activationQueryService, ReplayVerificationService replayVerificationService, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter, ActivationSharedSecretConverter activationSharedSecretConverter) {
+    public EncryptionServiceAead(ApplicationVersionRepository applicationVersionRepository, LocalizationProvider localizationProvider, TemporaryKeyServiceAead temporaryKeyService, ActivationQueryService activationQueryService, ReplayVerificationService replayVerificationService, ServerPrivateKeysConverter serverPrivateKeysConverter, PublicKeysConverter publicKeysConverter, SharedSecretExtractor sharedSecretExtractor) {
         super(localizationProvider, applicationVersionRepository, activationQueryService);
         this.localizationProvider = localizationProvider;
         this.temporaryKeyService = temporaryKeyService;
         this.replayVerificationService = replayVerificationService;
         this.serverPrivateKeysConverter = serverPrivateKeysConverter;
         this.publicKeysConverter = publicKeysConverter;
-        this.activationSharedSecretConverter = activationSharedSecretConverter;
+        this.sharedSecretExtractor = sharedSecretExtractor;
     }
 
     @Override
@@ -155,10 +157,7 @@ public class EncryptionServiceAead extends EncryptionService {
         final PublicKeyRegistry publicKeyRegistry = publicKeysConverter.fromDBValue(devicePublicKeys);
         final PublicKey devicePublicKey = publicKeyRegistry.getPublicKey(KeyType.ECDSA_P384).orElseThrow(() -> localizationProvider.buildExceptionForCode(ServiceError.GENERIC_CRYPTOGRAPHY_ERROR));
 
-        final SharedSecret activationSharedSecret = new SharedSecret(activation.getSharedSecretEncryption(), activation.getSharedSecret());
-        final String activationSecretBase64 = activationSharedSecretConverter.fromDBValue(activationSharedSecret, activation.getUserId(), activation.getActivationId());
-        final byte[] activationSecretBytes = Base64.getDecoder().decode(activationSecretBase64);
-        final SecretKey activationSecret = KEY_CONVERTOR.convertBytesToSharedSecretKey(activationSecretBytes);
+        final SecretKey activationSecret = sharedSecretExtractor.extractActivationSecretKey(activation);
         final SecretKey sharedInfo2Key = SERVER_KEY_FACTORY.generateSharedInfo2Key(activationSecret);
         final byte[] sharedInfo2KeyBytes = KEY_CONVERTOR.convertSharedSecretKeyToBytes(sharedInfo2Key);
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/SharedSecretExtractor.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/util/SharedSecretExtractor.java
@@ -1,0 +1,60 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2025 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.wultra.security.powerauth.app.server.service.util;
+
+import com.wultra.security.powerauth.app.server.converter.ActivationSharedSecretConverter;
+import com.wultra.security.powerauth.app.server.database.model.SharedSecret;
+import com.wultra.security.powerauth.app.server.database.model.entity.ActivationRecordEntity;
+import com.wultra.security.powerauth.app.server.service.exceptions.GenericServiceException;
+import com.wultra.security.powerauth.crypto.lib.util.KeyConvertor;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+
+/**
+ * Utility class for shared secret key derivation.
+ *
+ * @author Roman Strobl, roman.strobl@wultra.com
+ */
+@AllArgsConstructor
+@Service
+public class SharedSecretExtractor {
+
+    private final ActivationSharedSecretConverter activationSharedSecretConverter;
+
+    private static final KeyConvertor KEY_CONVERTOR = new KeyConvertor();
+
+    /**
+     * Extract the activation secret key from activation entity.
+     *
+     * @param activation Activation entity.
+     * @return Activation shared secret key.
+     * @throws GenericServiceException Thrown in case key conversion fails.
+     */
+    public SecretKey extractActivationSecretKey(ActivationRecordEntity activation) throws GenericServiceException {
+        final SharedSecret activationSharedSecret = new SharedSecret(activation.getSharedSecretEncryption(), activation.getSharedSecret());
+        final String activationSecretBase64 = activationSharedSecretConverter.fromDBValue(activationSharedSecret, activation.getUserId(), activation.getActivationId());
+        final byte[] activationSecretBytes = Base64.getDecoder().decode(activationSecretBase64);
+        return KEY_CONVERTOR.convertBytesToSharedSecretKey(activationSecretBytes);
+    }
+
+}


### PR DESCRIPTION
Updated offline signature for v4 using KMAC-256 in activation scope.