### PR TITLE
Fix #2431: Prepare release 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.0] - 2026-07-17
+## [2.2.0] - 2026-07-20
 
 ### Added
 - Temporary block of activation [(#2390)](https://github.com/wultra/powerauth-server/issues/2390)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.2.0] - 2026-07-17
+
 ### Added
 - Temporary block of activation [(#2390)](https://github.com/wultra/powerauth-server/issues/2390)
 - Added secure configuration store with per-application and per-activation scopes [(#2391)](https://github.com/wultra/powerauth-server/issues/2391)
@@ -16,4 +19,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated to Spring Boot 4 and Jackson 3 [(#2379)](https://github.com/wultra/powerauth-server/issues/2379)
 - Upgraded Docker base image to `ibm-semeru-runtimes:open-jdk-25.0.3.0-jre-noble` (OpenJDK 25) [(#2396)](https://github.com/wultra/powerauth-server/issues/2396)
 
-[unreleased]: https://github.com/wultra/powerauth-server/compare/2.1.0...HEAD
+[unreleased]: https://github.com/wultra/powerauth-server/compare/2.2.0...HEAD
+[2.2.0]: https://github.com/wultra/powerauth-server/compare/2.1.0...2.2.0

--- a/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260717-add-tag-2.2.0.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.2.x/20260717-add-tag-2.2.0.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ PowerAuth Server and related software components
+  ~ Copyright (C) 2026 Wultra s.r.o.
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published
+  ~ by the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ~
+  -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.33.xsd">
+
+    <changeSet id="1" logicalFilePath="powerauth-java-server/2.2.x/20260717-add-tag-2.2.0.xml" author="Roman Strobl">
+        <tagDatabase tag="powerauth-server/2.2.0"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
+++ b/docs/db/changelog/changesets/powerauth-java-server/2.2.x/db.changelog-version.xml
@@ -6,5 +6,6 @@
     <include file="20260428-asymmetric-signature-audit.xml" relativeToChangelogFile="true" />
     <include file="20260527-activation-temporary-block.xml" relativeToChangelogFile="true" />
     <include file="20260602-config-store.xml" relativeToChangelogFile="true" />
+    <include file="20260717-add-tag-2.2.0.xml" relativeToChangelogFile="true" />
 
 </databaseChangeLog>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>com.wultra.security</groupId>
     <artifactId>powerauth-server-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.2.0</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/powerauth-admin/pom.xml
+++ b/powerauth-admin/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <dependencies>

--- a/powerauth-client-model/pom.xml
+++ b/powerauth-client-model/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <dependencies>

--- a/powerauth-fido2-model/pom.xml
+++ b/powerauth-fido2-model/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <artifactId>powerauth-fido2-model</artifactId>

--- a/powerauth-fido2/pom.xml
+++ b/powerauth-fido2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <dependencies>

--- a/powerauth-java-server/pom.xml
+++ b/powerauth-java-server/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <dependencies>

--- a/powerauth-rest-client-spring/pom.xml
+++ b/powerauth-rest-client-spring/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.wultra.security</groupId>
         <artifactId>powerauth-server-parent</artifactId>
-        <version>2.2.0-SNAPSHOT</version>
+        <version>2.2.0</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
### Description

Prepares release version `2.2.0` of PowerAuth Server.

- Bumped all module versions from `2.2.0-SNAPSHOT` to `2.2.0`
- Added Liquibase tag changeset `powerauth-server/2.2.0` to close the 2.2.x release line

Closes #2431