### PR TITLE
Fix #2296: Convert credential ID to Base64 standard if received in Base64 URL by API

### DIFF
--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/converter/serialization/Base64UrlToBase64Deserializer.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/converter/serialization/Base64UrlToBase64Deserializer.java
@@ -1,0 +1,81 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.security.powerauth.fido2.model.converter.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+import java.io.Serial;
+
+/**
+ * Jackson deserializer that transparently normalizes Base64URL-encoded strings
+ * to standard Base64 encoding (RFC 4648 §4). The deserializer accepts both encodings
+ * and always produces a standard Base64 string.
+ *
+ * @author Pavel Sindelar, pavel.sindelar@wultra.com
+ */
+public class Base64UrlToBase64Deserializer extends StdDeserializer<String> {
+
+    @Serial
+    private static final long serialVersionUID = 4871203406847302591L;
+
+    public Base64UrlToBase64Deserializer() {
+        this(null);
+    }
+
+    public Base64UrlToBase64Deserializer(final Class<?> valueClass) {
+        super(valueClass);
+    }
+
+    @Override
+    public String deserialize(final JsonParser parser, final DeserializationContext context) throws IOException {
+        final String value = parser.getText();
+        if (value == null) {
+            return null;
+        }
+
+        if (value.length() % 4 == 1) {
+            throw InvalidFormatException.from(
+                    parser,
+                    "Invalid value for path '%s': length mod 4 == 1 is not a valid Base64 remainder".formatted(parser.getParsingContext().pathAsPointer()),
+                    value,
+                    String.class
+            );
+        }
+
+        if (value.length() % 4 == 0 && !value.contains("-") && !value.contains("_")) {
+            // already standard Base64 string
+            return value;
+        }
+
+        final String normalized = value.replace('-', '+').replace('_', '/');
+
+        final int remainder = normalized.length() % 4;
+        if (remainder == 0) {
+            // no padding needed
+            return normalized;
+        }
+
+        // add padding
+        return normalized + "=".repeat(4 - remainder);
+    }
+}

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/converter/serialization/Base64UrlToBase64Deserializer.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/converter/serialization/Base64UrlToBase64Deserializer.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 
 import java.io.IOException;
 import java.io.Serial;
