### PR TITLE
Fix #2299: Set subject id to the audit log records

### DIFF
--- a/docs/PowerAuth-Server-2.1.0.md
+++ b/docs/PowerAuth-Server-2.1.0.md
@@ -22,3 +22,11 @@ For convenience, you can use Liquibase for your database migration.
 
 * Dropped the non-unique index `pa_activation_code` on column `activation_code`.
 * Added a unique constraint `pa_activation_code_application_uk` on columns `(application_id, activation_code)` to enforce activation code uniqueness at the database level per application.
+
+### `audit_log` Table
+
+Added a new indexed column `subject_id` holding an identifier linking the audit record to an entity it is related to (e.g. user ID for user-related audit records).
+
+<!-- begin box warning -->
+The auditing tables may be already updated in your database schema if the database schema is not separated for different PowerAuth applications. In case the column `audit_log.subject_id` and its index `audit_log_subject_id_idx` are already present, you can safely skip this migration step.
+<!-- end -->

--- a/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260327-audit-subject-id.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260327-audit-subject-id.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Server and related software components
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+
+    <changeSet id="1" logicalFilePath="powerauth-java-server/2.1.x/20260327-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="audit_log" columnName="subject_id"/>
+            </not>
+        </preConditions>
+        <comment>Add subject_id column to audit_log table</comment>
+        <addColumn tableName="audit_log">
+            <column name="subject_id" type="varchar(256)"/>
+        </addColumn>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+    <changeSet id="2" logicalFilePath="powerauth-java-server/2.1.x/20260327-audit-subject-id.xml" author="Pavel Sindelar">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <indexExists tableName="audit_log" indexName="audit_log_subject_id_idx"/>
+            </not>
+        </preConditions>
+        <comment>Create a new index on audit_log(subject_id)</comment>
+        <createIndex tableName="audit_log" indexName="audit_log_subject_id_idx">
+            <column name="subject_id"/>
+        </createIndex>
+        <!-- no rollback on purpose, the audit tables may be shared across several components -->
+        <rollback />
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
@@ -4,5 +4,6 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
     <include file="20260316-activation-code-unique.xml" relativeToChangelogFile="true" />
+    <include file="20260327-audit-subject-id.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/docs/sql/mssql/create_schema.sql
+++ b/docs/sql/mssql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 08/01/2026, 10:15
+-- Ran at: 3/30/26, 10:02
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -189,7 +189,7 @@ GO
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::28::Lubos Racansky
 -- Create a new index on pa_activation(activation_code)
-ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+CREATE NONCLUSTERED INDEX pa_activation_code ON pa_activation(activation_code);
 GO
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::29::Lubos Racansky
@@ -689,3 +689,13 @@ ALTER TABLE pa_activation ADD activation_fingerprint varchar(255);
 GO
 
 -- Changeset powerauth-java-server/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
+-- Drop non-unique index on pa_activation(activation_code) before replacing with unique constraint
+DROP INDEX pa_activation_code ON pa_activation;
+GO
+
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::2::Vit Kotacka
+-- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
+ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+GO
+

--- a/docs/sql/mssql/create_schema.sql
+++ b/docs/sql/mssql/create_schema.sql
@@ -699,3 +699,13 @@ GO
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 GO
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id varchar(256);
+GO
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE NONCLUSTERED INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+GO
+

--- a/docs/sql/mssql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/mssql/migration_2.0.0_2.1.0.sql
@@ -17,3 +17,12 @@ GO
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 GO
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id varchar(256);
+GO
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE NONCLUSTERED INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+GO

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 08/01/2026, 10:16
+-- Ran at: 3/30/26, 9:57
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -153,7 +153,7 @@ CREATE INDEX pa_activation_keypair ON pa_activation(master_keypair_id);
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::28::Lubos Racansky
 -- Create a new index on pa_activation(activation_code)
-ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+CREATE INDEX pa_activation_code ON pa_activation(activation_code);
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::29::Lubos Racansky
 -- Create a new index on pa_activation(user_id)
@@ -546,3 +546,11 @@ ALTER TABLE pa_activation ADD CONSTRAINT pa_server_public_key_id_fk FOREIGN KEY 
 ALTER TABLE pa_activation ADD activation_fingerprint VARCHAR2(255);
 
 -- Changeset powerauth-java-server/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
