### PR TITLE
Fix #2424: Avoid renaming column signature in pa_signature_audit due to upgrade

### DIFF
--- a/docs/Database-Structure.md
+++ b/docs/Database-Structure.md
@@ -186,7 +186,7 @@ Stores the records with values used for attempts for the signature validation.
 | additional_info     | VARCHAR(255) | -                                          | Additional information related to the signature request in JSON format.   |
 | data_base64         | TEXT         | -                                          | Data passed as the base for the signature, encoded as Base64.             |
 | signature_type      | VARCHAR(255) | -                                          | Requested type of the signature.                                          |
-| auth_code           | VARCHAR(255) | -                                          | Provided value of the authentication code (symmetric records). Null for asymmetric-signature records. |
+| signature           | VARCHAR(255) | -                                          | Provided value of the authentication code (symmetric records). Null for asymmetric-signature records. |
 | signature_asymmetric | TEXT        | -                                          | Provided value of the asymmetric signature (ECDSA, ML-DSA), stored as CLOB. Null for symmetric authentication-code records. |
 | signature_algorithm | VARCHAR(32)  | -                                          | Algorithm used for the signature (symmetric: `PowerAuth-V3`, or `PowerAuth-V4`; asymmetric: `ECDSA_P256`, `ECDSA_P384`, `MLDSA_65`, or `MLDSA_87`). |
 | signature_format    | VARCHAR(32)  | -                                          | Format of the signature (symmetric: `DECIMAL`, or `BASE64`; asymmetric: `DER` or `JOSE`). |

--- a/docs/PowerAuth-Server-2.2.0.md
+++ b/docs/PowerAuth-Server-2.2.0.md
@@ -9,9 +9,9 @@ For convenience, you can use Liquibase for the database migration.
 The database table `pa_signature_audit` has been extended with new columns used for asymmetric signatures:
 - column `signature_algorithm` with type `VARCHAR(32)` - algorithm used for the signature (symmetric: `PowerAuth-V3`, or `PowerAuth-V4`; asymmetric: `ECDSA_P256`, `ECDSA_P384`, `MLDSA_65`, or `MLDSA_87`)
 - column `signature_format` with type `varchar(32)` - format of the signature (symmetric: `DECIMAL`, or `BASE64`; asymmetric: `DER` or `JOSE`)
-- column `signature_asymmetric` with type `CLOB` - value of the asymmetric signature (ECDSA, ML-DSA); stored as `CLOB`
+- column `signature_asymmetric` with type `CLOB` - value of the asymmetric signature (ECDSA, ML-DSA); stored as `CLOB` because post-quantum (ML-DSA) signatures exceed the maximum `VARCHAR` length on Oracle
 
-The existing `signature` column has been renamed to `auth_code` and made nullable. It stores the authentication code for symmetric records (PowerAuth v3/v4); asymmetric-signature records leave it `NULL` and store their value in `signature_asymmetric` instead. Existing rows keep their value under the new `auth_code` name.
+The existing `signature` column has been made nullable. It keeps holding the authentication code for symmetric records (PowerAuth v3/v4); asymmetric-signature records leave it `NULL` and store their value in `signature_asymmetric` instead.
 
 ### Table `pa_activation`
 

--- a/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml
@@ -62,16 +62,8 @@
         <preConditions onFail="MARK_RAN">
             <columnExists tableName="pa_signature_audit" columnName="signature"/>
         </preConditions>
-        <comment>Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology</comment>
-        <renameColumn tableName="pa_signature_audit" oldColumnName="signature" newColumnName="auth_code" columnDataType="varchar(255)"/>
-    </changeSet>
-
-    <changeSet id="5" logicalFilePath="powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml" author="Roman Strobl">
-        <preConditions onFail="MARK_RAN">
-            <columnExists tableName="pa_signature_audit" columnName="auth_code"/>
-        </preConditions>
-        <comment>Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null</comment>
-        <dropNotNullConstraint tableName="pa_signature_audit" columnName="auth_code" columnDataType="varchar(255)"/>
+        <comment>Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null</comment>
+        <dropNotNullConstraint tableName="pa_signature_audit" columnName="signature" columnDataType="varchar(255)"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/docs/sql/mssql/create_schema.sql
+++ b/docs/sql/mssql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:28 PM
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -746,13 +746,8 @@ ALTER TABLE pa_signature_audit ADD signature_asymmetric varchar(MAX);
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-exec sp_rename 'pa_signature_audit.signature', 'auth_code', 'COLUMN';
-GO
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit ALTER COLUMN auth_code varchar(255) NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit ALTER COLUMN signature varchar(255) NULL;
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl

