### PR TITLE
Fix #2004: Drop pa_activation_code index before ALTER COLUMN on MSSQL

### DIFF
--- a/docs/PowerAuth-Server-2.1.0.md
+++ b/docs/PowerAuth-Server-2.1.0.md
@@ -34,15 +34,23 @@ The migration applies the following changes in order:
 
 1. **Backfill NULL `activation_code` values** _(legacy databases only)_ — if any rows have a `NULL` activation code, they are updated with a unique `LEGACY-<uuid>` placeholder value. This step is automatically **skipped** (marked as ran) if no NULL values exist, which is the expected case for all databases managed by Liquibase since 1.4.x.
 
-2. **Add `NOT NULL` constraint** on `activation_code` — aligns the DB schema with the JPA entity definition. This is a fast operation (metadata-only on MSSQL when no NULLs exist; full table scan on PostgreSQL and Oracle).
+2. _(MSSQL only)_ **Drop the old non-unique index** `pa_activation_code` — MSSQL blocks `ALTER COLUMN` when a dependent index exists. This step is automatically **skipped** on PostgreSQL and Oracle.
 
-3. **Add unique constraint** `pa_activation_code_application_uk` on `(activation_code, application_id)` — enforces activation code uniqueness at the database level per application, replacing the previous application-level check. **This is an index build and can take significant time on large tables** (see performance data below).
+3. **Add `NOT NULL` constraint** on `activation_code` — aligns the DB schema with the JPA entity definition. This is a fast operation (metadata-only on MSSQL when no NULLs exist; full table scan on PostgreSQL and Oracle).
 
-4. **Drop the old non-unique index** `pa_activation_code` on `activation_code` — replaced by the unique constraint above (near-instant operation).
+4. **Add unique constraint** `pa_activation_code_application_uk` on `(activation_code, application_id)` — enforces activation code uniqueness at the database level per application, replacing the previous application-level check. **This is an index build and can take significant time on large tables** (see performance data below).
+
+5. _(PostgreSQL, Oracle)_ **Drop the old non-unique index** `pa_activation_code` — replaced by the unique constraint above (near-instant operation). Automatically skipped on MSSQL (already dropped in step 2).
 
 > ⚠️ **Maintenance window recommended.**
-> Step 3 (index build) locks the table and can take several minutes on large deployments.
+> Step 4 (index build) locks the table and can take several minutes on large deployments.
 > Consider running the Liquibase migration manually during a maintenance window before upgrading the application.
+
+> ⚠️ **MSSQL: brief index gap during migration.**
+> On MSSQL, step 2 drops the old `pa_activation_code` index before the new unique constraint is created in step 4.
+> During this window, queries filtering on `activation_code` alone will perform a full table scan.
+> The gap is bounded by steps 3 and 4 only, which are fast operations on MSSQL (metadata-only NOT NULL + index build).
+> Plan the migration during a maintenance window to avoid query performance impact.
 
 > ⚠️ **Legacy databases with NULL `activation_code` values.**
 > Step 1 (backfill) will UPDATE any rows with NULL `activation_code`.

--- a/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
@@ -23,9 +23,12 @@
 
     <changeSet id="0" logicalFilePath="powerauth-java-server/2.1.x/20260316-activation-code-unique.xml" author="Vit Kotacka">
         <preConditions onFail="MARK_RAN">
-            <indexExists indexName="pa_activation_code"/>
+            <and>
+                <dbms type="mssql"/>
+                <indexExists indexName="pa_activation_code"/>
+            </and>
         </preConditions>
-        <comment>Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).</comment>
+        <comment>MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.</comment>
         <dropIndex tableName="pa_activation" indexName="pa_activation_code"/>
     </changeSet>
 

--- a/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
@@ -21,6 +21,14 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
+    <changeSet id="0" logicalFilePath="powerauth-java-server/2.1.x/20260316-activation-code-unique.xml" author="Vit Kotacka">
+        <preConditions onFail="MARK_RAN">
+            <indexExists indexName="pa_activation_code"/>
+        </preConditions>
+        <comment>Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).</comment>
+        <dropIndex tableName="pa_activation" indexName="pa_activation_code"/>
+    </changeSet>
+
     <changeSet id="1" logicalFilePath="powerauth-java-server/2.1.x/20260316-activation-code-unique.xml" author="Vit Kotacka">
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="pa_activation" columnName="activation_code"/>
@@ -45,7 +53,7 @@
         <preConditions onFail="MARK_RAN">
             <indexExists indexName="pa_activation_code"/>
         </preConditions>
-        <comment>Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk</comment>
+        <comment>Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.</comment>
         <dropIndex tableName="pa_activation" indexName="pa_activation_code"/>
     </changeSet>
 

--- a/docs/sql/mssql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/mssql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:04
+-- Ran at: 28.04.26 15:48
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -17,6 +17,11 @@ UPDATE pa_activation
             WHERE activation_code IS NULL;
 GO
 
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
+-- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+DROP INDEX pa_activation_code ON pa_activation;
+GO
+
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation ALTER COLUMN activation_code varchar(255) NOT NULL;
@@ -28,7 +33,7 @@ ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQU
 GO
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
+-- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
 DROP INDEX pa_activation_code ON pa_activation;
 GO
 