+-- Drop non-unique index on pa_activation(activation_code) before replacing with unique constraint
+DROP INDEX pa_activation_code;
+
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::2::Vit Kotacka
+-- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
+ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -554,3 +554,11 @@ DROP INDEX pa_activation_code;
 -- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+

--- a/docs/sql/oracle/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/migration_2.0.0_2.1.0.sql
@@ -15,3 +15,10 @@ DROP INDEX pa_activation_code;
 -- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 08/01/2026, 10:17
+-- Ran at: 3/30/26, 9:54
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -153,7 +153,7 @@ CREATE INDEX pa_activation_keypair ON pa_activation(master_keypair_id);
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::28::Lubos Racansky
 -- Create a new index on pa_activation(activation_code)
-ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+CREATE INDEX pa_activation_code ON pa_activation(activation_code);
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::29::Lubos Racansky
 -- Create a new index on pa_activation(user_id)
@@ -546,3 +546,11 @@ ALTER TABLE pa_activation ADD CONSTRAINT pa_server_public_key_id_fk FOREIGN KEY 
 ALTER TABLE pa_activation ADD activation_fingerprint VARCHAR(255);
 
 -- Changeset powerauth-java-server/2.0.x/20251215-add-tag-2.0.0.xml::1::Lubos Racansky
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
+-- Drop non-unique index on pa_activation(activation_code) before replacing with unique constraint
+DROP INDEX pa_activation_code;
+
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::2::Vit Kotacka
+-- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
+ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
+

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -554,3 +554,11 @@ DROP INDEX pa_activation_code;
 -- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR(256);
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+

--- a/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
@@ -15,3 +15,10 @@ DROP INDEX pa_activation_code;
 -- Add unique constraint on (application_id, activation_code) to enforce activation code uniqueness at DB level, replacing the application-level SELECT COUNT uniqueness check
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (application_id, activation_code);
 
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
+-- Add subject_id column to audit_log table
+ALTER TABLE audit_log ADD subject_id VARCHAR(256);
+
+-- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
+-- Create a new index on audit_log(subject_id)
+CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
 
         <!-- Wultra Dependencies -->
         <powerauth-java-crypto.version>2.1.0-SNAPSHOT</powerauth-java-crypto.version>
-        <wultra-core.version>2.0.0</wultra-core.version>
+        <wultra-core.version>2.1.0</wultra-core.version>
 
         <istack-commons-runtime.version>3.0.12</istack-commons-runtime.version>
 

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationFlagsServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationFlagsServiceBehavior.java
@@ -112,7 +112,9 @@ public class ActivationFlagsServiceBehavior {
             if (!newFlags.isEmpty()) { // only in case there are new flags
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.ACTIVATION.getCode())
+                        .subjectId(activation.getUserId())
                         .param("activationId", activationId)
+                        .param("userId", activation.getUserId())
                         .param("flags", newFlags)
                         .param("addedFlags", activationFlags)
                         .build();
@@ -158,7 +160,9 @@ public class ActivationFlagsServiceBehavior {
             });
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.ACTIVATION.getCode())
+                    .subjectId(activation.getUserId())
                     .param("activationId", activationId)
+                    .param("userId", activation.getUserId())
                     .param("flags", activationFlags)
                     .build();
             audit.log(AuditLevel.INFO, "Setting new activation flags: {} to activation {}", auditDetail, activationFlags, activationId);
@@ -201,7 +205,9 @@ public class ActivationFlagsServiceBehavior {
             });
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.ACTIVATION.getCode())
+                    .subjectId(activation.getUserId())
                     .param("activationId", activationId)
+                    .param("userId", activation.getUserId())
                     .param("removedFlags", activationFlags)
                     .build();
             audit.log(AuditLevel.INFO, "Removing activation flags: {} from activation {}", auditDetail, activationFlags, activationId);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehavior.java