--- a/docs/sql/mssql/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/mssql/migration_2.1.0_2.2.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:27 PM
 -- Against: null@offline:mssql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -23,13 +23,8 @@ ALTER TABLE pa_signature_audit ADD signature_asymmetric varchar(MAX);
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-exec sp_rename 'pa_signature_audit.signature', 'auth_code', 'COLUMN';
-GO
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit ALTER COLUMN auth_code varchar(255) NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit ALTER COLUMN signature varchar(255) NULL;
 GO
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl

--- a/docs/sql/oracle/create_schema.sql
+++ b/docs/sql/oracle/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:28 PM
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -593,12 +593,8 @@ ALTER TABLE pa_signature_audit ADD signature_format VARCHAR2(32);
 ALTER TABLE pa_signature_audit ADD signature_asymmetric CLOB;
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit MODIFY auth_code NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit MODIFY signature NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations

--- a/docs/sql/oracle/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/oracle/migration_2.1.0_2.2.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:27 PM
 -- Against: null@offline:oracle
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -20,12 +20,8 @@ ALTER TABLE pa_signature_audit ADD signature_format VARCHAR2(32);
 ALTER TABLE pa_signature_audit ADD signature_asymmetric CLOB;
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit MODIFY auth_code NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit MODIFY signature NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations

--- a/docs/sql/postgresql/create_schema.sql
+++ b/docs/sql/postgresql/create_schema.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/db.changelog-module.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:27 PM
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -593,12 +593,8 @@ ALTER TABLE pa_signature_audit ADD signature_format VARCHAR(32);
 ALTER TABLE pa_signature_audit ADD signature_asymmetric TEXT;
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit ALTER COLUMN  auth_code DROP NOT NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit ALTER COLUMN  signature DROP NOT NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations

--- a/docs/sql/postgresql/migration_2.1.0_2.2.0.sql
+++ b/docs/sql/postgresql/migration_2.1.0_2.2.0.sql
@@ -2,7 +2,7 @@
 -- Update Database Script
 -- *********************************************************************
 -- Change Log: ./docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
--- Ran at: 07/07/2026, 21:11
+-- Ran at: 7/8/26, 11:26 PM
 -- Against: null@offline:postgresql
 -- Liquibase version: 4.33.0
 -- *********************************************************************
@@ -20,12 +20,8 @@ ALTER TABLE pa_signature_audit ADD signature_format VARCHAR(32);
 ALTER TABLE pa_signature_audit ADD signature_asymmetric TEXT;
 
 -- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::4::Roman Strobl