@@ -41,3 +46,4 @@ GO
 -- Create a new index on audit_log(subject_id)
 CREATE NONCLUSTERED INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 GO
+

--- a/docs/sql/mssql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/mssql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 28.04.26 15:48
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -18,7 +18,7 @@ UPDATE pa_activation
 GO
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
--- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+-- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
 DROP INDEX pa_activation_code ON pa_activation;
 GO
 

--- a/docs/sql/oracle/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/migration_2.0.0_2.1.0.sql
@@ -16,10 +16,6 @@ UPDATE pa_activation
             SET activation_code = 'LEGACY-' || LOWER(RAWTOHEX(SYS_GUID()))
             WHERE activation_code IS NULL;
 
--- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
--- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
-DROP INDEX pa_activation_code;
-
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation MODIFY activation_code NOT NULL;
@@ -29,7 +25,7 @@ ALTER TABLE pa_activation MODIFY activation_code NOT NULL;
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (activation_code, application_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
+-- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar

--- a/docs/sql/oracle/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:04
+-- Ran at: 28.04.26 15:48
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -16,6 +16,10 @@ UPDATE pa_activation
             SET activation_code = 'LEGACY-' || LOWER(RAWTOHEX(SYS_GUID()))
             WHERE activation_code IS NULL;
 
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
+-- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+DROP INDEX pa_activation_code;
+
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation MODIFY activation_code NOT NULL;
@@ -25,7 +29,7 @@ ALTER TABLE pa_activation MODIFY activation_code NOT NULL;
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (activation_code, application_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
+-- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
@@ -35,3 +39,4 @@ ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+

--- a/docs/sql/oracle/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 28.04.26 15:48
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -17,7 +17,7 @@ UPDATE pa_activation
             WHERE activation_code IS NULL;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
--- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+-- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka

--- a/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 28.04.26 15:48
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -17,7 +17,7 @@ UPDATE pa_activation
             WHERE activation_code IS NULL;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
--- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+-- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka

--- a/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
@@ -16,10 +16,6 @@ UPDATE pa_activation
             SET activation_code = 'LEGACY-' || gen_random_uuid()::text
             WHERE activation_code IS NULL;
 
--- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
--- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
-DROP INDEX pa_activation_code;
-
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation ALTER COLUMN  activation_code SET NOT NULL;
@@ -29,7 +25,7 @@ ALTER TABLE pa_activation ALTER COLUMN  activation_code SET NOT NULL;
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (activation_code, application_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
+-- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar

--- a/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:03
+-- Ran at: 28.04.26 15:48
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -16,6 +16,10 @@ UPDATE pa_activation
             SET activation_code = 'LEGACY-' || gen_random_uuid()::text
             WHERE activation_code IS NULL;
 
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
+-- Drop non-unique index pa_activation_code before modifying the column. Required on MSSQL which blocks ALTER COLUMN when a dependent index exists. On environments where id=1..3 already ran successfully, this is a no-op (MARK_RAN).
+DROP INDEX pa_activation_code;
+
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation ALTER COLUMN  activation_code SET NOT NULL;
@@ -25,7 +29,7 @@ ALTER TABLE pa_activation ALTER COLUMN  activation_code SET NOT NULL;
 ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQUE (activation_code, application_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
+-- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
 DROP INDEX pa_activation_code;
 
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::1::Pavel Sindelar
@@ -35,3 +39,4 @@ ALTER TABLE audit_log ADD subject_id VARCHAR(256);
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+


### PR DESCRIPTION
## Summary

Fix for MSSQL migration failure introduced by PR #2311.

## Problem

MSSQL error 5074: *"The index 'pa_activation_code' is dependent on column 'activation_code'."*

MSSQL blocks `ALTER COLUMN` on any column that has a dependent index — even when only adding `NOT NULL`. PostgreSQL and Oracle do not have this restriction.

## Fix

Added changeset `id=0` to drop the old non-unique index `pa_activation_code` **before** the `ALTER COLUMN` (changeset `id=1`).

Existing changesets `id=1..3` are **unchanged** to avoid re-running on environments where the migration already succeeded on PostgreSQL or Oracle (Liquibase tracks by `id + logicalFilePath + author`).

### New execution order
| Changeset | Operation |
|-----------|-----------|
| fix-nulls::1 | Backfill NULL activation_code (MARK_RAN if none) |
| unique::0 | **DROP INDEX** pa_activation_code (new — fixes MSSQL) |
| unique::1 | ADD NOT NULL on activation_code |
| unique::2 | ADD UNIQUE constraint (activation_code, application_id) |
| unique::3 | DROP INDEX pa_activation_code (safety net — MARK_RAN on fresh installs) |

### Behaviour on all scenarios
| Scenario | id=0 | id=1..3 |
|----------|------|---------|
| Fresh MSSQL | drops index ✅ | NOT NULL succeeds, UNIQUE added, id=3 MARK_RAN |
| Fresh PostgreSQL/Oracle | drops index ✅ | same as above |
| Already ran id=1..3 (PostgreSQL/Oracle) | MARK_RAN ✅ | skipped (already in DATABASECHANGELOG) |

## Files changed
- `docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml`
- `docs/sql/postgresql/migration_2.0.0_2.1.0.sql`
- `docs/sql/oracle/migration_2.0.0_2.1.0.sql`
- `docs/sql/mssql/migration_2.0.0_2.1.0.sql`