### PR TITLE
Fix #2004: Drop pa_activation_code index before ALTER COLUMN on MSSQL (backport)

### DIFF
--- a/docs/PowerAuth-Server-2.1.0.md
+++ b/docs/PowerAuth-Server-2.1.0.md
@@ -34,15 +34,23 @@ The migration applies the following changes in order:
 
 1. **Backfill NULL `activation_code` values** _(legacy databases only)_ — if any rows have a `NULL` activation code, they are updated with a unique `LEGACY-<uuid>` placeholder value. This step is automatically **skipped** (marked as ran) if no NULL values exist, which is the expected case for all databases managed by Liquibase since 1.4.x.
 
-2. **Add `NOT NULL` constraint** on `activation_code` — aligns the DB schema with the JPA entity definition. This is a fast operation (metadata-only on MSSQL when no NULLs exist; full table scan on PostgreSQL and Oracle).
+2. _(MSSQL only)_ **Drop the old non-unique index** `pa_activation_code` — MSSQL blocks `ALTER COLUMN` when a dependent index exists. This step is automatically **skipped** on PostgreSQL and Oracle.
 
-3. **Add unique constraint** `pa_activation_code_application_uk` on `(activation_code, application_id)` — enforces activation code uniqueness at the database level per application, replacing the previous application-level check. **This is an index build and can take significant time on large tables** (see performance data below).
+3. **Add `NOT NULL` constraint** on `activation_code` — aligns the DB schema with the JPA entity definition. This is a fast operation (metadata-only on MSSQL when no NULLs exist; full table scan on PostgreSQL and Oracle).
 
-4. **Drop the old non-unique index** `pa_activation_code` on `activation_code` — replaced by the unique constraint above (near-instant operation).
+4. **Add unique constraint** `pa_activation_code_application_uk` on `(activation_code, application_id)` — enforces activation code uniqueness at the database level per application, replacing the previous application-level check. **This is an index build and can take significant time on large tables** (see performance data below).
+
+5. _(PostgreSQL, Oracle)_ **Drop the old non-unique index** `pa_activation_code` — replaced by the unique constraint above (near-instant operation). Automatically skipped on MSSQL (already dropped in step 2).
 
 > ⚠️ **Maintenance window recommended.**
-> Step 3 (index build) locks the table and can take several minutes on large deployments.
+> Step 4 (index build) locks the table and can take several minutes on large deployments.
 > Consider running the Liquibase migration manually during a maintenance window before upgrading the application.
+
+> ⚠️ **MSSQL: brief index gap during migration.**
+> On MSSQL, step 2 drops the old `pa_activation_code` index before the new unique constraint is created in step 4.
+> During this window, queries filtering on `activation_code` alone will perform a full table scan.
+> The gap is bounded by steps 3 and 4 only, which are fast operations on MSSQL (metadata-only NOT NULL + index build).
+> Plan the migration during a maintenance window to avoid query performance impact.
 
 > ⚠️ **Legacy databases with NULL `activation_code` values.**
 > Step 1 (backfill) will UPDATE any rows with NULL `activation_code`.

--- a/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.1.x/20260316-activation-code-unique.xml
@@ -21,6 +21,17 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
 
+    <changeSet id="0" logicalFilePath="powerauth-java-server/2.1.x/20260316-activation-code-unique.xml" author="Vit Kotacka">
+        <preConditions onFail="MARK_RAN">
+            <and>
+                <dbms type="mssql"/>
+                <indexExists indexName="pa_activation_code"/>
+            </and>
+        </preConditions>
+        <comment>MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.</comment>
+        <dropIndex tableName="pa_activation" indexName="pa_activation_code"/>
+    </changeSet>
+
     <changeSet id="1" logicalFilePath="powerauth-java-server/2.1.x/20260316-activation-code-unique.xml" author="Vit Kotacka">
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="pa_activation" columnName="activation_code"/>
@@ -45,7 +56,7 @@
         <preConditions onFail="MARK_RAN">
             <indexExists indexName="pa_activation_code"/>
         </preConditions>
-        <comment>Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk</comment>
+        <comment>Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.</comment>
         <dropIndex tableName="pa_activation" indexName="pa_activation_code"/>
     </changeSet>
 

--- a/docs/sql/mssql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/mssql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:04
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -17,6 +17,11 @@ UPDATE pa_activation
             WHERE activation_code IS NULL;
 GO
 
+-- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
+-- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
+DROP INDEX pa_activation_code ON pa_activation;
+GO
+
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::1::Vit Kotacka
 -- Add NOT NULL constraint on pa_activation(activation_code) to align the DB schema with the JPA entity definition. Applied before the unique constraint to fail fast if NULL values exist, avoiding an expensive index build on dirty data.
 ALTER TABLE pa_activation ALTER COLUMN activation_code varchar(255) NOT NULL;
@@ -28,7 +33,7 @@ ALTER TABLE pa_activation ADD CONSTRAINT pa_activation_code_application_uk UNIQU
 GO
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::3::Vit Kotacka
--- Drop non-unique index on pa_activation(activation_code) replaced by unique constraint pa_activation_code_application_uk
+-- Safety-net drop of non-unique index pa_activation_code. Normally already dropped by id=0; this changeset is a no-op (MARK_RAN) on fresh installs but ensures correctness on environments that ran id=1..3 before id=0 was introduced.
 DROP INDEX pa_activation_code ON pa_activation;
 GO
 
@@ -41,3 +46,4 @@ GO
 -- Create a new index on audit_log(subject_id)
 CREATE NONCLUSTERED INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 GO
+

--- a/docs/sql/oracle/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/oracle/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:04
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -35,3 +35,4 @@ ALTER TABLE audit_log ADD subject_id VARCHAR2(256);
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+

--- a/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
+++ b/docs/sql/postgresql/migration_2.0.0_2.1.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.1.x/db.changelog-version.xml
--- Ran at: 08.04.26 12:03
+-- Ran at: 28.04.26 20:17
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -35,3 +35,4 @@ ALTER TABLE audit_log ADD subject_id VARCHAR(256);
 -- Changeset powerauth-java-server/2.1.x/20260327-audit-subject-id.xml::2::Pavel Sindelar
 -- Create a new index on audit_log(subject_id)
 CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
+


### PR DESCRIPTION
* Fix MSSQL migration: drop pa_activation_code index before ALTER COLUMN

MSSQL blocks ALTER COLUMN on a column with a dependent index (error 5074). Added changeset id=0 to drop the old non-unique index first. Existing changesets id=1..3 are unchanged to avoid re-running on environments where the migration already succeeded on PostgreSQL/Oracle.



* Restrict DROP INDEX changeset to MSSQL only

Changeset id=0 now uses <dbms type="mssql"/> precondition so it is skipped (MARK_RAN) on PostgreSQL and Oracle, which do not require dropping the index before ALTER COLUMN.



* Document MSSQL index gap and update migration step numbering

- Clarify that DROP INDEX (step 2) is MSSQL-only, skipped on PostgreSQL/Oracle
- Add warning about brief index gap on MSSQL between step 2 (drop) and step 4 (unique)
- Renumber steps to reflect actual execution order across all DBs



* Remove MSSQL-only changeset id=0 from PostgreSQL and Oracle migration SQL

Liquibase offline mode does not evaluate <dbms> preconditions, so changeset id=0 (DROP INDEX, MSSQL only) was incorrectly included in the PostgreSQL and Oracle reference SQL scripts. Removed manually.



---------


(cherry picked from commit 1eee10fe663b53c223728020307665290a4e0c5f)