--- Rename signature column to auth_code in pa_signature_audit table to match the authentication code terminology
-ALTER TABLE pa_signature_audit RENAME COLUMN signature TO auth_code;
-
--- Changeset powerauth-java-server/2.2.x/20260428-asymmetric-signature-audit.xml::5::Roman Strobl
--- Make auth_code column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave auth_code null
-ALTER TABLE pa_signature_audit ALTER COLUMN  auth_code DROP NOT NULL;
+-- Make signature column nullable in pa_signature_audit table because asymmetric audit records store their value in signature_asymmetric and leave signature null
+ALTER TABLE pa_signature_audit ALTER COLUMN  signature DROP NOT NULL;
 
 -- Changeset powerauth-java-server/2.2.x/20260527-activation-temporary-block.xml::1::Roman Strobl
 -- Add timestamp_block_expire column to pa_activation table to support automatic temporary unblocking of activations

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/database/model/entity/SignatureEntity.java
@@ -104,15 +104,15 @@ public class SignatureEntity implements Serializable {
     private String signatureType;
 
     /**
-     * Authentication code. Populated for PowerAuth v3/v4 authentication-code records;
-     * null for asymmetric-signature records (which use {@link #signatureAsymmetric}).
+     * Authentication code for PowerAuth v3/v4 authentication-code records. Null for asymmetric-signature
+     * records, which store their value in {@link #signatureAsymmetric} instead.
      */
-    @Column(name = "auth_code", updatable = false)
-    private String authCode;
+    @Column(name = "signature", updatable = false)
+    private String signature;
 
     /**
-     * Asymmetric signature (ECDSA, ML-DSA) stored as CLOB. Mutually exclusive with {@link #authCode}:
-     * authentication-code records populate {@code authCode}; asymmetric records populate {@code signatureAsymmetric}.
+     * Asymmetric signature (ECDSA, ML-DSA) stored as CLOB. Mutually exclusive with {@link #signature}:
+     * symmetric records populate {@code signature}; asymmetric records populate {@code signatureAsymmetric}.
      */
     @Column(name = "signature_asymmetric", updatable = false, columnDefinition = "CLOB")
     private String signatureAsymmetric;
@@ -167,7 +167,7 @@ public class SignatureEntity implements Serializable {
     private Date timestampCreated;
 
     /**
-     * Return the audit value associated with this record: the authentication code for
+     * Return the audited value of this record: the authentication code for
      * PowerAuth v3/v4 records, or the asymmetric signature (ECDSA, ML-DSA) for asymmetric records.
      * These two are mutually exclusive.
      *
@@ -175,7 +175,7 @@ public class SignatureEntity implements Serializable {
      */
     @Transient
     public String getAuditedSignature() {
-        return authCode != null ? authCode : signatureAsymmetric;
+        return signature != null ? signature : signatureAsymmetric;
     }
 
     @Override
@@ -187,7 +187,7 @@ public class SignatureEntity implements Serializable {
         hash = 23 * hash + Objects.hashCode(this.activationStatus);
         hash = 23 * hash + Objects.hashCode(this.dataBase64);
         hash = 23 * hash + Objects.hashCode(this.signatureType);
-        hash = 23 * hash + Objects.hashCode(this.authCode);
+        hash = 23 * hash + Objects.hashCode(this.signature);
         hash = 23 * hash + Objects.hashCode(this.signatureAsymmetric);
         hash = 23 * hash + Objects.hashCode(this.signatureMetadata);
         hash = 23 * hash + Objects.hashCode(this.signatureDataBody);
@@ -213,7 +213,7 @@ public class SignatureEntity implements Serializable {
         final SignatureEntity other = (SignatureEntity) o;
         return Objects.equals(this.dataBase64, other.dataBase64)
                 && Objects.equals(this.signatureType, other.signatureType)
-                && Objects.equals(this.authCode, other.authCode)
+                && Objects.equals(this.signature, other.signature)
                 && Objects.equals(this.signatureAsymmetric, other.signatureAsymmetric)
                 && Objects.equals(this.signatureMetadata, other.signatureMetadata)
                 && Objects.equals(this.signatureDataBody, other.signatureDataBody)
@@ -230,7 +230,7 @@ public class SignatureEntity implements Serializable {
 
     @Override
     public String toString() {
-        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", signatureType=" + signatureType + ", authCodePresent=" + (authCode != null) + ", signatureAsymmetricLength=" + (signatureAsymmetric != null ? signatureAsymmetric.length() : 0) + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
+        return "SignatureEntity{" + "id=" + id + ", activation=" + activation + ", activationCounter=" + activationCounter + ", activationCtrDataBase64=" + activationCtrDataBase64 + ", activationStatus=" + activationStatus + ", dataBase64=" + dataBase64 + ", signatureType=" + signatureType + ", signaturePresent=" + (signature != null) + ", signatureAsymmetricLength=" + (signatureAsymmetric != null ? signatureAsymmetric.length() : 0) + ", additionalInfo= " + additionalInfo + ", valid=" + valid + ", version=" + version + ", note=" + note + ", timestampCreated=" + timestampCreated + "}";
     }
 
 }

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehavior.java
@@ -185,7 +185,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationStatus(activation.getActivationStatus());
         signatureAuditRecord.setAdditionalInfo(additionalInfo);
         signatureAuditRecord.setDataBase64(data);
-        signatureAuditRecord.setAuthCode(signatureData.getSignature());
+        signatureAuditRecord.setSignature(signatureData.getSignature());
         signatureAuditRecord.setSignatureMetadata(authMetadata);
         signatureAuditRecord.setSignatureDataBody(signatureData.getRequestBody());
         signatureAuditRecord.setSignatureType(signatureType.name());

--- a/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
+++ b/powerauth-java-server/src/main/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehavior.java
@@ -184,7 +184,7 @@ public class AuditingServiceBehavior {
         signatureAuditRecord.setActivationStatus(activation.getActivationStatus());
         signatureAuditRecord.setAdditionalInfo(additionalInfo);
         signatureAuditRecord.setDataBase64(data);
-        signatureAuditRecord.setAuthCode(authenticationData.getAuthenticationCode());
+        signatureAuditRecord.setSignature(authenticationData.getAuthenticationCode());
         signatureAuditRecord.setSignatureMetadata(authMetadata);
         signatureAuditRecord.setSignatureDataBody(authenticationData.getRequestBody());
         signatureAuditRecord.setSignatureType(authenticationCodeType.name());

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v3/AuditingServiceBehaviorTest.java
@@ -127,7 +127,7 @@ class AuditingServiceBehaviorTest {
         final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
         verify(signatureAuditRepository).save(entityCaptor.capture());
         final SignatureEntity saved = entityCaptor.getValue();
-        assertEquals("39319618-09892741", saved.getAuthCode());
+        assertEquals("39319618-09892741", saved.getSignature());
         assertNull(saved.getSignatureAsymmetric());
         assertEquals("39319618-09892741", saved.getAuditedSignature());
     }
@@ -164,7 +164,7 @@ class AuditingServiceBehaviorTest {
 
     /**
      * Test that an asymmetric signature audit record stores the signature in the {@code signatureAsymmetric}
-     * (CLOB) column and leaves the {@code authCode} column empty.
+     * (CLOB) column and leaves the {@code signature} column empty.
      */
     @Test
     void testLogAsymmetricSignatureAuditRecord_storedInSignatureAsymmetric() {
@@ -189,7 +189,7 @@ class AuditingServiceBehaviorTest {
         verify(signatureAuditRepository).save(entityCaptor.capture());
 
         final SignatureEntity saved = entityCaptor.getValue();
-        assertNull(saved.getAuthCode());
+        assertNull(saved.getSignature());
         assertEquals(signatureBase64, saved.getSignatureAsymmetric());
         assertEquals(signatureBase64, saved.getAuditedSignature());
         assertEquals("ASYMMETRIC", saved.getSignatureType());
@@ -199,7 +199,7 @@ class AuditingServiceBehaviorTest {
 
     /**
      * Test that the signature audit log API surfaces the asymmetric signature value for records that store it
-     * in the {@code signatureAsymmetric} column and leave {@code authCode} null.
+     * in the {@code signatureAsymmetric} column and leave {@code signature} null.
      */
     @Test
     void testGetSignatureAuditLog_surfacesAsymmetricSignature() throws Exception {

--- a/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
+++ b/powerauth-java-server/src/test/java/com/wultra/security/powerauth/app/server/service/behavior/tasks/v4/AuditingServiceBehaviorTest.java
@@ -127,7 +127,7 @@ class AuditingServiceBehaviorTest {
         final ArgumentCaptor<SignatureEntity> entityCaptor = ArgumentCaptor.forClass(SignatureEntity.class);
         verify(signatureAuditRepository).save(entityCaptor.capture());
         final SignatureEntity saved = entityCaptor.getValue();
-        assertEquals("39319618-09892741", saved.getAuthCode());
+        assertEquals("39319618-09892741", saved.getSignature());
         assertNull(saved.getSignatureAsymmetric());
         assertEquals("39319618-09892741", saved.getAuditedSignature());
     }
@@ -164,7 +164,7 @@ class AuditingServiceBehaviorTest {
 
     /**
      * Test that an asymmetric signature audit record stores the signature in the {@code signatureAsymmetric}
-     * (CLOB) column and leaves the {@code authCode} column empty.
+     * (CLOB) column and leaves the {@code signature} column empty.
      */
     @Test
     void testLogAsymmetricSignatureAuditRecord_storedInSignatureAsymmetric() {
@@ -189,7 +189,7 @@ class AuditingServiceBehaviorTest {
         verify(signatureAuditRepository).save(entityCaptor.capture());
 
         final SignatureEntity saved = entityCaptor.getValue();
-        assertNull(saved.getAuthCode());
+        assertNull(saved.getSignature());
         assertEquals(signatureBase64, saved.getSignatureAsymmetric());
         assertEquals(signatureBase64, saved.getAuditedSignature());
         assertEquals("ASYMMETRIC", saved.getSignatureType());
@@ -199,7 +199,7 @@ class AuditingServiceBehaviorTest {
 
     /**
      * Test that the audit log API surfaces the asymmetric signature value for records that store it
-     * in the {@code signatureAsymmetric} column and leave {@code authCode} null.
+     * in the {@code signatureAsymmetric} column and leave {@code signature} null.
      */
     @Test
     void testGetAuditLog_surfacesAsymmetricSignature() throws Exception {


### PR DESCRIPTION
The column rename is avoided during separation of columns for authentication codes and asymmetric signatures.