### PR TITLE
Add CycloneDX Maven plugin version 2.9.1 for SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <logstash.version>8.1</logstash.version>
         <equalsverifier.version>3.19.4</equalsverifier.version>
         <zxing.version>3.5.3</zxing.version>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
 
         <!-- Test dependencies -->
         <webauthn4j.version>0.29.2.RELEASE</webauthn4j.version>
@@ -326,6 +327,11 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
(cherry picked from commit 29fca273bb7342f2ff27d34016f9b5571d4a2d0c)