### PR TITLE
fix #2386: isolate application config service test fixture

### DIFF
--- a/powerauth-java-server/src/test/resources/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigServiceTest.sql
+++ b/powerauth-java-server/src/test/resources/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigServiceTest.sql
@@ -1,5 +1,4 @@
 DELETE FROM pa_application_config WHERE application_id = 21;
-DELETE FROM pa_application WHERE id = 21;
 
-INSERT INTO pa_application (id, name) VALUES
+MERGE INTO pa_application (id, name) KEY(id) VALUES
     (21, 'PA_Tests');

--- a/powerauth-java-server/src/test/resources/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigServiceTest.sql
+++ b/powerauth-java-server/src/test/resources/com/wultra/security/powerauth/app/server/service/persistence/ApplicationConfigServiceTest.sql
@@ -1,2 +1,5 @@
+DELETE FROM pa_application_config WHERE application_id = 21;
+DELETE FROM pa_application WHERE id = 21;
+
 INSERT INTO pa_application (id, name) VALUES
     (21, 'PA_Tests');


### PR DESCRIPTION
## Description

This change makes the `ApplicationConfigServiceTest` SQL fixture independent from previous executions in the same test database.

The fixture prepares a clean test state for the application configuration scenario before inserting the application row used by the test. The cleanup is intentionally scoped to this test fixture so it does not affect unrelated test data.

## Motivation and Context

The `Test with Maven` workflow for PR #2385 fails in `ApplicationConfigServiceTest$Encrypted` with an H2 primary-key violation:

```text
Unique index or primary key violation on PUBLIC.PA_APPLICATION(ID), key: 21
```

The failure is not related to the Lombok annotation processor change in PR #2385. The affected test class has two nested Spring test contexts, `Encrypted` and `Plain`, and both load the same SQL fixture with `@Sql("ApplicationConfigServiceTest.sql")`.

The test profile uses a named in-memory H2 database with `DB_CLOSE_ON_EXIT=FALSE`. As a result, these nested test contexts can observe state prepared by a previous execution of the same fixture. When the fixture is executed again, the application row expected by the test may already exist, which causes the duplicate primary-key failure seen in CI.

Making the fixture self-isolating keeps the test independent of context execution order and prevents this CI-only collision while preserving the behavior covered by the test.

## Testing

The focused test passes locally:

```bash
mvn -pl powerauth-java-server test -Dtest=ApplicationConfigServiceTest
```

## Notes

No production code is changed. The fix is limited to the test fixture used by `ApplicationConfigServiceTest`.

Closes #2386
