### PR TITLE
Fix #2340: Explicit null check in AsymmetricSignatureService#computeSignaturesForActivation;; Remove unused local variable in ActivationStatusServiceBehavior

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationStatusServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/ActivationStatusServiceBehavior.java
@@ -122,7 +122,6 @@ public class ActivationStatusServiceBehavior {
             activationRemoveServiceBehavior.deactivatePendingActivation(timestamp, activation, false);
 
             final ApplicationEntity application = activation.getApplication();
-            final String applicationId = application.getId();
 
             // Build the common response fields shared across all activation states
             final GetActivationStatusResponse response = buildActivationDetailResponse(activation, application);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/AsymmetricSignatureService.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/crypto/AsymmetricSignatureService.java
@@ -33,6 +33,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.Map;
 
 /**
@@ -55,7 +56,7 @@ public class AsymmetricSignatureService {
      */
     public Map<String, String> computeSignaturesForActivation(ActivationRecordEntity activation) throws GenericServiceException {
         final ApplicationEntity application = activation.getApplication();
-        final String activationCode = activation.getActivationCode();
+        final String activationCode = Objects.requireNonNull(activation.getActivationCode(), "Activation code must not be null");
 
         final Map<String, String> signatures = new LinkedHashMap<>();
 


### PR DESCRIPTION
Fixes of Coverity issues.