### PR TITLE
Fix #2393: Define signature column length for tests

### DIFF
--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
@@ -106,7 +106,7 @@ public class SignatureEntity implements Serializable {
     /**
      * Signature.
      */
-    @Column(name = "signature", nullable = false, updatable = false)
+    @Column(name = "signature", nullable = false, updatable = false, length = 8000)
     private String signature;
 
     /**


### PR DESCRIPTION
The `signature` column length should be set for tests which use H2 database.