### PR TITLE
Fix #2426: Add AAGUID for version 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Temporary block of activation [(#2390)](https://github.com/wultra/powerauth-server/issues/2390)
 - Added secure configuration store with per-application and per-activation scopes [(#2391)](https://github.com/wultra/powerauth-server/issues/2391)
+- Added AAGUID for Wultra Authenticator 1.2 [(#2426)](https://github.com/wultra/powerauth-server/issues/2426)
 
 ### Changed
 - Consolidated `CHANGELOG.md` to the strict Keep a Changelog 1.1.0 format and added Copilot changelog instructions [(#2398)](https://github.com/wultra/powerauth-server/issues/2398)

--- a/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2DefaultAuthenticators.java
+++ b/powerauth-fido2/src/main/java/com/wultra/powerauth/fido2/service/model/Fido2DefaultAuthenticators.java
@@ -32,7 +32,8 @@ import java.util.stream.Collectors;
 public class Fido2DefaultAuthenticators {
 
     private static final Set<String> WULTRA_MODELS = Set.of(
-            "dca09ba7-4992-4be8-9283-ee98cd6fb529"
+            "dca09ba7-4992-4be8-9283-ee98cd6fb529",
+            "99001b4d-4c81-4590-b115-ed23a6633af1"
     );
 
     private static final Set<Fido2Authenticator> MODELS = Set.of(
@@ -163,6 +164,7 @@ public class Fido2DefaultAuthenticators {
 
             // Wultra
             Fido2Authenticator.create("dca09ba7-4992-4be8-9283-ee98cd6fb529", "Wultra Authenticator 1", SignatureType.POSSESSION_KNOWLEDGE, List.of("usb")),
+            Fido2Authenticator.create("99001b4d-4c81-4590-b115-ed23a6633af1", "Wultra Authenticator 1.2", SignatureType.POSSESSION_KNOWLEDGE, List.of("usb")),
 
             // Yubico
             Fido2Authenticator.create("0bb43545-fd2c-4185-87dd-feb0b2916ace", "Security Key NFC by Yubico - Enterprise Edition"),

--- a/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorServiceTest.java
+++ b/powerauth-fido2/src/test/java/com/wultra/powerauth/fido2/service/Fido2AuthenticatorServiceTest.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
 class Fido2AuthenticatorServiceTest {
 
     private final static String WA1_AAGUID = "dca09ba7-4992-4be8-9283-ee98cd6fb529";
+    private final static String WA12_AAGUID = "99001b4d-4c81-4590-b115-ed23a6633af1";
 
     @Mock
     private Fido2AuthenticatorRepository fido2AuthenticatorRepository;
@@ -79,6 +80,19 @@ class Fido2AuthenticatorServiceTest {
         final Fido2Authenticator authenticator = tested.findByAaguid(aaguid);
         assertEquals(aaguid, authenticator.aaguid());
         assertEquals("Wultra Authenticator 1", authenticator.description());
+        assertEquals(SignatureType.POSSESSION_KNOWLEDGE, authenticator.signatureType());
+        assertEquals(List.of("usb"), authenticator.transports());
+    }
+
+    @Test
+    void testFindByAaguid_fromDefaultSet_wultra12() {
+        final UUID aaguid = UUID.fromString(WA12_AAGUID);
+        when(fido2AuthenticatorRepository.findById(aaguid.toString()))
+                .thenReturn(Optional.empty());
+
+        final Fido2Authenticator authenticator = tested.findByAaguid(aaguid);
+        assertEquals(aaguid, authenticator.aaguid());
+        assertEquals("Wultra Authenticator 1.2", authenticator.description());
         assertEquals(SignatureType.POSSESSION_KNOWLEDGE, authenticator.signatureType());
         assertEquals(List.of("usb"), authenticator.transports());
     }


### PR DESCRIPTION
### Description
Registers AAGUID `99001b4d-4c81-4590-b115-ed23a6633af1` for Wultra Authenticator 1.2 in the default FIDO2 authenticator set, using the same profile as Wultra Authenticator 1 (`POSSESSION_KNOWLEDGE`, `usb` transport). The AAGUID is also added to `WULTRA_MODELS` so it is treated as a Wultra authenticator.

### Motivation and Context
A new attestation key and AAGUID were generated for Wultra Authenticator 1.2. The server must recognize this AAGUID to resolve the correct name and authentication factors.

### Testing
- `mvn -q -pl powerauth-fido2 test` — passing.
- Added `testFindByAaguid_fromDefaultSet_wultra12()`.

### Closes
Closes #2426