### PR TITLE
Fix #2422: Separate auditing for authentication code and asymmetric signatures

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -186,7 +186,8 @@ Stores the records with values used for attempts for the signature validation.
 | additional_info     | VARCHAR(255) | -                                          | Additional information related to the signature request in JSON format.   |
 | data_base64         | TEXT         | -                                          | Data passed as the base for the signature, encoded as Base64.             |
 | signature_type      | VARCHAR(255) | -                                          | Requested type of the signature.                                          |
-| signature           | VARCHAR(8000)| -                                          | Provided value of the signature.                                          |
+| auth_code           | VARCHAR(255) | -                                          | Provided value of the authentication code (symmetric records). Null for asymmetric-signature records. |
+| signature_asymmetric | TEXT        | -                                          | Provided value of the asymmetric signature (ECDSA, ML-DSA), stored as CLOB. Null for symmetric authentication-code records. |
 | signature_algorithm | VARCHAR(32)  | -                                          | Algorithm used for the signature (symmetric: `PowerAuth-V3`, or `PowerAuth-V4`; asymmetric: `ECDSA_P256`, `ECDSA_P384`, `MLDSA_65`, or `MLDSA_87`). |
 | signature_format    | VARCHAR(32)  | -                                          | Format of the signature (symmetric: `DECIMAL`, or `BASE64`; asymmetric: `DER` or `JOSE`). |
 | signature_metadata  | TEXT         | -                                          | JSON with signature metadata related to the signature calculation.        |

--- a/docs/PowerAuth-Server-2.2.0.md
+++ b/docs/PowerAuth-Server-2.2.0.md
@@ -9,7 +9,9 @@ For convenience, you can use Liquibase for the database migration.
 The database table `pa_signature_audit` has been extended with new columns used for asymmetric signatures:
 - column `signature_algorithm` with type `VARCHAR(32)` - algorithm used for the signature (symmetric: `PowerAuth-V3`, or `PowerAuth-V4`; asymmetric: `ECDSA_P256`, `ECDSA_P384`, `MLDSA_65`, or `MLDSA_87`)
 - column `signature_format` with type `varchar(32)` - format of the signature (symmetric: `DECIMAL`, or `BASE64`; asymmetric: `DER` or `JOSE`)
-- column `signature` type was changed to `VARCHAR(8000)` to accommodate larger PQC signatures
+- column `signature_asymmetric` with type `CLOB` - value of the asymmetric signature (ECDSA, ML-DSA); stored as `CLOB`
+
+The existing `signature` column has been renamed to `auth_code` and made nullable. It stores the authentication code for symmetric records (PowerAuth v3/v4); asymmetric-signature records leave it `NULL` and store their value in `signature_asymmetric` instead. Existing rows keep their value under the new `auth_code` name.
 
 ### Table `pa_activation`
 

--- a/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml
@@ -47,8 +47,31 @@
     </changeSet>
 
     <changeSet id="3" logicalFilePath="powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml" author="Roman Strobl">
-        <comment>Change data type of signature column in pa_signature_audit table from varchar(255) to varchar(8000) to support longer asymmetric signatures</comment>
-        <modifyDataType tableName="pa_signature_audit" columnName="signature" newDataType="varchar(8000)"/>
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="pa_signature_audit" columnName="signature_asymmetric"/>
+            </not>
+        </preConditions>
+        <comment>Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)</comment>
+        <addColumn tableName="pa_signature_audit">
+            <column name="signature_asymmetric" type="clob"/>
+        </addColumn>
+    </changeSet>
+
+    <changeSet id="4" logicalFilePath="powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="pa_signature_audit" columnName="signature"/>
+        </preConditions>
+        <comment>Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology</comment>
+        <renameColumn tableName="pa_signature_audit" oldColumnName="signature" newColumnName="auth_code" columnDataType="varchar(255)"/>
+    </changeSet>
+
+    <changeSet id="5" logicalFilePath="powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml" author="Roman Strobl">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="pa_signature_audit" columnName="auth_code"/>
+        </preConditions>
+        <comment>Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null</comment>
+        <dropNotNullConstraint tableName="pa_signature_audit" columnName="auth_code" columnDataType="varchar(255)"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/docs/sql/mssql/create_schema.sql
+++ b/docs/sql/mssql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 5/18/26, 1:18 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -695,8 +695,8 @@ GO
 --             NULL values are present, which is the expected case for all non-legacy databases.
 --             Rollback is not supported — original NULL values cannot be restored.
 UPDATE pa_activation
-SET activation_code = 'LEGACY-' + LOWER(CONVERT(varchar(36), NEWID()))
-WHERE activation_code IS NULL;
+            SET activation_code = 'LEGACY-' + LOWER(CONVERT(varchar(36), NEWID()))
+            WHERE activation_code IS NULL;
 GO
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
@@ -731,7 +731,7 @@ GO
 
 -- Changeset powerauth-java-server/2.1.x/20260416-add-tag-2.1.0.xml::1::Pavel Sindelar
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm varchar(32);
 GO
 
