### PR TITLE
fix #2398: align changelog with strict keep a changelog 1.1.0 format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,12 +12,20 @@ creating the PR, not after merge.
 
 ### Format
 
-Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
+Strictly follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
+The file starts with the canonical header (mentioning both Keep a Changelog and
+Semantic Versioning), keeps an `## [Unreleased]` section at the top, and makes
+every version linkable via reference-style links at the bottom:
 
 ```markdown
 # Changelog
 
-## X.Y.Z (TBA)
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 ### Added
 - New feature description [(#N)](https://github.com/wultra/powerauth-server/issues/N)
 
@@ -27,9 +35,12 @@ Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
 ### Fixed
 - Bug fix description [(#N)](...)
 
-## 1.2.3 - 2025-03-01
+## [1.2.3] - 2025-03-01
 ### Added
 - ...
+
+[unreleased]: https://github.com/wultra/powerauth-server/compare/1.2.3...HEAD
+[1.2.3]: https://github.com/wultra/powerauth-server/compare/1.2.2...1.2.3
 ```
 
 **Change type subsections** (use only those that apply):
@@ -41,8 +52,10 @@ Follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/):
 - `Security` — security vulnerability fixes
 
 **Rules:**
-- Always add new entries under `## X.Y.Z (TBA)` (the unreleased section at the top).
-- On release, rename `## X.Y.Z (TBA)` to `## x.y.z - YYYY-MM-DD` (ISO 8601 date).
+- The header must mention both [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+- Always add new entries under the `## [Unreleased]` section at the top.
+- On release, rename `## [Unreleased]` to `## [x.y.z] - YYYY-MM-DD` (ISO 8601 date), add a fresh empty `## [Unreleased]` above it, update the `[unreleased]` reference link, and add the new version's compare link.
+- Versions and sections must be linkable via reference-style links at the bottom of the file.
 - Each entry: `- <Description starting with verb> [(#N)](url)` — link to the issue, not the PR.
 - Descriptions should be human-readable, not raw commit messages (e.g. "Fixed NPE when application list is empty" not "fix #811: add missing import").
 - Skip the Changelog update only for changes with no user-visible impact (e.g. pure CI/tooling changes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
-## 2.2.0 (TBA)
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 ### Added
 - Temporary block of activation [(#2390)](https://github.com/wultra/powerauth-server/issues/2390)
 
 ### Changed
-- Consolidated `CHANGELOG.md` to Keep a Changelog 1.1.0 format and added Copilot changelog instructions [(#2398)](https://github.com/wultra/powerauth-server/issues/2398)
+- Consolidated `CHANGELOG.md` to the strict Keep a Changelog 1.1.0 format and added Copilot changelog instructions [(#2398)](https://github.com/wultra/powerauth-server/issues/2398)
 - Migrated to Spring Boot 4 and Jackson 3 [(#2379)](https://github.com/wultra/powerauth-server/issues/2379)
 - Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(#2396)](https://github.com/wultra/powerauth-server/issues/2396)
+
+[unreleased]: https://github.com/wultra/powerauth-server/compare/2.1.0...HEAD


### PR DESCRIPTION
🤖

## Description
Re-align the root `CHANGELOG.md` with the **strict** Keep a Changelog 1.1.0 format mandated by the parent epic (`wultra/tasklist#986`):
- Add the canonical header mentioning both Keep a Changelog and Semantic Versioning.
- Replace `## 2.2.0 (TBA)` with a `## [Unreleased]` section.
- Add reference-style version links at the bottom (`[unreleased]: .../compare/2.1.0...HEAD`).

Update `.github/copilot-instructions.md` Changelog section to document the strict format (canonical header, `## [Unreleased]`, linkable version headings, SemVer mention, updated release/rename procedure).

## Motivation and Context
The first implementation (#2399) used an earlier draft convention. Epic `wultra/tasklist#986` now mandates the strict Keep a Changelog 1.1.0 format, so this sub-issue was reopened for re-alignment.

## Closes
Closes #2398