@@ -161,6 +161,7 @@ public class ActivationHistoryServiceBehavior {
         // Prepare shared parameters
         final AuditDetail.Builder auditDetailBuilder = AuditDetail.builder()
                 .type(AuditType.ACTIVATION.getCode())
+                .subjectId(activation.getUserId())
                 .param("activationId", activation.getActivationId())
                 .param("userId", activation.getUserId())
                 .param("applicationId", activation.getApplication().getId())

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
@@ -208,6 +208,7 @@ public class AuditingServiceBehavior {
                 .param("note", note)
                 .param("timestamp", currentTimestamp)
                 .type(AuditType.SIGNATURE.getCode())
+                .subjectId(activation.getUserId())
                 .build();
         audit.log("Signature validation completed: {}, activation ID: {}, user ID: {}", AuditLevel.INFO, auditDetail,
                 (valid ? "SUCCESS" : "FAILURE (" + note + ")"),

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/OperationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/OperationServiceBehavior.java
@@ -212,6 +212,7 @@ public class OperationServiceBehavior {
 
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.OPERATION.getCode())
+                    .subjectId(operationEntity.getUserId())
                     .param("id", operationId)
                     .param("userId", operationEntity.getUserId())
                     .param("applications", applications)
@@ -389,6 +390,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -422,6 +424,7 @@ public class OperationServiceBehavior {
 
                     final AuditDetail auditDetail = AuditDetail.builder()
                             .type(AuditType.OPERATION.getCode())
+                            .subjectId(userId)
                             .param("id", operationId)
                             .param("userId", userId)
                             .param("appId", applicationId)
@@ -454,6 +457,7 @@ public class OperationServiceBehavior {
 
                     final AuditDetail auditDetail = AuditDetail.builder()
                             .type(AuditType.OPERATION.getCode())
+                            .subjectId(userId)
                             .param("id", operationId)
                             .param("userId", userId)
                             .param("appId", applicationId)
@@ -545,6 +549,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -563,6 +568,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -628,6 +634,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(operationEntity.getUserId())
                         .param("id", operationId)
                         .param("failureCount", operationEntity.getFailureCount())
                         .param("status", operationEntity.getStatus().name())
@@ -652,6 +659,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(operationEntity.getUserId())
                         .param("id", operationId)
                         .param("failureCount", operationEntity.getFailureCount())
                         .param("status", operationEntity.getStatus().name())
@@ -711,6 +719,7 @@ public class OperationServiceBehavior {
 
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.OPERATION.getCode())
+                    .subjectId(operationEntity.getUserId())
                     .param("id", operationId)
                     .param("failureCount", operationEntity.getFailureCount())
                     .param("status", operationEntity.getStatus().name())

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
@@ -210,6 +210,7 @@ public class AuditingServiceBehavior {
                 .param("note", note)
                 .param("timestamp", currentTimestamp)
                 .type(AuditType.AUTHENTICATION.getCode())
+                .subjectId(activation.getUserId())
                 .build();
         audit.log("Authentication validation completed: {}, activation ID: {}, user ID: {}", AuditLevel.INFO, auditDetail,
                 (valid ? "SUCCESS" : "FAILURE (" + note + ")"),

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OperationServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/OperationServiceBehavior.java
@@ -213,6 +213,7 @@ public class OperationServiceBehavior {
 
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.OPERATION.getCode())
+                    .subjectId(operationEntity.getUserId())
                     .param("id", operationId)
                     .param("userId", operationEntity.getUserId())
                     .param("applications", applications)
@@ -390,6 +391,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -423,6 +425,7 @@ public class OperationServiceBehavior {
 
                     final AuditDetail auditDetail = AuditDetail.builder()
                             .type(AuditType.OPERATION.getCode())
+                            .subjectId(userId)
                             .param("id", operationId)
                             .param("userId", userId)
                             .param("appId", applicationId)
@@ -455,6 +458,7 @@ public class OperationServiceBehavior {
 
                     final AuditDetail auditDetail = AuditDetail.builder()
                             .type(AuditType.OPERATION.getCode())
+                            .subjectId(userId)
                             .param("id", operationId)
                             .param("userId", userId)
                             .param("appId", applicationId)
@@ -546,6 +550,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -564,6 +569,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(userId)
                         .param("id", operationId)
                         .param("userId", userId)
                         .param("appId", applicationId)
@@ -629,6 +635,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(operationEntity.getUserId())
                         .param("id", operationId)
                         .param("failureCount", operationEntity.getFailureCount())
                         .param("status", operationEntity.getStatus().name())
@@ -653,6 +660,7 @@ public class OperationServiceBehavior {
 
                 final AuditDetail auditDetail = AuditDetail.builder()
                         .type(AuditType.OPERATION.getCode())
+                        .subjectId(operationEntity.getUserId())
                         .param("id", operationId)
                         .param("failureCount", operationEntity.getFailureCount())
                         .param("status", operationEntity.getStatus().name())
@@ -712,6 +720,7 @@ public class OperationServiceBehavior {
 
             final AuditDetail auditDetail = AuditDetail.builder()
                     .type(AuditType.OPERATION.getCode())
+                    .subjectId(operationEntity.getUserId())
                     .param("id", operationId)
                     .param("failureCount", operationEntity.getFailureCount())
                     .param("status", operationEntity.getStatus().name())

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAssertionProvider.java
@@ -217,6 +217,7 @@ public class PowerAuthAssertionProvider implements AssertionProvider {
     private void auditAssertionResult(final AuthenticatorDetail authenticator, final UserActionResult result) {
         final AuditDetail auditDetail = AuditDetail.builder()
                 .type(AUDIT_TYPE_FIDO2)
+                .subjectId(authenticator.getUserId())
                 .param("userId", authenticator.getUserId())
                 .param("applicationId", authenticator.getApplicationId())
                 .param("activationId", authenticator.getActivationId())

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/fido2/PowerAuthAuthenticatorProvider.java
@@ -314,6 +314,7 @@ public class PowerAuthAuthenticatorProvider implements AuthenticatorProvider {
     private void auditStoredAuthenticator(Activation activation) {
         final AuditDetail auditDetail = AuditDetail.builder()
                 .type(AUDIT_TYPE_FIDO2)
+                .subjectId(activation.getUserId())
                 .param("userId", activation.getUserId())
                 .param("applicationId", activation.getApplicationId())
                 .param("activationId", activation.getActivationId())

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/ActivationHistoryServiceBehaviorTest.java
@@ -59,6 +59,7 @@ class ActivationHistoryServiceBehaviorTest {
     @Test
     void testLogAuditItem_additionalData() {
         final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setUserId("internal-user-id");
         activation.setApplication(new ApplicationEntity());
         activation.setActivationStatus(ActivationStatus.ACTIVE);
         activation.setAdditionalData("""
@@ -75,11 +76,13 @@ class ActivationHistoryServiceBehaviorTest {
 
         assertThat(capturedAuditDetail.getType()).isEqualTo("activation");
         assertThat(capturedAuditDetail.getParam().get("additionalData")).isEqualTo(Map.of("foo", "bar"));
+        assertThat(capturedAuditDetail.getSubjectId()).isEqualTo("internal-user-id");
     }
 
     @Test
     void testLogAuditItem_additionalData_invalidJson() {
         final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setUserId("internal-user-id");
         activation.setApplication(new ApplicationEntity());
         activation.setActivationStatus(ActivationStatus.ACTIVE);
         activation.setAdditionalData("invalid json");
@@ -94,5 +97,6 @@ class ActivationHistoryServiceBehaviorTest {
 
         assertThat(capturedAuditDetail.getType()).isEqualTo("activation");
         assertThat(capturedAuditDetail.getParam().get("additionalData")).isNull();
+        assertThat(capturedAuditDetail.getSubjectId()).isEqualTo("internal-user-id");
     }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
@@ -111,5 +111,7 @@ class AuditingServiceBehaviorTest {
         signatureMetadata.setAuthDataMethod("POST");
         signatureMetadata.setAuthDataUriId("/pa/signature/validate");
         assertEquals(signatureMetadata, params.get("signatureMetadata"));
+
+        assertEquals("user789", auditDetail.getSubjectId());
     }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
@@ -111,5 +111,7 @@ class AuditingServiceBehaviorTest {
         authMetadata.setAuthDataMethod("POST");
         authMetadata.setAuthDataUriId("/pa/auth/validate");
         assertEquals(authMetadata, params.get("authenticationMetadata"));
+
+        assertEquals("user789", auditDetail.getSubjectId());
     }
 }

--- a/powerauth-java-server/src/test/resources/schema.sql
+++ b/powerauth-java-server/src/test/resources/schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS audit_log
     calling_class     VARCHAR(256) NOT NULL,
     thread_name       VARCHAR(256) NOT NULL,
     version           VARCHAR(256),
-    build_time        TIMESTAMP
+    build_time        TIMESTAMP,
+    subject_id        VARCHAR(256)
 );
 
 CREATE TABLE IF NOT EXISTS audit_param


### PR DESCRIPTION
See [Copilot overview](https://github.com/wultra/powerauth-server/pull/2301#pullrequestreview-4028939762).

The `subjectId` is set to `userId` in all PowerAuth Server generated audit log records.