@@ -741,8 +741,18 @@ ALTER TABLE pa_signature_audit ADD signature_format varchar(32);
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to text to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit ALTER COLUMN signature varchar (max);
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric varchar(MAX);
+GO
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+exec sp_rename 'pa_signature_audit.signature', 'auth_code', 'COLUMN';
+GO
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit ALTER COLUMN auth_code varchar(255) NULL;
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
@@ -760,10 +770,9 @@ GO
 CREATE NONCLUSTERED INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire) WHERE timestamp_block_expire IS NOT NULL;
 GO
 
-
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
-CREATE TABLE pa_config_store (id bigint NOT NULL, application_id int NOT NULL, activation_id varchar(37), config_scope varchar(32) NOT NULL, config_data varchar (max), encryption_mode varchar(255) CONSTRAINT DF_pa_config_store_encryption_mode DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created datetime2(6) NOT NULL, timestamp_last_updated datetime2(6), CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
+CREATE TABLE pa_config_store (id bigint NOT NULL, application_id int NOT NULL, activation_id varchar(37), config_scope varchar(32) NOT NULL, config_data varchar(MAX), encryption_mode varchar(255) CONSTRAINT DF_pa_config_store_encryption_mode DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created datetime2 NOT NULL, timestamp_last_updated datetime2, CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::2::Roman Strobl
@@ -785,3 +794,4 @@ GO
 -- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE NONCLUSTERED INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
 GO
+

--- a/docs/sql/mssql/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/mssql/migration_2.1.0_2.2.0.sql
@@ -2,13 +2,13 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 5/11/26, 12:51 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm varchar(32);
 GO
 
@@ -18,8 +18,18 @@ ALTER TABLE pa_signature_audit ADD signature_format varchar(32);
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to varchar(8000) to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit ALTER COLUMN signature varchar(8000);
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric varchar(MAX);
+GO
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+exec sp_rename 'pa_signature_audit.signature', 'auth_code', 'COLUMN';
+GO
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit ALTER COLUMN auth_code varchar(255) NULL;
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
@@ -37,10 +47,9 @@ GO
 CREATE NONCLUSTERED INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire) WHERE timestamp_block_expire IS NOT NULL;
 GO
 
-
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
-CREATE TABLE pa_config_store (id bigint NOT NULL, application_id int NOT NULL, activation_id varchar(37), config_scope varchar(32) NOT NULL, config_data varchar (max), encryption_mode varchar(255) CONSTRAINT DF_pa_config_store_encryption_mode DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created datetime2(6) NOT NULL, timestamp_last_updated datetime2(6), CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
+CREATE TABLE pa_config_store (id bigint NOT NULL, application_id int NOT NULL, activation_id varchar(37), config_scope varchar(32) NOT NULL, config_data varchar(MAX), encryption_mode varchar(255) CONSTRAINT DF_pa_config_store_encryption_mode DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created datetime2 NOT NULL, timestamp_last_updated datetime2, CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::2::Roman Strobl
@@ -62,3 +71,4 @@ GO
 -- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE NONCLUSTERED INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
 GO
+

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 5/18/26, 1:17 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -93,7 +93,7 @@ CREATE TABLE pa_master_keypair (id INTEGER NOT NULL, application_id INTEGER NOT 
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::12::Lubos Racansky
 -- Create a new table pa_activation
-CREATE TABLE pa_activation (activation_id VARCHAR2(37) NOT NULL, application_id INTEGER NOT NULL, user_id VARCHAR2(255) NOT NULL, activation_name VARCHAR2(255), activation_code VARCHAR2(255), activation_status INTEGER NOT NULL, activation_otp VARCHAR2(255), activation_otp_validation INTEGER DEFAULT 0 NOT NULL, blocked_reason VARCHAR2(255), counter INTEGER NOT NULL, ctr_data VARCHAR2(255), device_public_key_base64 VARCHAR2(255), extras VARCHAR2(255), platform VARCHAR2(255), device_info VARCHAR2(255), flags VARCHAR2(255), failed_attempts INTEGER NOT NULL, max_failed_attempts INTEGER DEFAULT 5 NOT NULL, server_private_key_base64 VARCHAR2(255) NOT NULL, server_private_key_encryption INTEGER DEFAULT 0 NOT NULL, server_public_key_base64 VARCHAR2(255) NOT NULL, timestamp_activation_expire TIMESTAMP(6) NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, timestamp_last_used TIMESTAMP(6) NOT NULL, timestamp_last_change TIMESTAMP(6), master_keypair_id INTEGER, version INTEGER DEFAULT 2, CONSTRAINT PK_PA_ACTIVATION PRIMARY KEY (activation_id), CONSTRAINT activation_keypair_fk FOREIGN KEY (master_keypair_id) REFERENCES pa_master_keypair(id), CONSTRAINT activation_application_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
+CREATE TABLE pa_activation (activation_id VARCHAR2(37) NOT NULL, application_id INTEGER NOT NULL, user_id VARCHAR2(255) NOT NULL, activation_name VARCHAR2(255), activation_code VARCHAR2(255), activation_status INTEGER NOT NULL, activation_otp VARCHAR2(255), activation_otp_validation INTEGER DEFAULT 0 NOT NULL, blocked_reason VARCHAR2(255), counter INTEGER NOT NULL, ctr_data VARCHAR2(255), device_public_key_base64 VARCHAR2(255), extras VARCHAR2(255), platform VARCHAR2(255), device_info VARCHAR2(255), flags VARCHAR2(255), failed_attempts INTEGER NOT NULL, max_failed_attempts INTEGER DEFAULT 5 NOT NULL, server_private_key_base64 VARCHAR2(255) NOT NULL, server_private_key_encryption INTEGER DEFAULT 0 NOT NULL, server_public_key_base64 VARCHAR2(255) NOT NULL, timestamp_activation_expire TIMESTAMP(6) NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, timestamp_last_used TIMESTAMP(6) NOT NULL, timestamp_last_change TIMESTAMP(6), master_keypair_id INTEGER, version INTEGER DEFAULT 2, CONSTRAINT PK_PA_ACTIVATION PRIMARY KEY (activation_id), CONSTRAINT activation_application_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT activation_keypair_fk FOREIGN KEY (master_keypair_id) REFERENCES pa_master_keypair(id));
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::13::Lubos Racansky
 -- Create a new table pa_application_version
@@ -552,8 +552,8 @@ ALTER TABLE pa_activation ADD activation_fingerprint VARCHAR2(255);
 --             NULL values are present, which is the expected case for all non-legacy databases.
 --             Rollback is not supported — original NULL values cannot be restored.
 UPDATE pa_activation
-SET activation_code = 'LEGACY-' || LOWER(RAWTOHEX(SYS_GUID()))
-WHERE activation_code IS NULL;
+            SET activation_code = 'LEGACY-' || LOWER(RAWTOHEX(SYS_GUID()))
+            WHERE activation_code IS NULL;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
 -- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
@@ -581,7 +581,7 @@ CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260416-add-tag-2.1.0.xml::1::Pavel Sindelar
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR2(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::2::Roman Strobl
@@ -589,8 +589,16 @@ ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR2(32);
 ALTER TABLE pa_signature_audit ADD signature_format VARCHAR2(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to text to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit MODIFY signature CLOB;
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric CLOB;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit MODIFY auth_code NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations
@@ -604,10 +612,9 @@ ALTER TABLE pa_activation ADD temporary_block_count NUMBER(38, 0) DEFAULT 0 NOT 
 -- Create a partial index on pa_activation(timestamp_block_expire) to support the scheduled expiration of temporary activation blocks (on Oracle a plain single-column index achieves the same effect, since all-null keys are not indexed)
 CREATE INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire);
 
-
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
-CREATE TABLE pa_config_store (id NUMBER(38, 0) NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR2(37), config_scope VARCHAR2(32) NOT NULL, config_data CLOB, encryption_mode VARCHAR2(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, timestamp_last_updated TIMESTAMP(6), CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
+CREATE TABLE pa_config_store (id NUMBER(38, 0) NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR2(37), config_scope VARCHAR2(32) NOT NULL, config_data CLOB, encryption_mode VARCHAR2(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP NOT NULL, timestamp_last_updated TIMESTAMP, CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::2::Roman Strobl
 -- Create a new sequence pa_config_store_seq
@@ -624,3 +631,4 @@ CREATE INDEX pa_config_store_activation_id_idx ON pa_config_store(activation_id)
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::5::Roman Strobl
 -- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
+

--- a/docs/sql/oracle/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/oracle/migration_2.1.0_2.2.0.sql
@@ -2,13 +2,13 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 5/11/26, 12:49 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR2(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::2::Roman Strobl
@@ -16,8 +16,16 @@ ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR2(32);
 ALTER TABLE pa_signature_audit ADD signature_format VARCHAR2(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to varchar(8000) to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit MODIFY signature VARCHAR2(8000);
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric CLOB;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit MODIFY auth_code NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations
@@ -31,10 +39,9 @@ ALTER TABLE pa_activation ADD temporary_block_count NUMBER(38, 0) DEFAULT 0 NOT 
 -- Create a partial index on pa_activation(timestamp_block_expire) to support the scheduled expiration of temporary activation blocks (on Oracle a plain single-column index achieves the same effect, since all-null keys are not indexed)
 CREATE INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire);
 
-
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
-CREATE TABLE pa_config_store (id NUMBER(38, 0) NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR2(37), config_scope VARCHAR2(32) NOT NULL, config_data CLOB, encryption_mode VARCHAR2(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP(6) NOT NULL, timestamp_last_updated TIMESTAMP(6), CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
+CREATE TABLE pa_config_store (id NUMBER(38, 0) NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR2(37), config_scope VARCHAR2(32) NOT NULL, config_data CLOB, encryption_mode VARCHAR2(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP NOT NULL, timestamp_last_updated TIMESTAMP, CONSTRAINT PK_PA_CONFIG_STORE PRIMARY KEY (id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::2::Roman Strobl
 -- Create a new sequence pa_config_store_seq
@@ -51,3 +58,4 @@ CREATE INDEX pa_config_store_activation_id_idx ON pa_config_store(activation_id)
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::5::Roman Strobl
 -- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
+

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 5/18/26, 1:16 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -121,7 +121,7 @@ CREATE TABLE pa_activation_history (id BIGINT NOT NULL, activation_id VARCHAR(37
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::19::Lubos Racansky
 -- Create a new table pa_recovery_code
-CREATE TABLE pa_recovery_code (id BIGINT NOT NULL, recovery_code VARCHAR(23) NOT NULL, application_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL, activation_id VARCHAR(37), status INTEGER NOT NULL, failed_attempts INTEGER DEFAULT 0 NOT NULL, max_failed_attempts INTEGER DEFAULT 10 NOT NULL, timestamp_created TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, timestamp_last_used TIMESTAMP(6) WITHOUT TIME ZONE, timestamp_last_change TIMESTAMP(6) WITHOUT TIME ZONE, CONSTRAINT pa_recovery_code_pkey PRIMARY KEY (id), CONSTRAINT recovery_code_activation_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id), CONSTRAINT recovery_code_application_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
+CREATE TABLE pa_recovery_code (id BIGINT NOT NULL, recovery_code VARCHAR(23) NOT NULL, application_id INTEGER NOT NULL, user_id VARCHAR(255) NOT NULL, activation_id VARCHAR(37), status INTEGER NOT NULL, failed_attempts INTEGER DEFAULT 0 NOT NULL, max_failed_attempts INTEGER DEFAULT 10 NOT NULL, timestamp_created TIMESTAMP(6) WITHOUT TIME ZONE NOT NULL, timestamp_last_used TIMESTAMP(6) WITHOUT TIME ZONE, timestamp_last_change TIMESTAMP(6) WITHOUT TIME ZONE, CONSTRAINT pa_recovery_code_pkey PRIMARY KEY (id), CONSTRAINT recovery_code_application_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT recovery_code_activation_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
 
 -- Changeset powerauth-java-server/1.4.x/20230322-init-db.xml::20::Lubos Racansky
 -- Create a new table pa_recovery_puk
@@ -552,8 +552,8 @@ ALTER TABLE pa_activation ADD activation_fingerprint VARCHAR(255);
 --             NULL values are present, which is the expected case for all non-legacy databases.
 --             Rollback is not supported — original NULL values cannot be restored.
 UPDATE pa_activation
-SET activation_code = 'LEGACY-' || gen_random_uuid()::text
-WHERE activation_code IS NULL;
+            SET activation_code = 'LEGACY-' || gen_random_uuid()::text
+            WHERE activation_code IS NULL;
 
 -- Changeset powerauth-java-server/2.1.x/20260316-activation-code-unique.xml::0::Vit Kotacka
 -- MSSQL only: drop non-unique index pa_activation_code before ALTER COLUMN. MSSQL blocks ALTER COLUMN when a dependent index exists (error 5074); PostgreSQL and Oracle do not have this restriction.
@@ -581,7 +581,7 @@ CREATE INDEX audit_log_subject_id_idx ON audit_log(subject_id);
 
 -- Changeset powerauth-java-server/2.1.x/20260416-add-tag-2.1.0.xml::1::Pavel Sindelar
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::2::Roman Strobl
@@ -589,8 +589,16 @@ ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR(32);
 ALTER TABLE pa_signature_audit ADD signature_format VARCHAR(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to text to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit ALTER COLUMN signature TYPE TEXT USING (signature::TEXT);
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric TEXT;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit ALTER COLUMN  auth_code DROP NOT NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations
@@ -603,7 +611,6 @@ ALTER TABLE pa_activation ADD temporary_block_count BIGINT DEFAULT 0 NOT NULL;
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::3::Roman Strobl
 -- Create a partial index on pa_activation(timestamp_block_expire) to support the scheduled expiration of temporary activation blocks (on Oracle a plain single-column index achieves the same effect, since all-null keys are not indexed)
 CREATE INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire) WHERE timestamp_block_expire IS NOT NULL;
-
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
@@ -622,5 +629,6 @@ CREATE INDEX pa_config_store_application_id_idx ON pa_config_store(application_i
 CREATE INDEX pa_config_store_activation_id_idx ON pa_config_store(activation_id);
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::5::Roman Strobl
--- Create a unique index on pa_config_store(application_id, activation_id, config_scope). For per-device records (activation_id IS NOT NULL) this enforces at most one document per activation on every database.
+-- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
+

--- a/docs/sql/postgresql/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/postgresql/migration_2.1.0_2.2.0.sql
@@ -2,13 +2,13 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 5/11/26, 12:46 PM
+-- Ran at: 07/07/2026, 21:11
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::1::Roman Strobl
--- Add signature_algorithm column to pa_signature_audit table to store signature algorithm
+-- Add signature_algorithm column to pa_signature_audit table to store the signature algorithm
 ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::2::Roman Strobl
@@ -16,8 +16,16 @@ ALTER TABLE pa_signature_audit ADD signature_algorithm VARCHAR(32);
 ALTER TABLE pa_signature_audit ADD signature_format VARCHAR(32);
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::3::Roman Strobl
--- Change data type of signature column in pa_signature_audit table from varchar(255) to varchar(8000) to support longer asymmetric signatures
-ALTER TABLE pa_signature_audit ALTER COLUMN signature TYPE VARCHAR(8000) USING (signature::VARCHAR(8000));
+-- Add signature_asymmetric CLOB column to pa_signature_audit table to store asymmetric signatures (ECDSA, ML-DSA)
+ALTER TABLE pa_signature_audit ADD signature_asymmetric TEXT;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
+-- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
+ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
+
+-- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
+-- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
+ALTER TABLE pa_signature_audit ALTER COLUMN  auth_code DROP NOT NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations
@@ -31,10 +39,9 @@ ALTER TABLE pa_activation ADD temporary_block_count BIGINT DEFAULT 0 NOT NULL;
 -- Create a partial index on pa_activation(timestamp_block_expire) to support the scheduled expiration of temporary activation blocks (on Oracle a plain single-column index achieves the same effect, since all-null keys are not indexed)
 CREATE INDEX pa_activation_block_expire_idx ON pa_activation(timestamp_block_expire) WHERE timestamp_block_expire IS NOT NULL;
 
-
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::1::Roman Strobl
 -- Create a new table pa_config_store
-CREATE TABLE pa_config_store (id BIGINT NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR(37), config_scope VARCHAR(32) NOT NULL, config_data TEXT, encryption_mode VARCHAR(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP WITHOUT TIME ZONE NOT NULL, timestamp_last_updated TIMESTAMP WITHOUT TIME ZONE, CONSTRAINT pa_config_store_pkey PRIMARY KEY (id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id));
+CREATE TABLE pa_config_store (id BIGINT NOT NULL, application_id INTEGER NOT NULL, activation_id VARCHAR(37), config_scope VARCHAR(32) NOT NULL, config_data TEXT, encryption_mode VARCHAR(255) DEFAULT 'NO_ENCRYPTION' NOT NULL, timestamp_created TIMESTAMP WITHOUT TIME ZONE NOT NULL, timestamp_last_updated TIMESTAMP WITHOUT TIME ZONE, CONSTRAINT pa_config_store_pkey PRIMARY KEY (id), CONSTRAINT pa_config_store_activation_id_fk FOREIGN KEY (activation_id) REFERENCES pa_activation(activation_id), CONSTRAINT pa_config_store_application_id_fk FOREIGN KEY (application_id) REFERENCES pa_application(id));
 
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::2::Roman Strobl
 -- Create a new sequence pa_config_store_seq
@@ -51,3 +58,4 @@ CREATE INDEX pa_config_store_activation_id_idx ON pa_config_store(activation_id)
 -- Changeset powerauth-java-server/2.2.x/20260602-config-store.xml::5::Roman Strobl
 -- Create a unique index on pa_config_store(application_id, activation_id, config_scope).
 CREATE UNIQUE INDEX pa_config_store_application_id_activation_id_config_scope_idx ON pa_config_store(application_id, activation_id, config_scope);
+

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
@@ -230,7 +230,7 @@ public class SignatureEntity implements Serializable {
 
     @Override
     public String toString() {
-        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", signatureType=" + signatureType + ", authCode=" + authCode + ", signatureAsymmetric=" + signatureAsymmetric + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
+        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", signatureType=" + signatureType + ", authCodePresent=" + (authCode != null) + ", signatureAsymmetricLength=" + (signatureAsymmetric != null ? signatureAsymmetric.length() : 0) + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
@@ -104,10 +104,18 @@ public class SignatureEntity implements Serializable {
     private String signatureType;
 
     /**
-     * Signature.
+     * Authentication code. Populated for PowerAuth v3/v4 authentication-code records;
+     * null for asymmetric-signature records (which use {@link #signatureAsymmetric}).
      */
-    @Column(name = "signature", nullable = false, updatable = false, length = 8000)
-    private String signature;
+    @Column(name = "auth_code", updatable = false)
+    private String authCode;
+
+    /**
+     * Asymmetric signature (ECDSA, ML-DSA) stored as CLOB. Mutually exclusive with {@link #authCode}:
+     * authentication-code records populate {@code authCode}; asymmetric records populate {@code signatureAsymmetric}.
+     */
+    @Column(name = "signature_asymmetric", updatable = false, columnDefinition = "CLOB")
+    private String signatureAsymmetric;
 
     /**
      * Signature metadata associated with this signature.
@@ -158,6 +166,18 @@ public class SignatureEntity implements Serializable {
     @Column(name = "timestamp_created", nullable = false)
     private Date timestampCreated;
 
+    /**
+     * Return the audit value associated with this record: the authentication code for
+     * PowerAuth v3/v4 records, or the asymmetric signature (ECDSA, ML-DSA) for asymmetric records.
+     * These two are mutually exclusive.
+     *
+     * @return Authentication code if present, otherwise the asymmetric signature.
+     */
+    @Transient
+    public String getAuditedSignature() {
+        return authCode != null ? authCode : signatureAsymmetric;
+    }
+
     @Override
     public int hashCode() {
         int hash = 7;
@@ -167,7 +187,8 @@ public class SignatureEntity implements Serializable {
         hash = 23 * hash + Objects.hashCode(this.activationStatus);
         hash = 23 * hash + Objects.hashCode(this.dataBase64);
         hash = 23 * hash + Objects.hashCode(this.signatureType);
-        hash = 23 * hash + Objects.hashCode(this.signature);
+        hash = 23 * hash + Objects.hashCode(this.authCode);
+        hash = 23 * hash + Objects.hashCode(this.signatureAsymmetric);
         hash = 23 * hash + Objects.hashCode(this.signatureMetadata);
         hash = 23 * hash + Objects.hashCode(this.signatureDataBody);
         hash = 23 * hash + Objects.hashCode(this.additionalInfo);
@@ -192,7 +213,8 @@ public class SignatureEntity implements Serializable {
         final SignatureEntity other = (SignatureEntity) o;
         return Objects.equals(this.dataBase64, other.dataBase64)
                 && Objects.equals(this.signatureType, other.signatureType)
-                && Objects.equals(this.signature, other.signature)
+                && Objects.equals(this.authCode, other.authCode)
+                && Objects.equals(this.signatureAsymmetric, other.signatureAsymmetric)
                 && Objects.equals(this.signatureMetadata, other.signatureMetadata)
                 && Objects.equals(this.signatureDataBody, other.signatureDataBody)
                 && Objects.equals(this.additionalInfo, other.additionalInfo)
@@ -208,7 +230,7 @@ public class SignatureEntity implements Serializable {
 
     @Override
     public String toString() {
-        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", authenticationCodeType=" + signatureType + ", signature=" + signature + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
+        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", signatureType=" + signatureType + ", authCode=" + authCode + ", signatureAsymmetric=" + signatureAsymmetric + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
@@ -136,7 +136,7 @@ public class AuditingServiceBehavior {
                     item.setActivationId(signatureEntity.getActivation().getActivationId());
                     item.setDataBase64(signatureEntity.getDataBase64());
                     item.setSignatureVersion(signatureEntity.getSignatureVersion());
-                    item.setSignature(signatureEntity.getSignature());
+                    item.setSignature(signatureEntity.getAuditedSignature());
                     item.setSignatureType(signatureEntity.getSignatureType());
                     item.setSignatureAlgorithm(signatureEntity.getSignatureAlgorithm());
                     item.setSignatureFormat(signatureEntity.getSignatureFormat());
@@ -185,7 +185,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationStatus(activation.getActivationStatus());
         signatureAuditRecord.setAdditionalInfo(additionalInfo);
         signatureAuditRecord.setDataBase64(data);
-        signatureAuditRecord.setSignature(signatureData.getSignature());
+        signatureAuditRecord.setAuthCode(signatureData.getSignature());
         signatureAuditRecord.setSignatureMetadata(authMetadata);
         signatureAuditRecord.setSignatureDataBody(signatureData.getRequestBody());
         signatureAuditRecord.setSignatureType(signatureType.name());
@@ -254,7 +254,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationCounter(activation.getCounter());
         signatureAuditRecord.setActivationCtrDataBase64(activation.getCtrDataBase64());
         signatureAuditRecord.setDataBase64(dataBase64);
-        signatureAuditRecord.setSignature(signatureBase64);
+        signatureAuditRecord.setSignatureAsymmetric(signatureBase64);
         signatureAuditRecord.setSignatureType(ASYMMETRIC_SIGNATURE_TYPE);
         signatureAuditRecord.setSignatureAlgorithm(signatureAlgorithm);
         signatureAuditRecord.setSignatureFormat(signatureFormat);

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
@@ -137,7 +137,7 @@ public class AuditingServiceBehavior {
                     item.setActivationId(signatureEntity.getActivation().getActivationId());
                     item.setDataBase64(signatureEntity.getDataBase64());
                     item.setSignatureVersion(signatureEntity.getSignatureVersion());
-                    item.setSignature(signatureEntity.getSignature());
+                    item.setSignature(signatureEntity.getAuditedSignature());
                     item.setSignatureType(signatureEntity.getSignatureType());
                     item.setSignatureAlgorithm(signatureEntity.getSignatureAlgorithm());
                     item.setSignatureFormat(signatureEntity.getSignatureFormat());
@@ -184,7 +184,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationStatus(activation.getActivationStatus());
         signatureAuditRecord.setAdditionalInfo(additionalInfo);
         signatureAuditRecord.setDataBase64(data);
-        signatureAuditRecord.setSignature(authenticationData.getAuthenticationCode());
+        signatureAuditRecord.setAuthCode(authenticationData.getAuthenticationCode());
         signatureAuditRecord.setSignatureMetadata(authMetadata);
         signatureAuditRecord.setSignatureDataBody(authenticationData.getRequestBody());
         signatureAuditRecord.setSignatureType(authenticationCodeType.name());
@@ -256,7 +256,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationCounter(activation.getCounter());
         signatureAuditRecord.setActivationCtrDataBase64(activation.getCtrDataBase64());
         signatureAuditRecord.setDataBase64(dataBase64);
-        signatureAuditRecord.setSignature(signatureBase64);
+        signatureAuditRecord.setSignatureAsymmetric(signatureBase64);
         signatureAuditRecord.setSignatureType(ASYMMETRIC_SIGNATURE_TYPE);
         signatureAuditRecord.setSignatureAlgorithm(signatureAlgorithm);
         signatureAuditRecord.setSignatureFormat(signatureFormat);

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -122,6 +123,13 @@ class AuditingServiceBehaviorTest {
         assertEquals(signatureMetadata, params.get("signatureMetadata"));
 
         assertEquals("user789", auditDetail.getSubjectId());
+
+        final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
+        verify(signatureAuditRepository).save(entityCaptor.capture());
+        final SignatureEntity saved = entityCaptor.getValue();
+        assertEquals("39319618-09892741", saved.getAuthCode());
+        assertNull(saved.getSignatureAsymmetric());
+        assertEquals("39319618-09892741", saved.getAuditedSignature());
     }
 
     /**
@@ -152,5 +160,74 @@ class AuditingServiceBehaviorTest {
                 .thenReturn(List.of(signatureEntity));
 
         assertEquals("POSSESSION_KNOWLEDGE_BIOMETRY", tested.getSignatureAuditLog(request).getItems().get(0).getSignatureType());
+    }
+
+    /**
+     * Test that an asymmetric signature audit record stores the signature in the {@code signatureAsymmetric}
+     * (CLOB) column and leaves the {@code authCode} column empty.
+     */
+    @Test
+    void testLogAsymmetricSignatureAuditRecord_storedInSignatureAsymmetric() {
+        final ApplicationEntity applicationEntity = new ApplicationEntity();
+        applicationEntity.setId("app456");
+
+        final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setApplication(applicationEntity);
+        activation.setActivationId("act123");
+        activation.setUserId("user789");
+        activation.setActivationStatus(ActivationStatus.ACTIVE);
+        activation.setCounter(0L);
+        activation.setCtrDataBase64("Y3RyRGF0YQ==");
+        activation.setVersion(3);
+
+        final String signatureBase64 = Base64.getEncoder().encodeToString(new byte[3000]);
+
+        tested.logAsymmetricSignatureAuditRecord(activation, "ZGF0YQ==", signatureBase64,
+                "ECDSA_P256", "DER", true, "asymmetric_signature_ok", new java.util.Date());
+
+        final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
+        verify(signatureAuditRepository).save(entityCaptor.capture());
+
+        final SignatureEntity saved = entityCaptor.getValue();
+        assertNull(saved.getAuthCode());
+        assertEquals(signatureBase64, saved.getSignatureAsymmetric());
+        assertEquals(signatureBase64, saved.getAuditedSignature());
+        assertEquals("ASYMMETRIC", saved.getSignatureType());
+        assertEquals("ECDSA_P256", saved.getSignatureAlgorithm());
+        assertEquals("DER", saved.getSignatureFormat());
+    }
+
+    /**
+     * Test that the signature audit log API surfaces the asymmetric signature value for records that store it
+     * in the {@code signatureAsymmetric} column and leave {@code authCode} null.
+     */
+    @Test
+    void testGetSignatureAuditLog_surfacesAsymmetricSignature() throws Exception {
+        final SignatureAuditRequest request = new SignatureAuditRequest();
+        request.setUserId("user789");
+
+        final ActivationRecordEntity activationRecordEntity = new ActivationRecordEntity();
+        final ApplicationEntity applicationEntity = new ApplicationEntity();
+        applicationEntity.setId("app456");
+        activationRecordEntity.setApplication(applicationEntity);
+        activationRecordEntity.setActivationId("act123");
+        activationRecordEntity.setUserId("user789");
+
+        final String signatureBase64 = Base64.getEncoder().encodeToString(new byte[3000]);
+
+        final SignatureEntity signatureEntity = new SignatureEntity();
+        signatureEntity.setId(1L);
+        signatureEntity.setSignatureType("ASYMMETRIC");
+        signatureEntity.setSignatureAsymmetric(signatureBase64);
+        signatureEntity.setActivationCounter(0L);
+        signatureEntity.setActivationStatus(ActivationStatus.ACTIVE);
+        signatureEntity.setValid(true);
+        signatureEntity.setVersion(3);
+        signatureEntity.setActivation(activationRecordEntity);
+
+        when(signatureAuditRepository.findSignatureAuditRecordsForUser(any(), any(), any()))
+                .thenReturn(List.of(signatureEntity));
+
+        assertEquals(signatureBase64, tested.getSignatureAuditLog(request).getItems().get(0).getSignature());
     }
 }

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -122,6 +123,13 @@ class AuditingServiceBehaviorTest {
         assertEquals(authMetadata, params.get("authenticationMetadata"));
 
         assertEquals("user789", auditDetail.getSubjectId());
+
+        final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
+        verify(signatureAuditRepository).save(entityCaptor.capture());
+        final SignatureEntity saved = entityCaptor.getValue();
+        assertEquals("39319618-09892741", saved.getAuthCode());
+        assertNull(saved.getSignatureAsymmetric());
+        assertEquals("39319618-09892741", saved.getAuditedSignature());
     }
 
     /**
@@ -152,5 +160,74 @@ class AuditingServiceBehaviorTest {
                 .thenReturn(List.of(signatureEntity));
 
         assertEquals("POSSESSION_KNOWLEDGE_BIOMETRY", tested.getAuditLog(request).getItems().get(0).getSignatureType());
+    }
+
+    /**
+     * Test that an asymmetric signature audit record stores the signature in the {@code signatureAsymmetric}
+     * (CLOB) column and leaves the {@code authCode} column empty.
+     */
+    @Test
+    void testLogAsymmetricSignatureAuditRecord_storedInSignatureAsymmetric() {
+        final ApplicationEntity applicationEntity = new ApplicationEntity();
+        applicationEntity.setId("app456");
+
+        final ActivationRecordEntity activation = new ActivationRecordEntity();
+        activation.setApplication(applicationEntity);
+        activation.setActivationId("act123");
+        activation.setUserId("user789");
+        activation.setActivationStatus(ActivationStatus.ACTIVE);
+        activation.setCounter(0L);
+        activation.setCtrDataBase64("Y3RyRGF0YQ==");
+        activation.setVersion(4);
+
+        final String signatureBase64 = Base64.getEncoder().encodeToString(new byte[3000]);
+
+        tested.logAsymmetricSignatureAuditRecord(activation, "ZGF0YQ==", signatureBase64,
+                "MLDSA_65", "DER", true, "asymmetric_signature_ok", new java.util.Date());
+
+        final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
+        verify(signatureAuditRepository).save(entityCaptor.capture());
+
+        final SignatureEntity saved = entityCaptor.getValue();
+        assertNull(saved.getAuthCode());
+        assertEquals(signatureBase64, saved.getSignatureAsymmetric());
+        assertEquals(signatureBase64, saved.getAuditedSignature());
+        assertEquals("ASYMMETRIC", saved.getSignatureType());
+        assertEquals("MLDSA_65", saved.getSignatureAlgorithm());
+        assertEquals("DER", saved.getSignatureFormat());
+    }
+
+    /**
+     * Test that the audit log API surfaces the asymmetric signature value for records that store it
+     * in the {@code signatureAsymmetric} column and leave {@code authCode} null.
+     */
+    @Test
+    void testGetAuditLog_surfacesAsymmetricSignature() throws Exception {
+        final SignatureAuditRequest request = new SignatureAuditRequest();
+        request.setUserId("user789");
+
+        final ActivationRecordEntity activationRecordEntity = new ActivationRecordEntity();
+        final ApplicationEntity applicationEntity = new ApplicationEntity();
+        applicationEntity.setId("app456");
+        activationRecordEntity.setApplication(applicationEntity);
+        activationRecordEntity.setActivationId("act123");
+        activationRecordEntity.setUserId("user789");
+
+        final String signatureBase64 = Base64.getEncoder().encodeToString(new byte[3000]);
+
+        final SignatureEntity signatureEntity = new SignatureEntity();
+        signatureEntity.setId(1L);
+        signatureEntity.setSignatureType("ASYMMETRIC");
+        signatureEntity.setSignatureAsymmetric(signatureBase64);
+        signatureEntity.setActivationCounter(0L);
+        signatureEntity.setActivationStatus(ActivationStatus.ACTIVE);
+        signatureEntity.setValid(true);
+        signatureEntity.setVersion(4);
+        signatureEntity.setActivation(activationRecordEntity);
+
+        when(signatureAuditRepository.findSignatureAuditRecordsForUser(any(), any(), any()))
+                .thenReturn(List.of(signatureEntity));
+
+        assertEquals(signatureBase64, tested.getAuditLog(request).getItems().get(0).getSignature());
     }
 }


### PR DESCRIPTION
## Description

Fixes the Oracle migration failure `ORA-00910: specified length too long for its datatype` on `pa_signature_audit`. The original changeset widened `signature` to `VARCHAR2(8000)`, exceeding Oracle's 4000-byte `VARCHAR2` limit — and ML-DSA (post-quantum) signatures don't fit in a `VARCHAR` at all.

The table now splits the two concerns:
- `signature` is **renamed to `auth_code`** (`VARCHAR(255)`, nullable) — holds symmetric v3/v4 authentication codes.
- New **`signature_asymmetric` `CLOB`** column — holds asymmetric signatures (ECDSA, ML-DSA).

The columns are mutually exclusive. `SignatureEntity.getAuditedSignature()` coalesces them into the unchanged `SignatureAuditItem.signature` API field, so the public contract stays backward compatible.

## Migration

New changesets in `2.2.x/20260428-asymmetric-signature-audit.xml` (all metadata-only, each with a `MARK_RAN` precondition):
- **3** — add `signature_asymmetric` (`clob` → `TEXT`/`CLOB`/`varchar(MAX)`)
- **4** — rename `signature` → `auth_code` (data preserved)
- **5** — drop `NOT NULL` on `auth_code`

Raw SQL mirrors regenerated for PostgreSQL, Oracle, and MSSQL. No released changeset edited.

## Testing

- `mvn -pl powerauth-java-server -am test-compile` passes; 23 relevant tests pass (auditing + asymmetric, v3 + v4).
- New/strengthened tests assert the mutually-exclusive column semantics and the read-API coalesce in both protocol versions.

## Closes

Closes #2422