### PR TITLE
fix #2398: consolidate changelog and add copilot changelog instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,48 @@
+# Copilot Instructions — powerauth-server
+
+This file captures conventions used when working with GitHub Copilot in the
+`powerauth-server` repository and the broader Wultra PowerAuth ecosystem.
+
+---
+
+## Changelog
+
+`CHANGELOG.md` lives at the **repo root**. Update it as part of every PR — before
+creating the PR, not after merge.
+
+### Format
+
+Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+
+```markdown
+# Changelog
+
+## X.Y.Z (TBA)
+### Added
+- New feature description [(#N)](https://github.com/wultra/powerauth-server/issues/N)
+
+### Changed
+- Changed behaviour description [(#N)](...)
+
+### Fixed
+- Bug fix description [(#N)](...)
+
+## 1.2.3 - 2025-03-01
+### Added
+- ...
+```
+
+**Change type subsections** (use only those that apply):
+- `Added` — new features
+- `Changed` — changes in existing functionality
+- `Deprecated` — soon-to-be removed features
+- `Removed` — removed features
+- `Fixed` — bug fixes
+- `Security` — security vulnerability fixes
+
+**Rules:**
+- Always add new entries under `## X.Y.Z (TBA)` (the unreleased section at the top).
+- On release, rename `## X.Y.Z (TBA)` to `## x.y.z - YYYY-MM-DD` (ISO 8601 date).
+- Each entry: `- <Description starting with verb> [(#N)](url)` — link to the issue, not the PR.
+- Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when application list is empty" not "fix #811: add missing import").
+- Skip the Changelog update only for changes with no user-visible impact (e.g. pure CI/tooling changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2.2.0 (TBA)
+### Added
+- Temporary block of activation [(#2390)](https://github.com/wultra/powerauth-server/issues/2390)
+
+### Changed
+- Consolidated `CHANGELOG.md` to Keep a Changelog 1.1.0 format and added Copilot changelog instructions [(#2398)](https://github.com/wultra/powerauth-server/issues/2398)
+- Migrated to Spring Boot 4 and Jackson 3 [(#2379)](https://github.com/wultra/powerauth-server/issues/2379)
+- Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(#2396)](https://github.com/wultra/powerauth-server/issues/2396)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,0 @@
-# Changelog
-
-## 2.2.0
-- [#2379](https://github.com/wultra/powerauth-server/issues/2379) - Migrated to Spring Boot 4 and Jackson 3.
-- [#2390](https://github.com/wultra/powerauth-server/issues/2390) - Temporary block of activation.
-- [#2396](https://github.com/wultra/powerauth-server/issues/2396) - Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) 


### PR DESCRIPTION
🤖

## Description
Consolidate the root CHANGELOG.md into Keep a Changelog 1.1.0 format (rename Changelog.md → CHANGELOG.md, group entries into change-type subsections) and add .github/copilot-instructions.md documenting the changelog conventions, adapted from the iap-server canonical reference with powerauth-server repository name and issue URLs.

## Motivation and Context
Aligns powerauth-server with the Wultra changelog and Copilot conventions defined in the parent epic wultra/tasklist#986.

## Closes
Closes #2398