+import java.util.Base64;
 
 /**
  * Jackson deserializer that transparently normalizes Base64URL-encoded strings
@@ -64,7 +65,7 @@ public class Base64UrlToBase64Deserializer extends StdDeserializer<String> {
 
         if (value.length() % 4 == 0 && !value.contains("-") && !value.contains("_")) {
             // already standard Base64 string
-            return value;
+            return validate(value, parser);
         }
 
         final String normalized = value.replace('-', '+').replace('_', '/');
@@ -72,10 +73,27 @@ public class Base64UrlToBase64Deserializer extends StdDeserializer<String> {
         final int remainder = normalized.length() % 4;
         if (remainder == 0) {
             // no padding needed
-            return normalized;
+            return validate(normalized, parser);
         }
 
         // add padding
-        return normalized + "=".repeat(4 - remainder);
+        final String normalizedPadded = normalized + "=".repeat(4 - remainder);
+
+        return validate(normalizedPadded, parser);
+    }
+
+    private String validate(final String value, final JsonParser parser) throws InvalidFormatException {
+        try {
+            Base64.getDecoder().decode(value);
+        } catch (final Exception e) {
+            throw InvalidFormatException.from(
+                    parser,
+                    "Invalid value for path '%s': %s".formatted(parser.getParsingContext().pathAsPointer(), e.getMessage()),
+                    value,
+                    String.class
+            );
+        }
+
+        return value;
     }
 }

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/AuthenticatorParameters.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/entity/AuthenticatorParameters.java
@@ -20,6 +20,8 @@ package com.wultra.security.powerauth.fido2.model.entity;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.wultra.security.powerauth.fido2.model.converter.serialization.Base64UrlToBase64Deserializer;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -36,6 +38,7 @@ import java.util.List;
 public class AuthenticatorParameters {
 
     @NotBlank
+    @JsonDeserialize(using = Base64UrlToBase64Deserializer.class)
     private String credentialId;
     @NotBlank
     private String type;

--- a/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/request/AssertionVerificationRequest.java
+++ b/powerauth-fido2-model/src/main/java/com/wultra/security/powerauth/fido2/model/request/AssertionVerificationRequest.java
@@ -20,6 +20,8 @@ package com.wultra.security.powerauth.fido2.model.request;
 
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.wultra.security.powerauth.fido2.model.converter.serialization.Base64UrlToBase64Deserializer;
 import com.wultra.security.powerauth.fido2.model.entity.AuthenticatorAssertionResponse;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -37,6 +39,7 @@ import java.util.List;
 public class AssertionVerificationRequest {
 
     @NotBlank
+    @JsonDeserialize(using = Base64UrlToBase64Deserializer.class)
     private String credentialId;
     @NotBlank
     private String type;

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToBase64DeserializerTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToBase64DeserializerTest.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.wultra.security.powerauth.fido2.model.converter.serialization.Base64UrlToBase64Deserializer;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for {@link Base64UrlToBase64Deserializer}.
@@ -43,50 +45,34 @@ class Base64UrlToBase64DeserializerTest {
         objectMapper.registerModule(module);
     }
 
-    @Test
-    void testDeserialize_base64UrlWithoutPadding_convertedToBase64() throws Exception {
-        final String result = objectMapper.readValue("\"-_--\"", String.class);
-        assertEquals("+/++", result);
+    @ParameterizedTest(name = "{0}")
+    @CsvSource(
+            value = {
+                    "base64UrlWithoutPadding_convertedToBase64,              -_--,     +/++",
+                    "base64UrlMissingPadding_paddingAdded,                   SGVsbG8,  SGVsbG8=",
+                    "alreadyStandardBase64_returnedUnchanged,                SGVsbG8=, SGVsbG8=",
+                    "alreadyStandardBase64NoPaddingNeeded_returnedUnchanged, ABCDEFGH, ABCDEFGH",
+                    "null_returnsNull,                                       null,     null",
+                    "dashOnly_convertedToPlus,                               AA-A,     AA+A",
+                    "underscoreOnly_convertedToSlash,                        AA_A,     AA/A"
+            },
+            nullValues = "null"
+    )
+    void testDeserialize_validInput(final String name, final String input, final String expected) throws Exception {
+        assertEquals(expected, objectMapper.readValue(
+                input != null ? "\"%s\"".formatted(input) : "null",
+                String.class
+        ));
     }
 
-    @Test
-    void testDeserialize_base64UrlMissingPadding_paddingAdded() throws Exception {
-        final String result = objectMapper.readValue("\"SGVsbG8\"", String.class);
-        assertEquals("SGVsbG8=", result);
-    }
-
-    @Test
-    void testDeserialize_alreadyStandardBase64_returnedUnchanged() throws Exception {
-        final String result = objectMapper.readValue("\"SGVsbG8=\"", String.class);
-        assertEquals("SGVsbG8=", result);
-    }
-
-    @Test
-    void testDeserialize_alreadyStandardBase64NoPaddingNeeded_returnedUnchanged() throws Exception {
-        final String result = objectMapper.readValue("\"ABCDEFGH\"", String.class);
-        assertEquals("ABCDEFGH", result);
-    }
-
-    @Test
-    void testDeserialize_null_returnsNull() throws Exception {
-        final String result = objectMapper.readValue("null", String.class);
-        assertNull(result);
-    }
-
-    @Test
-    void testDeserialize_dashOnly_convertedToPlus() throws Exception {
-        final String result = objectMapper.readValue("\"AA-A\"", String.class);
-        assertEquals("AA+A", result);
-    }
-
-    @Test
-    void testDeserialize_underscoreOnly_convertedToSlash() throws Exception {
-        final String result = objectMapper.readValue("\"AA_A\"", String.class);
-        assertEquals("AA/A", result);
-    }
-
-    @Test
-    void testDeserialize_invalidLength_throwsException() {
-        assertThrows(JsonMappingException.class, () -> objectMapper.readValue("\"A\"", String.class));
+    @ParameterizedTest(name = "{0}")
+    @CsvSource({
+            "invalidLength,                             A",
+            "invalidCharInStandardBase64,               A!B=",
+            "invalidCharInBase64UrlRequiringPadding,    A!-",
+            "invalidCharInBase64UrlNotRequiringPadding, -_!-"
+    })
+    void testDeserialize_invalidInput_throwsException(final String name, final String input) {
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue("\"%s\"".formatted(input), String.class));
     }
 }

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToBase64DeserializerTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/rest/model/converter/serialization/Base64UrlToBase64DeserializerTest.java
@@ -1,0 +1,92 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.wultra.powerauth.fido2.rest.model.converter.serialization;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.wultra.security.powerauth.fido2.model.converter.serialization.Base64UrlToBase64Deserializer;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test for {@link Base64UrlToBase64Deserializer}.
+ *
+ * @author Pavel Sindelar, pavel.sindelar@wultra.com
+ */
+class Base64UrlToBase64DeserializerTest {
+
+    private static ObjectMapper objectMapper;
+
+    @BeforeAll
+    static void setUp() {
+        final SimpleModule module = new SimpleModule();
+        module.addDeserializer(String.class, new Base64UrlToBase64Deserializer());
+        objectMapper = new ObjectMapper();
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    void testDeserialize_base64UrlWithoutPadding_convertedToBase64() throws Exception {
+        final String result = objectMapper.readValue("\"-_--\"", String.class);
+        assertEquals("+/++", result);
+    }
+
+    @Test
+    void testDeserialize_base64UrlMissingPadding_paddingAdded() throws Exception {
+        final String result = objectMapper.readValue("\"SGVsbG8\"", String.class);
+        assertEquals("SGVsbG8=", result);
+    }
+
+    @Test
+    void testDeserialize_alreadyStandardBase64_returnedUnchanged() throws Exception {
+        final String result = objectMapper.readValue("\"SGVsbG8=\"", String.class);
+        assertEquals("SGVsbG8=", result);
+    }
+
+    @Test
+    void testDeserialize_alreadyStandardBase64NoPaddingNeeded_returnedUnchanged() throws Exception {
+        final String result = objectMapper.readValue("\"ABCDEFGH\"", String.class);
+        assertEquals("ABCDEFGH", result);
+    }
+
+    @Test
+    void testDeserialize_null_returnsNull() throws Exception {
+        final String result = objectMapper.readValue("null", String.class);
+        assertNull(result);
+    }
+
+    @Test
+    void testDeserialize_dashOnly_convertedToPlus() throws Exception {
+        final String result = objectMapper.readValue("\"AA-A\"", String.class);
+        assertEquals("AA+A", result);
+    }
+
+    @Test
+    void testDeserialize_underscoreOnly_convertedToSlash() throws Exception {
+        final String result = objectMapper.readValue("\"AA_A\"", String.class);
+        assertEquals("AA/A", result);
+    }
+
+    @Test
+    void testDeserialize_invalidLength_throwsException() {
+        assertThrows(JsonMappingException.class, () -> objectMapper.readValue("\"A\"", String.class));
+    }
+}

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/RESTControllerAdvice.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/controller/RESTControllerAdvice.java
@@ -140,4 +140,14 @@ public class RESTControllerAdvice {
         return new ObjectResponse<>("ERROR", error);
     }
 
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public @ResponseBody ObjectResponse<PowerAuthError> handleHttpMessageNotReadableException(final HttpMessageNotReadableException e) {
+        logger.error("Error occurred while processing the request: {}", e.getMessage());
+        logger.debug("Exception details:", e);
+        final PowerAuthError error = new PowerAuthError();
+        error.setCode("INVALID_REQUEST");
+        error.setMessage(e.getMessage());
+        error.setLocalizedMessage(e.getLocalizedMessage());
+        return new ObjectResponse<>("ERROR", error);    }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/rest/controller/AssertionControllerTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/rest/controller/AssertionControllerTest.java
@@ -26,6 +26,7 @@ import com.wultra.security.powerauth.fido2.model.request.AssertionVerificationRe
 import com.wultra.security.powerauth.fido2.model.response.AssertionChallengeResponse;
 import com.wultra.security.powerauth.fido2.model.response.AssertionVerificationResponse;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -36,6 +37,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 import java.util.Base64;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -150,4 +152,61 @@ class AssertionControllerTest {
         verify(assertionService).authenticate(request);
     }
 
+    @Test
+    void testAuthenticate_base64UrlCredentialId_normalizedToBase64() throws Exception {
+        final String requestBody = """
+                {
+                  "requestObject": {
+                    "credentialId": "-_-",
+                    "type": "public-key",
+                    "response": {
+                      "clientDataJSON": "dGVzdAo=",
+                      "authenticatorData": "dGVzdAo=",
+                      "signature": "dGVzdAo="
+                    },
+                    "relyingPartyId": "example.com"
+                  }
+                }
+                """;
+
+        webTestClient.post()
+                .uri("/fido2/assertions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isOk();
+
+        final ArgumentCaptor<AssertionVerificationRequest> captor = ArgumentCaptor.forClass(AssertionVerificationRequest.class);
+        verify(assertionService).authenticate(captor.capture());
+        assertEquals("+/+=", captor.getValue().getCredentialId());
+    }
+
+    @Test
+    void testAuthenticate_invalidBase64CredentialId_returnsBadRequest() {
+        final String requestBody = """
+                {
+                  "requestObject": {
+                    "credentialId": "A",
+                    "type": "public-key",
+                    "response": {
+                      "clientDataJSON": "dGVzdAo=",
+                      "authenticatorData": "dGVzdAo=",
+                      "signature": "dGVzdAo="
+                    },
+                    "relyingPartyId": "example.com"
+                  }
+                }
+                """;
+
+        webTestClient.post()
+                .uri("/fido2/assertions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.responseObject.code").isEqualTo("INVALID_REQUEST")
+                .jsonPath("$.responseObject.message")
+                .isEqualTo("JSON parse error: Invalid value for path '/requestObject/credentialId': length mod 4 == 1 is not a valid Base64 remainder");
+    }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/rest/controller/RegistrationControllerTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/powerauth/fido2/rest/controller/RegistrationControllerTest.java
@@ -1,0 +1,113 @@
+/*
+ * PowerAuth Server and related software components
+ * Copyright (C) 2026 Wultra s.r.o.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.wultra.powerauth.fido2.rest.controller;
+
+import com.wultra.powerauth.fido2.service.RegistrationService;
+import com.wultra.security.powerauth.fido2.model.request.RegistrationRequest;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests of {@link RegistrationController}.
+ *
+ * @author Pavel Sindelar, pavel.sindelar@wultra.com
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = com.wultra.security.powerauth.app.server.Application.class)
+@ActiveProfiles("test")
+class RegistrationControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private RegistrationService registrationService;
+
+    @Test
+    void testRegister_base64UrlCredentialId_normalizedToBase64() throws Exception {
+        final String requestBody = """
+                {
+                  "requestObject": {
+                    "applicationId": "app-id",
+                    "activationName": "My Device",
+                    "authenticatorParameters": {
+                      "credentialId": "-_-",
+                      "type": "public-key",
+                      "response": {
+                        "clientDataJSON": "dGVzdAo=",
+                        "attestationObject": "dGVzdAo="
+                      },
+                      "relyingPartyId": "example.com"
+                    }
+                  }
+                }
+                """;
+
+        webTestClient.post()
+                .uri("/fido2/registrations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isOk();
+
+        final ArgumentCaptor<RegistrationRequest> captor = ArgumentCaptor.forClass(RegistrationRequest.class);
+        verify(registrationService).register(captor.capture());
+        assertEquals("+/+=", captor.getValue().getAuthenticatorParameters().getCredentialId());
+    }
+
+    @Test
+    void testRegister_invalidBase64CredentialId_returnsBadRequest() {
+        final String requestBody = """
+                {
+                  "requestObject": {
+                    "applicationId": "app-id",
+                    "activationName": "My Device",
+                    "authenticatorParameters": {
+                      "credentialId": "A",
+                      "type": "public-key",
+                      "response": {
+                        "clientDataJSON": "dGVzdAo=",
+                        "attestationObject": "dGVzdAo="
+                      },
+                      "relyingPartyId": "example.com"
+                    }
+                  }
+                }
+                """;
+
+        webTestClient.post()
+                .uri("/fido2/registrations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody)
+                .exchange()
+                .expectStatus().isBadRequest()
+                .expectBody()
+                .jsonPath("$.responseObject.code").isEqualTo("INVALID_REQUEST")
+                .jsonPath("$.responseObject.message")
+                .isEqualTo("JSON parse error: Invalid value for path '/requestObject/authenticatorParameters/credentialId': length mod 4 == 1 is not a valid Base64 remainder");
+    }
+}


### PR DESCRIPTION
The ultimate solution is to normalize the Base64 encoding on input (discussed with @zcgandcomp).